### PR TITLE
Fix spritesheet render completion race

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/src/plugins/elements/animated-sprite/addAnimatedSprite.js
+++ b/src/plugins/elements/animated-sprite/addAnimatedSprite.js
@@ -18,6 +18,7 @@ export const addAnimatedSprite = async ({
   parent,
   element,
   renderContext,
+  completionTracker,
   zIndex,
   signal,
 }) => {
@@ -38,45 +39,52 @@ export const addAnimatedSprite = async ({
     clips: normalizedClips,
     playback,
   });
-  const spriteSheet = new Spritesheet(Texture.from(src), normalizedAtlas);
-  await spriteSheet.parse();
-  if (signal?.aborted || parent.destroyed) return;
+  const completionVersion = completionTracker?.getVersion?.();
+  completionTracker?.track?.(completionVersion);
 
-  const { frameTextures } = resolveAnimatedSpriteFrameTextures({
-    spritesheet: spriteSheet,
-    atlas: normalizedAtlas,
-    clips: normalizedClips,
-    playback: normalizedPlayback,
-  });
+  try {
+    const spriteSheet = new Spritesheet(Texture.from(src), normalizedAtlas);
+    await spriteSheet.parse();
+    if (signal?.aborted || parent.destroyed) return;
 
-  const animatedSprite = new AnimatedSprite(frameTextures);
-  animatedSprite.label = id;
-  animatedSprite.zIndex = zIndex;
-
-  animatedSprite.animationSpeed = playbackFpsToAnimationSpeed(
-    normalizedPlayback.fps,
-  );
-  animatedSprite.loop = normalizedPlayback.loop;
-
-  if (app.debug) {
-    setupDebugMode(animatedSprite, id, app.debug, () => {
-      if (typeof app.render === "function") {
-        app.render();
-      }
+    const { frameTextures } = resolveAnimatedSpriteFrameTextures({
+      spritesheet: spriteSheet,
+      atlas: normalizedAtlas,
+      clips: normalizedClips,
+      playback: normalizedPlayback,
     });
-  } else if (normalizedPlayback.autoplay) {
-    queueDeferredAnimatedSpritePlay(renderContext, animatedSprite);
-  }
 
-  animatedSprite.x = Math.round(x);
-  animatedSprite.y = Math.round(y);
-  animatedSprite.width = Math.round(width);
-  animatedSprite.height = Math.round(height);
-  animatedSprite.alpha = alpha;
+    const animatedSprite = new AnimatedSprite(frameTextures);
+    animatedSprite.label = id;
+    animatedSprite.zIndex = zIndex;
 
-  parent.addChild(animatedSprite);
+    animatedSprite.animationSpeed = playbackFpsToAnimationSpeed(
+      normalizedPlayback.fps,
+    );
+    animatedSprite.loop = normalizedPlayback.loop;
 
-  if (typeof app.render === "function") {
-    app.render();
+    if (app.debug) {
+      setupDebugMode(animatedSprite, id, app.debug, () => {
+        if (typeof app.render === "function") {
+          app.render();
+        }
+      });
+    } else if (normalizedPlayback.autoplay) {
+      queueDeferredAnimatedSpritePlay(renderContext, animatedSprite);
+    }
+
+    animatedSprite.x = Math.round(x);
+    animatedSprite.y = Math.round(y);
+    animatedSprite.width = Math.round(width);
+    animatedSprite.height = Math.round(height);
+    animatedSprite.alpha = alpha;
+
+    parent.addChild(animatedSprite);
+
+    if (typeof app.render === "function") {
+      app.render();
+    }
+  } finally {
+    completionTracker?.complete?.(completionVersion);
   }
 };

--- a/src/plugins/elements/animated-sprite/updateAnimatedSprite.js
+++ b/src/plugins/elements/animated-sprite/updateAnimatedSprite.js
@@ -74,41 +74,48 @@ export const updateAnimatedSprite = async ({
       animatedSpriteElement.loop = nextPlayback.loop;
 
       if (playbackChanged || clipSetChanged || atlasChanged) {
-        const spriteSheet = new Spritesheet(Texture.from(nextSrc), nextAtlas);
-        await spriteSheet.parse();
-        if (signal?.aborted || animatedSpriteElement.destroyed) return;
+        const completionVersion = completionTracker?.getVersion?.();
+        completionTracker?.track?.(completionVersion);
 
-        const { frameTextures } = resolveAnimatedSpriteFrameTextures({
-          spritesheet: spriteSheet,
-          atlas: nextAtlas,
-          clips: nextClips,
-          playback: nextPlayback,
-        });
-        animatedSpriteElement.textures = frameTextures;
-        if (typeof app.render === "function") {
-          app.render();
-        }
+        try {
+          const spriteSheet = new Spritesheet(Texture.from(nextSrc), nextAtlas);
+          await spriteSheet.parse();
+          if (signal?.aborted || animatedSpriteElement.destroyed) return;
 
-        if (!app.debug && nextPlayback.autoplay) {
-          animatedSpriteElement.play();
-        } else {
-          if (!app.debug) {
-            animatedSpriteElement.stop?.();
+          const { frameTextures } = resolveAnimatedSpriteFrameTextures({
+            spritesheet: spriteSheet,
+            atlas: nextAtlas,
+            clips: nextClips,
+            playback: nextPlayback,
+          });
+          animatedSpriteElement.textures = frameTextures;
+          if (typeof app.render === "function") {
+            app.render();
           }
 
-          if (prevElement.id !== nextElement.id) {
-            cleanupDebugMode(animatedSpriteElement);
-            setupDebugMode(
-              animatedSpriteElement,
-              nextElement.id,
-              app.debug,
-              () => {
-                if (typeof app.render === "function") {
-                  app.render();
-                }
-              },
-            );
+          if (!app.debug && nextPlayback.autoplay) {
+            animatedSpriteElement.play();
+          } else {
+            if (!app.debug) {
+              animatedSpriteElement.stop?.();
+            }
+
+            if (prevElement.id !== nextElement.id) {
+              cleanupDebugMode(animatedSpriteElement);
+              setupDebugMode(
+                animatedSpriteElement,
+                nextElement.id,
+                app.debug,
+                () => {
+                  if (typeof app.render === "function") {
+                    app.render();
+                  }
+                },
+              );
+            }
           }
+        } finally {
+          completionTracker?.complete?.(completionVersion);
         }
       }
     }

--- a/vt/reference/animatedsprite/render-complete-next-state-keeps-spritesheet-01.webp
+++ b/vt/reference/animatedsprite/render-complete-next-state-keeps-spritesheet-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:512b01c089621813c637c7f5407947dcb870dc84daf3518688bcd0cd354a1026
+size 3214

--- a/vt/reference/animatedsprite/render-complete-next-state-keeps-spritesheet-02.webp
+++ b/vt/reference/animatedsprite/render-complete-next-state-keeps-spritesheet-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af2f5763076a4d059109189cba5c62783b0438b8c60866a4a36cf2fa2ed892bd
+size 19570

--- a/vt/specs/animatedsprite/render-complete-next-state-keeps-spritesheet.yaml
+++ b/vt/specs/animatedsprite/render-complete-next-state-keeps-spritesheet.yaml
@@ -1,0 +1,234 @@
+---
+title: Animated Sprite Survives RenderComplete Follow-Up State
+description: |
+  Reproduces the scene-preview regression where a spritesheet-animation entered in one state,
+  triggered a follow-up render on renderComplete, and then disappeared because the async atlas
+  parse from the previous render was aborted before the sprite reached the stage.
+specs:
+  - advancing to the next state on renderComplete should preserve an unchanged spritesheet-animation
+  - the final state should show the follow-up text and the spritesheet at the same time
+steps:
+  - action: customEvent
+    name: clearEvents
+  - action: customEvent
+    name: vtNextStateOnRenderComplete
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: snapShotAnimatedSpriteFrame
+    detail:
+      frameIndex: 0
+      elementId: "scene-layout-spritesheet"
+  - action: screenshot
+---
+states:
+  - id: baseline
+    elements:
+      - id: baseline-text
+        type: text
+        x: 110
+        "y": 84
+        content: "Baseline scene"
+        textStyle:
+          fontSize: 30
+          fill: "#E6E6E6"
+  - id: layout-with-spritesheet
+    elements:
+      - id: background-card
+        type: rect
+        x: 72
+        "y": 96
+        width: 1136
+        height: 560
+        fill: "#242424"
+      - id: scene-layout-spritesheet
+        type: spritesheet-animation
+        x: 310
+        "y": 210
+        width: 175
+        height: 240
+        src: fighter-spritesheet
+        atlas:
+          frames:
+            rollSequence0000.png:
+              frame:
+                x: 483
+                "y": 692
+                w: 169
+                h: 226
+              rotated: false
+              trimmed: true
+              spriteSourceSize:
+                x: 3
+                "y": 4
+                w: 169
+                h: 226
+              sourceSize:
+                w: 175
+                h: 240
+            rollSequence0001.png:
+              frame:
+                x: 468
+                "y": 2
+                w: 169
+                h: 226
+              rotated: false
+              trimmed: true
+              spriteSourceSize:
+                x: 3
+                "y": 4
+                w: 169
+                h: 226
+              sourceSize:
+                w: 175
+                h: 240
+            rollSequence0002.png:
+              frame:
+                x: 639
+                "y": 2
+                w: 167
+                h: 226
+              rotated: false
+              trimmed: true
+              spriteSourceSize:
+                x: 3
+                "y": 5
+                w: 167
+                h: 226
+              sourceSize:
+                w: 175
+                h: 240
+          meta:
+            format: RGBA8888
+            size:
+              w: 1024
+              h: 1024
+            scale: "1"
+        playback:
+          frames:
+            - 0
+            - 1
+            - 2
+          fps: 30
+          loop: true
+        alpha: 1
+      - id: scene-caption
+        type: text
+        x: 586
+        "y": 238
+        content: "Layout state"
+        textStyle:
+          fontSize: 34
+          fill: "#F2F2F2"
+      - id: scene-body
+        type: text
+        x: 586
+        "y": 294
+        content: "renderComplete should wait for the atlas parse."
+        textStyle:
+          fontSize: 24
+          fill: "#D0D0D0"
+  - id: layout-after-render-complete
+    elements:
+      - id: background-card
+        type: rect
+        x: 72
+        "y": 96
+        width: 1136
+        height: 560
+        fill: "#242424"
+      - id: scene-layout-spritesheet
+        type: spritesheet-animation
+        x: 310
+        "y": 210
+        width: 175
+        height: 240
+        src: fighter-spritesheet
+        atlas:
+          frames:
+            rollSequence0000.png:
+              frame:
+                x: 483
+                "y": 692
+                w: 169
+                h: 226
+              rotated: false
+              trimmed: true
+              spriteSourceSize:
+                x: 3
+                "y": 4
+                w: 169
+                h: 226
+              sourceSize:
+                w: 175
+                h: 240
+            rollSequence0001.png:
+              frame:
+                x: 468
+                "y": 2
+                w: 169
+                h: 226
+              rotated: false
+              trimmed: true
+              spriteSourceSize:
+                x: 3
+                "y": 4
+                w: 169
+                h: 226
+              sourceSize:
+                w: 175
+                h: 240
+            rollSequence0002.png:
+              frame:
+                x: 639
+                "y": 2
+                w: 167
+                h: 226
+              rotated: false
+              trimmed: true
+              spriteSourceSize:
+                x: 3
+                "y": 5
+                w: 167
+                h: 226
+              sourceSize:
+                w: 175
+                h: 240
+          meta:
+            format: RGBA8888
+            size:
+              w: 1024
+              h: 1024
+            scale: "1"
+        playback:
+          frames:
+            - 0
+            - 1
+            - 2
+          fps: 30
+          loop: true
+        alpha: 1
+      - id: scene-caption
+        type: text
+        x: 586
+        "y": 238
+        content: "Follow-up state"
+        textStyle:
+          fontSize: 34
+          fill: "#F2F2F2"
+      - id: scene-body
+        type: text
+        x: 586
+        "y": 294
+        content: "The unchanged spritesheet must still be mounted here."
+        textStyle:
+          fontSize: 24
+          fill: "#D0D0D0"
+      - id: scene-status
+        type: text
+        x: 586
+        "y": 364
+        content: "renderComplete advanced after async sprite work finished."
+        textStyle:
+          fontSize: 22
+          fill: "#B8B8B8"

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -383,6 +383,7 @@
         audio: [soundPlugin],
       };
       let index = 0;
+      let advanceToNextStateOnRenderComplete = false;
       const vtStateSource =
         document.getElementById("vt-state")?.textContent?.trim() ?? "";
       const vtDocuments = parseAllDocuments(vtStateSource).map(
@@ -550,6 +551,13 @@
           }
           window.__VT_ALL_EVENTS__.push(eventData);
           if (eventName === "renderComplete") {
+            if (
+              advanceToNextStateOnRenderComplete &&
+              payload?.aborted !== true
+            ) {
+              advanceToNextStateOnRenderComplete = false;
+              renderState(index + 1);
+            }
             return;
           }
           window.__VT_EVENTS__.push(eventData);
@@ -612,6 +620,10 @@
           if (states.length > index + 1) {
             renderState(index + 1);
           }
+        });
+
+        window.addEventListener("vtNextStateOnRenderComplete", () => {
+          advanceToNextStateOnRenderComplete = true;
         });
 
         window.addEventListener("vtPrevState", () => {


### PR DESCRIPTION
## Summary
- delay `renderComplete` until async spritesheet atlas parsing finishes on add/update
- add a VT harness hook and regression spec for the scene-preview follow-up render case
- bump package version to `1.7.1`

## Validation
- `bun run build`
- `bunx prettier --check package.json vt/templates/default.html vt/specs/animatedsprite/render-complete-next-state-keeps-spritesheet.yaml src/plugins/elements/animated-sprite/addAnimatedSprite.js src/plugins/elements/animated-sprite/updateAnimatedSprite.js`
- `bunx oxlint src/plugins/elements/animated-sprite/addAnimatedSprite.js src/plugins/elements/animated-sprite/updateAnimatedSprite.js`
- `docker run --rm --user $(id -u):$(id -g) -e RTGL_VT_DEBUG=true -e RTGL_VT_CONCURRENCY=1 -v "$PWD:/workspace" docker.io/han4wluc/rtgl:playwright-v1.57.0-rtgl-v1.1.0 rtgl vt screenshot --wait-event vt:ready --concurrency 1 --item animatedsprite/render-complete-next-state-keeps-spritesheet.yaml`
- push hook: `vitest run` (48 files, 280 tests)