### PR TITLE
fix: preserve slider runtime across updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/elements/updateSlider.spec.js
+++ b/spec/elements/updateSlider.spec.js
@@ -1,0 +1,156 @@
+import { Container } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
+import { addSlider } from "../../src/plugins/elements/slider/addSlider.js";
+import { updateSlider } from "../../src/plugins/elements/slider/updateSlider.js";
+
+const createSharedParams = () => ({
+  app: {
+    audioStage: {
+      add: vi.fn(),
+    },
+  },
+  animations: [],
+  animationBus: {
+    dispatch: vi.fn(),
+  },
+  completionTracker: {
+    getVersion: () => 0,
+    track: () => {},
+    complete: () => {},
+  },
+});
+
+const createSharedParamsWithNativeDrag = () => ({
+  ...createSharedParams(),
+  app: {
+    audioStage: {
+      add: vi.fn(),
+    },
+    renderer: {
+      events: {
+        mapPositionToPoint: (point, x, y) => {
+          point.x = x;
+          point.y = y;
+        },
+      },
+    },
+  },
+});
+
+const createSliderElement = (overrides = {}) => ({
+  id: "slider-1",
+  type: "slider",
+  x: 100,
+  y: 100,
+  width: 200,
+  height: 20,
+  alpha: 1,
+  direction: "horizontal",
+  min: 0,
+  max: 100,
+  step: 1,
+  initialValue: 0,
+  change: {
+    payload: { source: "drag" },
+  },
+  ...overrides,
+});
+
+describe("updateSlider", () => {
+  it("keeps dragging active when renders update the slider value", () => {
+    const parent = new Container();
+    const eventHandler = vi.fn();
+    const shared = createSharedParamsWithNativeDrag();
+    const prevElement = createSliderElement();
+
+    addSlider({
+      ...shared,
+      parent,
+      eventHandler,
+      zIndex: 0,
+      element: prevElement,
+    });
+
+    const slider = parent.getChildByLabel("slider-1");
+
+    slider.emit("pointerdown", { global: { x: 280, y: 110 } });
+
+    const nextElement = createSliderElement({
+      initialValue: eventHandler.mock.calls[0][1]._event.value,
+    });
+
+    updateSlider({
+      ...shared,
+      parent,
+      prevElement,
+      nextElement,
+      eventHandler,
+      zIndex: 0,
+    });
+
+    const moveEvent =
+      typeof PointerEvent === "function"
+        ? new PointerEvent("pointermove", {
+            clientX: 290,
+            clientY: 110,
+            bubbles: true,
+          })
+        : new MouseEvent("mousemove", {
+            clientX: 290,
+            clientY: 110,
+            bubbles: true,
+          });
+    const upEvent =
+      typeof PointerEvent === "function"
+        ? new PointerEvent("pointerup", {
+            clientX: 290,
+            clientY: 110,
+            bubbles: true,
+          })
+        : new MouseEvent("mouseup", {
+            clientX: 290,
+            clientY: 110,
+            bubbles: true,
+          });
+
+    document.dispatchEvent(moveEvent);
+    window.dispatchEvent(upEvent);
+
+    expect(eventHandler).toHaveBeenCalledTimes(2);
+    expect(eventHandler.mock.calls[1][0]).toBe("change");
+    expect(eventHandler.mock.calls[1][1]._event.value).toBeGreaterThan(
+      eventHandler.mock.calls[0][1]._event.value,
+    );
+  });
+
+  it("syncs programmatic value updates before the next pointerdown", () => {
+    const parent = new Container();
+    const eventHandler = vi.fn();
+    const shared = createSharedParams();
+    const prevElement = createSliderElement();
+
+    addSlider({
+      ...shared,
+      parent,
+      eventHandler,
+      zIndex: 0,
+      element: prevElement,
+    });
+
+    updateSlider({
+      ...shared,
+      parent,
+      prevElement,
+      nextElement: createSliderElement({ initialValue: 100 }),
+      eventHandler,
+      zIndex: 0,
+    });
+
+    const slider = parent.getChildByLabel("slider-1");
+
+    eventHandler.mockClear();
+    slider.emit("pointerdown", { global: { x: 300, y: 110 } });
+
+    expect(eventHandler).not.toHaveBeenCalled();
+  });
+});

