### PR TITLE
chore: release 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump `route-graphics` package version from `1.7.0` to `1.7.1`
- publish the current canonical `spritesheet-animation` package state for downstream upgrades

## Notes
- no source behavior changes are included in this PR
- this is a release bump so downstream apps can update to a package version that exposes `spritesheetAnimationPlugin` in the published build