--- a/spec/parser/parseSlider.test.yaml
+++ b/spec/parser/parseSlider.test.yaml
@@ -181,7 +181,7 @@ in:
       "y": 75
 throws: "Input error: slider initialValue is required"
 ---
-case: Test parsing slider throws when initialValue is outside min and max
+case: Test parsing slider clamps initialValue above max
 in:
   - state:
       id: outside-initial-value-slider
@@ -196,4 +196,53 @@ in:
       min: 10
       max: 20
       initialValue: 30
-throws: "Input error: slider initialValue must be between min and max"
+out:
+  id: outside-initial-value-slider
+  type: slider
+  barSrc: file:bar-minimal
+  thumbSrc: file:thumb-minimal
+  direction: vertical
+  alpha: 1
+  min: 10
+  max: 20
+  width: 100
+  height: 10
+  step: 1
+  initialValue: 20
+  x: 50
+  "y": 75
+  originX: 0
+  originY: 0
+---
+case: Test parsing slider clamps initialValue below min
+in:
+  - state:
+      id: below-initial-value-slider
+      type: slider
+      barSrc: file:bar-minimal
+      thumbSrc: file:thumb-minimal
+      direction: vertical
+      width: 100
+      height: 10
+      x: 50
+      "y": 75
+      min: 10
+      max: 20
+      initialValue: 5
+out:
+  id: below-initial-value-slider
+  type: slider
+  barSrc: file:bar-minimal
+  thumbSrc: file:thumb-minimal
+  direction: vertical
+  alpha: 1
+  min: 10
+  max: 20
+  width: 100
+  height: 10
+  step: 1
+  initialValue: 10
+  x: 50
+  "y": 75
+  originX: 0
+  originY: 0

--- a/src/plugins/elements/slider/addSlider.js
+++ b/src/plugins/elements/slider/addSlider.js
@@ -1,11 +1,11 @@
 import { Sprite, Container } from "pixi.js";
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
 import {
-  applySliderVisualState,
   bindSliderInteractions,
   getSliderLabels,
   getSliderTexture,
   resizeSliderThumb,
+  syncSliderRuntime,
 } from "./sliderRuntime.js";
 
 /**
@@ -23,18 +23,8 @@ export const addSlider = ({
   renderContext,
   zIndex,
 }) => {
-  const {
-    id,
-    x,
-    y,
-    width,
-    height,
-    alpha,
-    thumbSrc,
-    barSrc,
-    initialValue,
-    min,
-  } = sliderComputedNode;
+  const { id, x, y, width, height, alpha, thumbSrc, barSrc } =
+    sliderComputedNode;
 
   // Create container for the slider
   const sliderContainer = new Container();
@@ -60,7 +50,6 @@ export const addSlider = ({
   thumb.eventMode = "static";
   thumb.zIndex = 2;
 
-  let currentValue = initialValue ?? min;
   resizeSliderThumb({
     thumb,
     thumbSrc,
@@ -73,14 +62,15 @@ export const addSlider = ({
   sliderContainer.addChild(bar);
   sliderContainer.addChild(thumb);
 
-  applySliderVisualState({
+  bindSliderInteractions({
+    app,
     sliderContainer,
     sliderComputedNode,
     thumb,
-    currentValue,
+    eventHandler,
   });
 
-  bindSliderInteractions({
+  syncSliderRuntime({
     app,
     sliderContainer,
     sliderComputedNode,

--- a/src/plugins/elements/slider/deleteSlider.js
+++ b/src/plugins/elements/slider/deleteSlider.js
@@ -1,4 +1,5 @@
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import { destroySliderRuntime } from "./sliderRuntime.js";
 
 /**
  * Delete slider element
@@ -18,6 +19,9 @@ export const deleteSlider = ({
 
   const deleteElement = () => {
     if (sliderContainer && !sliderContainer.destroyed) {
+      destroySliderRuntime({
+        sliderContainer,
+      });
       sliderContainer.destroy({ children: true });
     }
   };

--- a/src/plugins/elements/slider/parseSlider.js
+++ b/src/plugins/elements/slider/parseSlider.js
@@ -1,5 +1,7 @@
 import { parseCommonObject } from "../util/parseCommonObject.js";
 
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
 /**
  * @typedef {import('../../../types.js').BaseElement} BaseElement
  * @typedef {import('../../../types.js').SliderComputedNode} SliderComputedNode
@@ -31,11 +33,7 @@ export const parseSlider = ({ state }) => {
     throw new Error("Input error: slider initialValue must be a valid number");
   }
 
-  if (state.initialValue < defaultMin || state.initialValue > defaultMax) {
-    throw new Error(
-      "Input error: slider initialValue must be between min and max",
-    );
-  }
+  const initialValue = clamp(state.initialValue, defaultMin, defaultMax);
 
   return {
     ...computedObj,
@@ -49,7 +47,7 @@ export const parseSlider = ({ state }) => {
     min: defaultMin,
     max: defaultMax,
     step: state.step ?? 1,
-    initialValue: state.initialValue,
+    initialValue,
     ...(state.hover && { hover: state.hover }),
     ...(state.change && { change: state.change }),
   };

--- a/src/plugins/elements/slider/sliderRuntime.js
+++ b/src/plugins/elements/slider/sliderRuntime.js
@@ -6,6 +6,7 @@ import {
 
 const BAR_PADDING = 0;
 const DEFAULT_TEXTURE_SIZE = 16;
+export const SLIDER_RUNTIME = Symbol("routeGraphicsSliderRuntime");
 
 const hasOwn = (object, key) =>
   object !== null &&
@@ -13,6 +14,123 @@ const hasOwn = (object, key) =>
   Object.prototype.hasOwnProperty.call(object, key);
 
 const clamp01 = (value) => Math.max(0, Math.min(1, value));
+
+const getInitialSliderValue = (sliderComputedNode) =>
+  sliderComputedNode.initialValue ?? sliderComputedNode.min;
+
+const readPointerId = (event) => {
+  if (!event || typeof event !== "object") {
+    return undefined;
+  }
+
+  if (typeof event.pointerId === "number") {
+    return event.pointerId;
+  }
+
+  if (typeof event.nativeEvent?.pointerId === "number") {
+    return event.nativeEvent.pointerId;
+  }
+
+  if (typeof event.data?.pointerId === "number") {
+    return event.data.pointerId;
+  }
+
+  return undefined;
+};
+
+const getNativeClientPoint = (event) => {
+  if (!event || typeof event !== "object") {
+    return null;
+  }
+
+  if (typeof event.clientX === "number" && typeof event.clientY === "number") {
+    return {
+      x: event.clientX,
+      y: event.clientY,
+    };
+  }
+
+  const touch = event.changedTouches?.[0] ?? event.touches?.[0];
+
+  if (
+    touch &&
+    typeof touch.clientX === "number" &&
+    typeof touch.clientY === "number"
+  ) {
+    return {
+      x: touch.clientX,
+      y: touch.clientY,
+    };
+  }
+
+  return null;
+};
+
+const canUseNativeDragTracking = (app) =>
+  typeof globalThis.addEventListener === "function" &&
+  typeof globalThis.removeEventListener === "function" &&
+  typeof globalThis.document?.addEventListener === "function" &&
+  typeof globalThis.document?.removeEventListener === "function" &&
+  typeof app?.renderer?.events?.mapPositionToPoint === "function";
+
+const mapNativeEventToGlobalPoint = ({ app, nativeEvent }) => {
+  const clientPoint = getNativeClientPoint(nativeEvent);
+
+  if (!clientPoint) {
+    return null;
+  }
+
+  const globalPoint = { x: 0, y: 0 };
+
+  app.renderer.events.mapPositionToPoint(
+    globalPoint,
+    clientPoint.x,
+    clientPoint.y,
+  );
+
+  return globalPoint;
+};
+
+const detachNativeDragListeners = (runtime) => {
+  runtime.removeNativeDragListeners?.();
+  runtime.removeNativeDragListeners = null;
+};
+
+const attachNativeDragListeners = ({ runtime, moveListener, upListener }) => {
+  if (
+    !canUseNativeDragTracking(runtime.app) ||
+    runtime.removeNativeDragListeners
+  ) {
+    return;
+  }
+
+  const listeners = [];
+  const addListener = (target, type, listener) => {
+    target.addEventListener(type, listener, true);
+    listeners.push([target, type, listener]);
+  };
+
+  if (typeof globalThis.PointerEvent === "function") {
+    addListener(globalThis.document, "pointermove", moveListener);
+    addListener(globalThis, "pointerup", upListener);
+    addListener(globalThis, "pointercancel", upListener);
+  } else {
+    addListener(globalThis.document, "mousemove", moveListener);
+    addListener(globalThis, "mouseup", upListener);
+
+    if ("ontouchstart" in globalThis) {
+      addListener(globalThis.document, "touchmove", moveListener);
+      addListener(globalThis, "touchend", upListener);
+      addListener(globalThis, "touchcancel", upListener);
+    }
+  }
+
+  runtime.removeNativeDragListeners = () => {
+    for (const [target, type, listener] of listeners) {
+      target.removeEventListener(type, listener, true);
+    }
+  };
+};
 
 export const getSliderTexture = (src) =>
   src ? Texture.from(src) : Texture.EMPTY;
@@ -323,6 +441,117 @@ const setSliderCursor = ({ sliderContainer, sliderComputedNode, cursor }) => {
   }
 };
 
+const applySliderRuntimeVisualState = (runtime) => {
+  applySliderVisualState({
+    sliderContainer: runtime.sliderContainer,
+    sliderComputedNode: runtime.sliderComputedNode,
+    thumb: runtime.thumb,
+    currentValue: runtime.currentValue,
+    hoverOverride:
+      runtime.sliderComputedNode.hover && runtime.hoverController?.isHovering()
+        ? runtime.sliderComputedNode.hover
+        : null,
+  });
+};
+
+const syncSliderRuntimeCursor = (runtime) => {
+  const cursor =
+    runtime.hoverController?.isHovering() === true
+      ? runtime.sliderComputedNode.hover?.cursor
+      : null;
+
+  setSliderCursor({
+    sliderContainer: runtime.sliderContainer,
+    sliderComputedNode: runtime.sliderComputedNode,
+    cursor,
+  });
+};
+
+const ensureSliderRuntime = ({
+  app,
+  sliderContainer,
+  sliderComputedNode,
+  thumb,
+  eventHandler,
+}) => {
+  /** @type {any} */
+  let runtime = sliderContainer[SLIDER_RUNTIME];
+
+  if (!runtime) {
+    clearInheritedHoverTarget(sliderContainer);
+
+    runtime = {
+      app,
+      sliderContainer,
+      sliderComputedNode,
+      thumb,
+      eventHandler,
+      currentValue: getInitialSliderValue(sliderComputedNode),
+      isDragging: false,
+      activePointerId: undefined,
+      listenersBound: false,
+      hoverController: null,
+      removeNativeDragListeners: null,
+    };
+
+    runtime.hoverController = createHoverStateController({
+      displayObject: sliderContainer,
+      onHoverChange: () => {
+        applySliderRuntimeVisualState(runtime);
+        syncSliderRuntimeCursor(runtime);
+      },
+    });
+
+    sliderContainer[SLIDER_RUNTIME] = runtime;
+  }
+
+  runtime.app = app;
+  runtime.sliderContainer = sliderContainer;
+  runtime.sliderComputedNode = sliderComputedNode;
+  runtime.thumb = thumb;
+  runtime.eventHandler = eventHandler;
+
+  return runtime;
+};
+
+export const syncSliderRuntime = ({
+  app,
+  sliderContainer,
+  sliderComputedNode,
+  thumb,
+  eventHandler,
+  adoptExternalValue = true,
+}) => {
+  const runtime = ensureSliderRuntime({
+    app,
+    sliderContainer,
+    sliderComputedNode,
+    thumb,
+    eventHandler,
+  });
+
+  if (adoptExternalValue) {
+    runtime.currentValue = getInitialSliderValue(sliderComputedNode);
+  }
+
+  applySliderRuntimeVisualState(runtime);
+  syncSliderRuntimeCursor(runtime);
+
+  return runtime;
+};
+
+export const destroySliderRuntime = ({ sliderContainer }) => {
+  const runtime = sliderContainer?.[SLIDER_RUNTIME];
+
+  if (!runtime) {
+    return;
+  }
+
+  detachNativeDragListeners(runtime);
+  runtime.hoverController?.destroy?.();
+  delete sliderContainer[SLIDER_RUNTIME];
+};
+
 export const bindSliderInteractions = ({
   app,
   sliderContainer,
@@ -330,102 +559,145 @@ export const bindSliderInteractions = ({
   thumb,
   eventHandler,
 }) => {
-  clearInheritedHoverTarget(sliderContainer);
+  const runtime = ensureSliderRuntime({
+    app,
+    sliderContainer,
+    sliderComputedNode,
+    thumb,
+    eventHandler,
+  });
 
-  const {
-    id,
-    hover,
-    change,
-    min,
-    max,
-    step,
-    direction,
-    initialValue,
-    width,
-    height,
-  } = sliderComputedNode;
-  let currentValue = initialValue ?? min;
-  let isDragging = false;
-  let hoverController = null;
+  if (runtime.listenersBound) {
+    return;
+  }
 
-  const applyCurrentVisualState = () => {
-    applySliderVisualState({
-      sliderContainer,
-      sliderComputedNode,
-      thumb,
-      currentValue,
-      hoverOverride: hoverController?.isHovering() ? hover : null,
-    });
-  };
+  runtime.listenersBound = true;
 
-  const onChange = (event) => {
-    const newPosition = sliderContainer.toLocal(event.global);
+  const onChangeFromGlobalPoint = (globalPoint) => {
+    const { sliderComputedNode: currentNode } = runtime;
+    const newPosition = runtime.sliderContainer.toLocal(globalPoint);
     const newValue = getSliderValueFromPosition({
       position: newPosition,
-      thumb,
-      direction,
-      min,
-      max,
-      step,
-      trackWidth: width,
-      trackHeight: height,
+      thumb: runtime.thumb,
+      direction: currentNode.direction,
+      min: currentNode.min,
+      max: currentNode.max,
+      step: currentNode.step,
+      trackWidth: currentNode.width,
+      trackHeight: currentNode.height,
     });
 
-    if (newValue !== currentValue) {
-      currentValue = newValue;
-      applyCurrentVisualState();
+    if (newValue !== runtime.currentValue) {
+      runtime.currentValue = newValue;
+      applySliderRuntimeVisualState(runtime);
 
-      if (change?.payload && eventHandler) {
-        eventHandler("change", {
-          _event: { id, value: currentValue },
-          ...change.payload,
+      if (currentNode.change?.payload && runtime.eventHandler) {
+        runtime.eventHandler("change", {
+          _event: { id: currentNode.id, value: runtime.currentValue },
+          ...currentNode.change.payload,
         });
       }
     }
   };
 
+  const onChange = (event) => {
+    if (!event?.global) {
+      return;
+    }
+
+    onChangeFromGlobalPoint(event.global);
+  };
+
+  const dragEndListener = (event) => {
+    const pointerId = readPointerId(event);
+
+    if (
+      runtime.activePointerId !== undefined &&
+      pointerId !== undefined &&
+      pointerId !== runtime.activePointerId
+    ) {
+      return;
+    }
+
+    if (runtime.isDragging) {
+      runtime.isDragging = false;
+      runtime.activePointerId = undefined;
+      detachNativeDragListeners(runtime);
+    }
+  };
+
+  const nativeDragMoveListener = (nativeEvent) => {
+    if (!runtime.isDragging) {
+      return;
+    }
+
+    const pointerId = readPointerId(nativeEvent);
+
+    if (
+      runtime.activePointerId !== undefined &&
+      pointerId !== undefined &&
+      pointerId !== runtime.activePointerId
+    ) {
+      return;
+    }
+
+    const globalPoint = mapNativeEventToGlobalPoint({
+      app: runtime.app,
+      nativeEvent,
+    });
+
+    if (!globalPoint) {
+      return;
+    }
+
+    onChangeFromGlobalPoint(globalPoint);
+  };
+
   const dragStartListener = (event) => {
-    isDragging = true;
+    runtime.isDragging = true;
+    runtime.activePointerId = readPointerId(event);
+    attachNativeDragListeners({
+      runtime,
+      moveListener: nativeDragMoveListener,
+      upListener: dragEndListener,
+    });
     onChange(event);
   };
 
   const dragMoveListener = (event) => {
-    if (isDragging) {
+    if (runtime.isDragging) {
       onChange(event);
     }
   };
 
-  const dragEndListener = () => {
-    if (isDragging) {
-      isDragging = false;
-    }
-  };
-
   sliderContainer.on("pointerdown", dragStartListener);
-  sliderContainer.on("globalpointermove", dragMoveListener);
+
+  if (!canUseNativeDragTracking(app)) {
+    sliderContainer.on("globalpointermove", dragMoveListener);
+  }
+
   sliderContainer.on("pointerup", dragEndListener);
   sliderContainer.on("pointerupoutside", dragEndListener);
 
-  if (!hover) {
-    return;
-  }
-
-  hoverController = createHoverStateController({
-    displayObject: sliderContainer,
-    onHoverChange: applyCurrentVisualState,
-  });
-
   const overListener = () => {
-    hoverController.setDirectHover(true);
-    applyCurrentVisualState();
+    runtime.hoverController?.setDirectHover(true);
+    applySliderRuntimeVisualState(runtime);
+    syncSliderRuntimeCursor(runtime);
+
+    const hover = runtime.sliderComputedNode.hover;
+
+    if (!hover) {
+      return;
+    }
+
     setSliderCursor({
-      sliderContainer,
-      sliderComputedNode,
+      sliderContainer: runtime.sliderContainer,
+      sliderComputedNode: runtime.sliderComputedNode,
       cursor: hover.cursor,
     });
 
     if (hover.soundSrc) {
-      app.audioStage.add({
+      runtime.app?.audioStage?.add({
         id: `hover-${Date.now()}`,
         url: hover.soundSrc,
         loop: false,
@@ -434,13 +706,13 @@ export const bindSliderInteractions = ({
   };
 
   const outListener = () => {
-    if (isDragging) {
+    if (runtime.isDragging) {
       return;
     }
 
-    hoverController.setDirectHover(false);
-    applyCurrentVisualState();
-    setSliderCursor({ sliderContainer, sliderComputedNode, cursor: null });
+    runtime.hoverController?.setDirectHover(false);
+    applySliderRuntimeVisualState(runtime);
+    syncSliderRuntimeCursor(runtime);
   };
 
   sliderContainer.on("pointerover", overListener);

--- a/src/plugins/elements/slider/updateSlider.js
+++ b/src/plugins/elements/slider/updateSlider.js
@@ -1,11 +1,11 @@
 import { isDeepEqual } from "../../../util/isDeepEqual.js";
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
 import {
-  applySliderVisualState,
-  bindSliderInteractions,
   getSliderParts,
   renameSliderParts,
   resizeSliderThumb,
+  SLIDER_RUNTIME,
+  syncSliderRuntime,
 } from "./sliderRuntime.js";
 
 /**
@@ -54,30 +54,6 @@ export const updateSlider = ({
         id: nextSliderComputedNode.id,
       });
 
-      // Check if handler configuration changed
-      const handlerConfigChanged =
-        !isDeepEqual(
-          prevSliderComputedNode.hover,
-          nextSliderComputedNode.hover,
-        ) ||
-        !isDeepEqual(
-          prevSliderComputedNode.change,
-          nextSliderComputedNode.change,
-        ) ||
-        prevSliderComputedNode.min !== nextSliderComputedNode.min ||
-        prevSliderComputedNode.max !== nextSliderComputedNode.max ||
-        prevSliderComputedNode.step !== nextSliderComputedNode.step ||
-        prevSliderComputedNode.direction !== nextSliderComputedNode.direction ||
-        prevSliderComputedNode.initialValue !==
-          nextSliderComputedNode.initialValue ||
-        prevSliderComputedNode.thumbSrc !== nextSliderComputedNode.thumbSrc ||
-        prevSliderComputedNode.barSrc !== nextSliderComputedNode.barSrc ||
-        prevSliderComputedNode.inactiveBarSrc !==
-          nextSliderComputedNode.inactiveBarSrc ||
-        prevSliderComputedNode.width !== nextSliderComputedNode.width ||
-        prevSliderComputedNode.height !== nextSliderComputedNode.height ||
-        prevSliderComputedNode.id !== nextSliderComputedNode.id;
-
       if (bar && thumb) {
         resizeSliderThumb({
           thumb,
@@ -86,42 +62,25 @@ export const updateSlider = ({
           trackWidth: nextSliderComputedNode.width,
           trackHeight: nextSliderComputedNode.height,
         });
-
-        applySliderVisualState({
-          sliderContainer: sliderElement,
-          sliderComputedNode: nextSliderComputedNode,
-          thumb,
-          currentValue: nextSliderComputedNode.initialValue,
-        });
       }
 
       if (!bar || !thumb) {
         return;
       }
 
-      // Only recreate event handlers if the handler configuration actually changed
-      // This prevents unnecessary handler replacement and avoids the "ReferenceError: Can't find variable: id"
-      // error that occurs when PixiJS tries to complete pointer events on destroyed closures
-      if (handlerConfigChanged) {
-        // Remove all existing event listeners from container, bar, and thumb
-        sliderElement.removeAllListeners("pointerover");
-        sliderElement.removeAllListeners("pointerout");
-        sliderElement.removeAllListeners("pointerup");
-        sliderElement.removeAllListeners("pointerupoutside");
-        sliderElement.removeAllListeners("pointerdown");
-        sliderElement.removeAllListeners("globalpointermove");
-      }
+      const shouldAdoptExternalValue =
+        sliderElement[SLIDER_RUNTIME]?.isDragging !== true ||
+        prevSliderComputedNode.initialValue !==
+          nextSliderComputedNode.initialValue;
 
-      // Re-attach event handlers if configuration changed
-      if (handlerConfigChanged) {
-        bindSliderInteractions({
-          app,
-          sliderContainer: sliderElement,
-          sliderComputedNode: nextSliderComputedNode,
-          thumb,
-          eventHandler,
-        });
-      }
+      syncSliderRuntime({
+        app,
+        sliderContainer: sliderElement,
+        sliderComputedNode: nextSliderComputedNode,
+        thumb,
+        eventHandler,
+        adoptExternalValue: shouldAdoptExternalValue,
+      });
     }
   };
 


### PR DESCRIPTION
## Summary
- preserve slider drag/runtime state across updates instead of tearing down and rebinding listeners on every slider config change
- add native drag listener cleanup on slider delete and clamp parsed slider `initialValue` into the configured min/max range
- add slider regression coverage for rerender-during-drag and programmatic value sync, and bump the package version to `1.8.1`

## Testing
- `bunx vitest run spec/parser/parseSlider.test.yaml spec/elements/updateSlider.spec.js`
- pre-push hook: `bunx prettier --check src`
- pre-push hook: `vitest run`