### PR TITLE
Add configurable soft wipe text reveal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/pages/docs/nodes/text-revealing.md
+++ b/playground/pages/docs/nodes/text-revealing.md
@@ -15,22 +15,23 @@ Try it in the [Playground](/playground/?template=text-revealing).
 
 ## Field Reference
 
-| Field          | Type                                 | Required            | Default        | Notes                                                                                                                       |
-| -------------- | ------------------------------------ | ------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `id`           | string                               | Yes                 | -              | Element id.                                                                                                                 |
-| `type`         | string                               | Yes                 | -              | Must be `text-revealing`.                                                                                                   |
-| `x`            | number                               | Yes (public schema) | `0` at runtime | Position before anchor transform.                                                                                           |
-| `y`            | number                               | Yes (public schema) | `0` at runtime | Position before anchor transform.                                                                                           |
-| `content`      | array                                | No                  | `[]`           | Array of rich text segments.                                                                                                |
-| `width`        | number                               | No                  | auto           | If omitted, parser uses a 500px wrap basis for layout measurement.                                                          |
-| `anchorX`      | number                               | No                  | `0`            | Anchor offset ratio.                                                                                                        |
-| `anchorY`      | number                               | No                  | `0`            | Anchor offset ratio.                                                                                                        |
-| `alpha`        | number                               | No                  | `1`            | Opacity `0..1`.                                                                                                             |
-| `textStyle`    | object                               | No                  | text defaults  | Base style for segments.                                                                                                    |
+| Field          | Type                                 | Required            | Default        | Notes                                                                                                                           |
+| -------------- | ------------------------------------ | ------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `id`           | string                               | Yes                 | -              | Element id.                                                                                                                     |
+| `type`         | string                               | Yes                 | -              | Must be `text-revealing`.                                                                                                       |
+| `x`            | number                               | Yes (public schema) | `0` at runtime | Position before anchor transform.                                                                                               |
+| `y`            | number                               | Yes (public schema) | `0` at runtime | Position before anchor transform.                                                                                               |
+| `content`      | array                                | No                  | `[]`           | Array of rich text segments.                                                                                                    |
+| `width`        | number                               | No                  | auto           | If omitted, parser uses a 500px wrap basis for layout measurement.                                                              |
+| `anchorX`      | number                               | No                  | `0`            | Anchor offset ratio.                                                                                                            |
+| `anchorY`      | number                               | No                  | `0`            | Anchor offset ratio.                                                                                                            |
+| `alpha`        | number                               | No                  | `1`            | Opacity `0..1`.                                                                                                                 |
+| `textStyle`    | object                               | No                  | text defaults  | Base style for segments.                                                                                                        |
 | `speed`        | number                               | No                  | `50`           | Uses a curved `0..100` scale. `0..99` gets progressively faster with extra control in the upper range; `100` renders instantly. |
-| `revealEffect` | `typewriter` \| `softWipe` \| `none` | No                  | `typewriter`   | `softWipe` reveals pre-laid-out text with a soft left-to-right mask, one laid-out line at a time. `none` renders instantly. |
-| `indicator`    | object                               | No                  | -              | Revealing/complete icon config + offset.                                                                                    |
-| `complete`     | object                               | No                  | -              | Parsed and kept in computed node.                                                                                           |
+| `revealEffect` | `typewriter` \| `softWipe` \| `none` | No                  | `typewriter`   | `softWipe` reveals pre-laid-out text with a soft left-to-right mask, one laid-out line at a time. `none` renders instantly.     |
+| `softWipe`     | object                               | No                  | see below      | Parameters used when `revealEffect: softWipe`.                                                                                  |
+| `indicator`    | object                               | No                  | -              | Revealing/complete icon config + offset.                                                                                        |
+| `complete`     | object                               | No                  | -              | Parsed and kept in computed node.                                                                                               |
 
 ### `content[]` item shape
 
@@ -52,12 +53,22 @@ Try it in the [Playground](/playground/?template=text-revealing).
 | `complete.height`  | number | `12`    |
 | `offset`           | number | `12`    |
 
+### `softWipe`
+
+| Field         | Type                           | Default       |
+| ------------- | ------------------------------ | ------------- |
+| `direction`   | `leftToRight` \| `rightToLeft` | `leftToRight` |
+| `softness`    | number                         | `1.25`        |
+| `easing`      | `linear` \| `easeOutCubic`     | `linear`      |
+| `lineOverlap` | number `0..0.95`               | `0`           |
+| `lineDelay`   | number                         | `0`           |
+
 ## Behavior Notes
 
 - Reveal runs chunk by chunk.
 - `speed` uses an exponential/log-like mapping so `50..99` covers most of the fast reveal range with finer control than a linear scale.
 - `speed: 100` skips animation entirely and paints the final text immediately, regardless of `revealEffect`.
-- `softWipe` lays out the full text immediately and reveals it line by line with a moving soft mask.
+- `softWipe` lays out the full text immediately and reveals it line by line with a moving soft mask. Defaults match the original soft wipe behavior: left-to-right, linear motion, no overlap or lead highlight, and a feather width clamped to the legacy range.
 - `revealEffect: none` skips animation and paints text immediately.
 - Completion contributes to global `renderComplete` tracking.
 - `complete.payload` is currently parsed but no dedicated per-node event is emitted from this plugin.
@@ -188,6 +199,12 @@ elements:
     width: 720
     speed: 22
     revealEffect: softWipe
+    softWipe:
+      direction: leftToRight
+      softness: 1.25
+      easing: linear
+      lineOverlap: 0
+      lineDelay: 0
     indicator:
       revealing:
         src: circle-red

--- a/playground/pages/docs/nodes/text-revealing.md
+++ b/playground/pages/docs/nodes/text-revealing.md
@@ -55,20 +55,19 @@ Try it in the [Playground](/playground/?template=text-revealing).
 
 ### `softWipe`
 
-| Field         | Type                           | Default       |
-| ------------- | ------------------------------ | ------------- |
-| `direction`   | `leftToRight` \| `rightToLeft` | `leftToRight` |
-| `softness`    | number                         | `1.25`        |
-| `easing`      | `linear` \| `easeOutCubic`     | `linear`      |
-| `lineOverlap` | number `0..0.95`               | `0`           |
-| `lineDelay`   | number                         | `0`           |
+| Field         | Type                       | Default  |
+| ------------- | -------------------------- | -------- |
+| `softness`    | number                     | `1.25`   |
+| `easing`      | `linear` \| `easeOutCubic` | `linear` |
+| `lineOverlap` | number `0..0.95`           | `0`      |
+| `lineDelay`   | number                     | `0`      |
 
 ## Behavior Notes
 
 - Reveal runs chunk by chunk.
 - `speed` uses an exponential/log-like mapping so `50..99` covers most of the fast reveal range with finer control than a linear scale.
 - `speed: 100` skips animation entirely and paints the final text immediately, regardless of `revealEffect`.
-- `softWipe` lays out the full text immediately and reveals it line by line with a moving soft mask. Defaults match the original soft wipe behavior: left-to-right, linear motion, no overlap or lead highlight, and a feather width clamped to the legacy range.
+- `softWipe` lays out the full text immediately and reveals it line by line with a moving soft mask. Defaults match the original soft wipe behavior: linear motion, no overlap, and a feather width clamped to the legacy range.
 - `revealEffect: none` skips animation and paints text immediately.
 - Completion contributes to global `renderComplete` tracking.
 - `complete.payload` is currently parsed but no dedicated per-node event is emitted from this plugin.
@@ -200,7 +199,6 @@ elements:
     speed: 22
     revealEffect: softWipe
     softWipe:
-      direction: leftToRight
       softness: 1.25
       easing: linear
       lineOverlap: 0

--- a/spec/elements/textRevealingRuntime.softWipe.spec.js
+++ b/spec/elements/textRevealingRuntime.softWipe.spec.js
@@ -65,29 +65,33 @@ const getLineContainer = (container, element, lineIndex = 0) =>
     .getChildByLabel(`${element.id}-line-${lineIndex}`);
 
 describe("runTextReveal softWipe parameters", () => {
-  it("uses direction and softness when positioning line masks", async () => {
-    const left = await runSoftWipe({
+  it("uses softness when positioning line masks", async () => {
+    const baseline = await runSoftWipe({
       softWipe: {
-        direction: "leftToRight",
+        softness: 1.25,
+      },
+    });
+    const softened = await runSoftWipe({
+      softWipe: {
         softness: 2,
       },
     });
-    const right = await runSoftWipe({
-      softWipe: {
-        direction: "rightToLeft",
-        softness: 2,
-      },
-    });
 
-    const leftMask = getLineContainer(left.container, left.element).mask;
-    const rightMask = getLineContainer(right.container, right.element).mask;
+    const baselineMask = getLineContainer(
+      baseline.container,
+      baseline.element,
+    ).mask;
+    const softenedMask = getLineContainer(
+      softened.container,
+      softened.element,
+    ).mask;
 
-    expect(left.payload).toBeDefined();
-    expect(right.payload).toBeDefined();
-    expect(leftMask.x).toBeLessThan(rightMask.x);
+    expect(baseline.payload).toBeDefined();
+    expect(softened.payload).toBeDefined();
+    expect(softenedMask.x).toBeLessThan(baselineMask.x);
 
-    left.payload.onCancel();
-    right.payload.onCancel();
+    baseline.payload.onCancel();
+    softened.payload.onCancel();
   });
 
   it("applies easing to the indicator motion", async () => {

--- a/spec/elements/textRevealingRuntime.softWipe.spec.js
+++ b/spec/elements/textRevealingRuntime.softWipe.spec.js
@@ -1,0 +1,155 @@
+import { Container } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
+
+import { parseTextRevealing } from "../../src/plugins/elements/text-revealing/parseTextRevealing.js";
+import { runTextReveal } from "../../src/plugins/elements/text-revealing/textRevealingRuntime.js";
+
+const createCompletionTracker = () => ({
+  getVersion: () => 0,
+  track: vi.fn(),
+  complete: vi.fn(),
+});
+
+const createElement = (overrides = {}) =>
+  parseTextRevealing({
+    state: {
+      id: "soft-wipe-line",
+      type: "text-revealing",
+      x: 0,
+      y: 0,
+      width: 500,
+      speed: 35,
+      revealEffect: "softWipe",
+      content: [{ text: "Soft wipe runtime parameters" }],
+      textStyle: {
+        fontSize: 20,
+        fontFamily: "Arial",
+        breakWords: false,
+      },
+      ...overrides,
+    },
+  });
+
+const runSoftWipe = async (overrides = {}) => {
+  const container = new Container();
+  const completionTracker = createCompletionTracker();
+  const animationBus = { dispatch: vi.fn() };
+  const element = createElement(overrides);
+
+  await runTextReveal({
+    container,
+    element,
+    completionTracker,
+    animationBus,
+    zIndex: 0,
+    signal: new AbortController().signal,
+    playback: "autoplay",
+  });
+
+  const startAction = animationBus.dispatch.mock.calls.find(
+    ([action]) => action.type === "START",
+  )?.[0];
+
+  return {
+    container,
+    element,
+    completionTracker,
+    animationBus,
+    payload: startAction?.payload,
+  };
+};
+
+const getLineContainer = (container, element, lineIndex = 0) =>
+  container
+    .getChildByLabel(`${element.id}-content`)
+    .getChildByLabel(`${element.id}-line-${lineIndex}`);
+
+describe("runTextReveal softWipe parameters", () => {
+  it("uses direction and softness when positioning line masks", async () => {
+    const left = await runSoftWipe({
+      softWipe: {
+        direction: "leftToRight",
+        softness: 2,
+      },
+    });
+    const right = await runSoftWipe({
+      softWipe: {
+        direction: "rightToLeft",
+        softness: 2,
+      },
+    });
+
+    const leftMask = getLineContainer(left.container, left.element).mask;
+    const rightMask = getLineContainer(right.container, right.element).mask;
+
+    expect(left.payload).toBeDefined();
+    expect(right.payload).toBeDefined();
+    expect(leftMask.x).toBeLessThan(rightMask.x);
+
+    left.payload.onCancel();
+    right.payload.onCancel();
+  });
+
+  it("applies easing to the indicator motion", async () => {
+    const linear = await runSoftWipe({
+      softWipe: {
+        easing: "linear",
+        softness: 0,
+      },
+    });
+    const eased = await runSoftWipe({
+      softWipe: {
+        easing: "easeOutCubic",
+        softness: 0,
+      },
+    });
+
+    linear.payload.applyFrame(linear.payload.duration / 2);
+    eased.payload.applyFrame(eased.payload.duration / 2);
+
+    const linearIndicator = linear.container.children[1];
+    const easedIndicator = eased.container.children[1];
+
+    expect(easedIndicator.x).toBeGreaterThan(linearIndicator.x);
+
+    linear.payload.onCancel();
+    eased.payload.onCancel();
+  });
+
+  it("accounts for line delay and line overlap in total duration", async () => {
+    const content = [{ text: "First soft wipe line\nSecond soft wipe line" }];
+    const baseline = await runSoftWipe({ content });
+    const delayed = await runSoftWipe({
+      content,
+      softWipe: {
+        lineDelay: 250,
+      },
+    });
+    const overlapped = await runSoftWipe({
+      content,
+      softWipe: {
+        lineOverlap: 0.5,
+      },
+    });
+
+    expect(delayed.payload.duration).toBeGreaterThan(baseline.payload.duration);
+    expect(overlapped.payload.duration).toBeLessThan(baseline.payload.duration);
+
+    baseline.payload.onCancel();
+    delayed.payload.onCancel();
+    overlapped.payload.onCancel();
+  });
+
+  it("keeps the legacy edge width clamp when no softness override changes it", async () => {
+    const result = await runSoftWipe();
+    const lineContainer = getLineContainer(result.container, result.element);
+    const expectedEdgeWidth = Math.max(
+      18,
+      Math.min(64, Math.round(result.element.content[0].lineMaxHeight * 1.25)),
+    );
+
+    expect(lineContainer.mask.x).toBe(-expectedEdgeWidth);
+
+    result.payload.onCancel();
+  });
+});

--- a/spec/elements/updateTextRevealing.spec.js
+++ b/spec/elements/updateTextRevealing.spec.js
@@ -161,6 +161,48 @@ describe("updateTextRevealing", () => {
     );
   });
 
+  it("restarts reveal when softWipe parameters change", async () => {
+    const parent = new Container();
+    const child = new Container();
+    child.label = "line-1";
+    parent.addChild(child);
+
+    await updateTextRevealing({
+      parent,
+      prevElement: createElement({
+        revealEffect: "softWipe",
+        softWipe: {
+          easing: "linear",
+        },
+      }),
+      nextElement: createElement({
+        revealEffect: "softWipe",
+        softWipe: {
+          easing: "easeOutCubic",
+        },
+      }),
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      renderContext: createRenderContext(),
+      completionTracker: createCompletionTracker(),
+      zIndex: 0,
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.runTextReveal).toHaveBeenCalledTimes(1);
+    expect(mocks.runTextReveal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playback: "autoplay",
+        element: expect.objectContaining({
+          revealEffect: "softWipe",
+          softWipe: expect.objectContaining({
+            easing: "easeOutCubic",
+          }),
+        }),
+      }),
+    );
+  });
+
   it("renders immediately at max speed without queueing deferred reveal work", async () => {
     const parent = new Container();
     const child = new Container();

--- a/spec/parser/parseTextRevealing.softWipe.spec.js
+++ b/spec/parser/parseTextRevealing.softWipe.spec.js
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTextRevealing } from "../../src/plugins/elements/text-revealing/parseTextRevealing.js";
+
+const createState = (overrides = {}) => ({
+  id: "soft-wipe-line",
+  type: "text-revealing",
+  x: 0,
+  y: 0,
+  revealEffect: "softWipe",
+  content: [{ text: "Soft wipe parameters" }],
+  textStyle: {
+    fontFamily: "Arial",
+    fontSize: 20,
+    breakWords: false,
+  },
+  ...overrides,
+});
+
+describe("parseTextRevealing softWipe", () => {
+  it("normalizes supplied softWipe options with defaults", () => {
+    const parsed = parseTextRevealing({
+      state: createState({
+        softWipe: {
+          softness: 2,
+          lineDelay: 120,
+        },
+      }),
+    });
+
+    expect(parsed.softWipe).toEqual({
+      direction: "leftToRight",
+      softness: 2,
+      easing: "linear",
+      lineOverlap: 0,
+      lineDelay: 120,
+    });
+  });
+
+  it("clamps unsafe numeric values and falls back for unsupported options", () => {
+    const parsed = parseTextRevealing({
+      state: createState({
+        softWipe: {
+          direction: "diagonal",
+          softness: -1,
+          easing: "bounce",
+          lineOverlap: 2,
+          lineDelay: -20,
+        },
+      }),
+    });
+
+    expect(parsed.softWipe).toEqual({
+      direction: "leftToRight",
+      softness: 0,
+      easing: "linear",
+      lineOverlap: 0.95,
+      lineDelay: 0,
+    });
+  });
+});

--- a/spec/parser/parseTextRevealing.softWipe.spec.js
+++ b/spec/parser/parseTextRevealing.softWipe.spec.js
@@ -29,7 +29,6 @@ describe("parseTextRevealing softWipe", () => {
     });
 
     expect(parsed.softWipe).toEqual({
-      direction: "leftToRight",
       softness: 2,
       easing: "linear",
       lineOverlap: 0,
@@ -37,11 +36,11 @@ describe("parseTextRevealing softWipe", () => {
     });
   });
 
-  it("clamps unsafe numeric values and falls back for unsupported options", () => {
+  it("clamps unsafe numeric values and ignores unsupported options", () => {
     const parsed = parseTextRevealing({
       state: createState({
         softWipe: {
-          direction: "diagonal",
+          direction: "rightToLeft",
           softness: -1,
           easing: "bounce",
           lineOverlap: 2,
@@ -51,7 +50,6 @@ describe("parseTextRevealing softWipe", () => {
     });
 
     expect(parsed.softWipe).toEqual({
-      direction: "leftToRight",
       softness: 0,
       easing: "linear",
       lineOverlap: 0.95,

--- a/src/plugins/elements/text-revealing/parseTextRevealing.js
+++ b/src/plugins/elements/text-revealing/parseTextRevealing.js
@@ -2,6 +2,7 @@ import { CanvasTextMetrics, TextStyle } from "pixi.js";
 import { parseCommonObject } from "../util/parseCommonObject.js";
 import { DEFAULT_TEXT_STYLE } from "../../../types.js";
 import { toPixiTextStyle } from "../../../util/toPixiTextStyle.js";
+import { normalizeSoftWipeConfig } from "./softWipeConfig.js";
 
 /**
  * @typedef {import('../../../types.js').BaseElement} BaseElement
@@ -432,6 +433,9 @@ export const parseTextRevealing = ({ state }) => {
     },
     speed: state.speed ?? 50,
     revealEffect: state.revealEffect ?? "typewriter",
+    ...(state.softWipe !== undefined && {
+      softWipe: normalizeSoftWipeConfig(state.softWipe),
+    }),
     ...(state.width !== undefined && { width: state.width }),
     ...(state.complete && { complete: state.complete }),
   };

--- a/src/plugins/elements/text-revealing/softWipeConfig.js
+++ b/src/plugins/elements/text-revealing/softWipeConfig.js
@@ -1,5 +1,4 @@
 export const DEFAULT_SOFT_WIPE_CONFIG = {
-  direction: "leftToRight",
   softness: 1.25,
   easing: "linear",
   lineOverlap: 0,
@@ -8,8 +7,6 @@ export const DEFAULT_SOFT_WIPE_CONFIG = {
 
 export const LEGACY_SOFT_WIPE_MIN_EDGE = 18;
 export const LEGACY_SOFT_WIPE_MAX_EDGE = 64;
-
-const SOFT_WIPE_DIRECTIONS = new Set(["leftToRight", "rightToLeft"]);
 
 export const SOFT_WIPE_EASINGS = {
   linear: (progress) => progress,
@@ -25,9 +22,6 @@ export const normalizeSoftWipeConfig = (config = {}) => {
   const input = config && typeof config === "object" ? config : {};
 
   return {
-    direction: SOFT_WIPE_DIRECTIONS.has(input.direction)
-      ? input.direction
-      : DEFAULT_SOFT_WIPE_CONFIG.direction,
     softness: Math.max(
       0,
       finiteNumberOr(input.softness, DEFAULT_SOFT_WIPE_CONFIG.softness),

--- a/src/plugins/elements/text-revealing/softWipeConfig.js
+++ b/src/plugins/elements/text-revealing/softWipeConfig.js
@@ -1,0 +1,63 @@
+export const DEFAULT_SOFT_WIPE_CONFIG = {
+  direction: "leftToRight",
+  softness: 1.25,
+  easing: "linear",
+  lineOverlap: 0,
+  lineDelay: 0,
+};
+
+export const LEGACY_SOFT_WIPE_MIN_EDGE = 18;
+export const LEGACY_SOFT_WIPE_MAX_EDGE = 64;
+
+const SOFT_WIPE_DIRECTIONS = new Set(["leftToRight", "rightToLeft"]);
+
+export const SOFT_WIPE_EASINGS = {
+  linear: (progress) => progress,
+  easeOutCubic: (progress) => 1 - (1 - progress) ** 3,
+};
+
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+const finiteNumberOr = (value, fallback) =>
+  typeof value === "number" && Number.isFinite(value) ? value : fallback;
+
+export const normalizeSoftWipeConfig = (config = {}) => {
+  const input = config && typeof config === "object" ? config : {};
+
+  return {
+    direction: SOFT_WIPE_DIRECTIONS.has(input.direction)
+      ? input.direction
+      : DEFAULT_SOFT_WIPE_CONFIG.direction,
+    softness: Math.max(
+      0,
+      finiteNumberOr(input.softness, DEFAULT_SOFT_WIPE_CONFIG.softness),
+    ),
+    easing: Object.prototype.hasOwnProperty.call(
+      SOFT_WIPE_EASINGS,
+      input.easing,
+    )
+      ? input.easing
+      : DEFAULT_SOFT_WIPE_CONFIG.easing,
+    lineOverlap: clamp(
+      finiteNumberOr(input.lineOverlap, DEFAULT_SOFT_WIPE_CONFIG.lineOverlap),
+      0,
+      0.95,
+    ),
+    lineDelay: Math.max(
+      0,
+      finiteNumberOr(input.lineDelay, DEFAULT_SOFT_WIPE_CONFIG.lineDelay),
+    ),
+  };
+};
+
+export const getSoftWipeEasing = (name) =>
+  SOFT_WIPE_EASINGS[name] ?? SOFT_WIPE_EASINGS[DEFAULT_SOFT_WIPE_CONFIG.easing];
+
+export const getSoftWipeEdgeWidth = ({ maxLineHeight, softWipe }) =>
+  Math.max(
+    LEGACY_SOFT_WIPE_MIN_EDGE,
+    Math.min(
+      LEGACY_SOFT_WIPE_MAX_EDGE,
+      Math.round(maxLineHeight * softWipe.softness),
+    ),
+  );

--- a/src/plugins/elements/text-revealing/textRevealingRuntime.js
+++ b/src/plugins/elements/text-revealing/textRevealingRuntime.js
@@ -529,11 +529,7 @@ const runSoftWipeReveal = ({
     const texture = getCanvasTexture(canvas);
     const sprite = new Sprite(texture);
 
-    sprite.x = Math.floor(
-      softWipe.direction === "rightToLeft"
-        ? line.bounds.x
-        : line.bounds.x - edgeWidth,
-    );
+    sprite.x = Math.floor(line.bounds.x - edgeWidth);
     sprite.y = Math.floor(line.bounds.y);
     line.container.mask = sprite;
     contentContainer.addChild(sprite);
@@ -629,10 +625,7 @@ const runSoftWipeReveal = ({
       duration,
       applyFrame: (currentTime) => {
         let activeLine = timedLines[0];
-        let activeLineLeadingEdgeX =
-          softWipe.direction === "rightToLeft"
-            ? activeLine.bounds.x + activeLine.bounds.width
-            : activeLine.bounds.x;
+        let activeLineLeadingEdgeX = activeLine.bounds.x;
 
         for (let lineIndex = 0; lineIndex < timedLines.length; lineIndex++) {
           const line = timedLines[lineIndex];
@@ -653,104 +646,56 @@ const runSoftWipeReveal = ({
 
           const lineY = 0;
           const lineTravelDistance = line.bounds.width + edgeWidth;
-          let leadingEdgeX;
+          const lineStart = edgeWidth;
+          const lineLeadingEdge = lineStart + lineProgress * lineTravelDistance;
+          const hardEnd = Math.max(lineStart, lineLeadingEdge - edgeWidth);
 
-          if (softWipe.direction === "rightToLeft") {
-            const lineStart = 0;
-            const lineEnd = line.bounds.width;
-            const lineLeadingEdge = lineEnd - lineProgress * lineTravelDistance;
-            const hardStart = Math.min(lineEnd, lineLeadingEdge + edgeWidth);
-
-            if (hardStart < lineEnd) {
-              context.fillStyle = "#ffffff";
-              context.fillRect(
-                Math.max(lineStart, hardStart),
-                lineY,
-                lineEnd - Math.max(lineStart, hardStart),
-                line.bounds.height,
-              );
-            }
-
-            const gradientStart = Math.max(lineStart, lineLeadingEdge);
-            const gradientEnd = Math.min(lineEnd, lineLeadingEdge + edgeWidth);
-
-            if (gradientEnd > gradientStart) {
-              const gradient = context.createLinearGradient(
-                gradientStart,
-                0,
-                gradientEnd,
-                0,
-              );
-
-              gradient.addColorStop(0, "rgba(255, 255, 255, 0)");
-              gradient.addColorStop(1, "rgba(255, 255, 255, 1)");
-              context.fillStyle = gradient;
-              context.fillRect(
-                gradientStart,
-                lineY,
-                gradientEnd - gradientStart,
-                line.bounds.height,
-              );
-            }
-
-            leadingEdgeX =
-              line.bounds.x +
-              Math.max(0, Math.min(line.bounds.width, lineLeadingEdge));
-          } else {
-            const lineStart = edgeWidth;
-            const lineLeadingEdge =
-              lineStart + lineProgress * lineTravelDistance;
-            const hardEnd = Math.max(lineStart, lineLeadingEdge - edgeWidth);
-
-            if (hardEnd > lineStart) {
-              context.fillStyle = "#ffffff";
-              context.fillRect(
-                lineStart,
-                lineY,
-                Math.min(hardEnd - lineStart, line.bounds.width),
-                line.bounds.height,
-              );
-            }
-
-            const gradientStart = Math.max(
+          if (hardEnd > lineStart) {
+            context.fillStyle = "#ffffff";
+            context.fillRect(
               lineStart,
-              lineLeadingEdge - edgeWidth,
+              lineY,
+              Math.min(hardEnd - lineStart, line.bounds.width),
+              line.bounds.height,
             );
-            const gradientEnd = Math.min(
-              lineStart + line.bounds.width,
-              lineLeadingEdge,
+          }
+
+          const gradientStart = Math.max(
+            lineStart,
+            lineLeadingEdge - edgeWidth,
+          );
+          const gradientEnd = Math.min(
+            lineStart + line.bounds.width,
+            lineLeadingEdge,
+          );
+
+          if (gradientEnd > gradientStart) {
+            const gradient = context.createLinearGradient(
+              gradientStart,
+              0,
+              gradientEnd,
+              0,
             );
 
-            if (gradientEnd > gradientStart) {
-              const gradient = context.createLinearGradient(
-                gradientStart,
-                0,
-                gradientEnd,
-                0,
-              );
-
-              gradient.addColorStop(0, "rgba(255, 255, 255, 1)");
-              gradient.addColorStop(1, "rgba(255, 255, 255, 0)");
-              context.fillStyle = gradient;
-              context.fillRect(
-                gradientStart,
-                lineY,
-                gradientEnd - gradientStart,
-                line.bounds.height,
-              );
-            }
-
-            leadingEdgeX =
-              line.bounds.x +
-              Math.min(
-                line.bounds.width,
-                Math.max(0, lineLeadingEdge - lineStart),
-              );
+            gradient.addColorStop(0, "rgba(255, 255, 255, 1)");
+            gradient.addColorStop(1, "rgba(255, 255, 255, 0)");
+            context.fillStyle = gradient;
+            context.fillRect(
+              gradientStart,
+              lineY,
+              gradientEnd - gradientStart,
+              line.bounds.height,
+            );
           }
 
           texture.source.update();
           activeLine = line;
-          activeLineLeadingEdgeX = leadingEdgeX;
+          activeLineLeadingEdgeX =
+            line.bounds.x +
+            Math.min(
+              line.bounds.width,
+              Math.max(0, lineLeadingEdge - lineStart),
+            );
         }
 
         positionIndicatorForChunk(
@@ -758,10 +703,7 @@ const runSoftWipeReveal = ({
           activeLine.chunk,
           indicatorOffset,
         );
-        indicatorSprite.x =
-          softWipe.direction === "rightToLeft"
-            ? activeLineLeadingEdgeX - indicatorOffset - indicatorSprite.width
-            : activeLineLeadingEdgeX + indicatorOffset;
+        indicatorSprite.x = activeLineLeadingEdgeX + indicatorOffset;
       },
       applyTargetState: () => {
         finalize(false);

--- a/src/plugins/elements/text-revealing/textRevealingRuntime.js
+++ b/src/plugins/elements/text-revealing/textRevealingRuntime.js
@@ -9,12 +9,14 @@ import {
 import { getCharacterXPositionInATextObject } from "../../../util/getCharacterXPositionInATextObject";
 import abortableSleep from "../../../util/abortableSleep";
 import { toPixiTextStyle } from "../../../util/toPixiTextStyle.js";
+import {
+  getSoftWipeEdgeWidth,
+  getSoftWipeEasing,
+  normalizeSoftWipeConfig,
+} from "./softWipeConfig.js";
 
 const TEXT_REVEAL_RUNTIME = Symbol("textRevealRuntime");
 const TEXT_REVEAL_SNAPSHOT = Symbol("textRevealSnapshot");
-const MIN_SOFT_WIPE_EDGE = 18;
-const MAX_SOFT_WIPE_EDGE = 64;
-const SOFT_WIPE_EDGE_MULTIPLIER = 1.25;
 const DEFAULT_TEXT_REVEAL_SPEED = 50;
 const MIN_TEXT_REVEAL_SPEED = 0;
 const MAX_TEXT_REVEAL_SPEED = 100;
@@ -408,6 +410,57 @@ const runTypewriterReveal = async ({
   return true;
 };
 
+const createSoftWipeLineTimings = ({
+  lines,
+  edgeWidth,
+  baseDuration,
+  softWipe,
+}) => {
+  const lineWeights = lines.map((line) => {
+    const baseWeight = Math.max(1, line.totalCharacters);
+    const tailFactor = 1 + edgeWidth / Math.max(1, line.bounds.width);
+
+    return baseWeight * tailFactor;
+  });
+  const totalWeight = lineWeights.reduce((sum, weight) => sum + weight, 0);
+  const timedLines = [];
+  let nextStartTime = 0;
+  let totalDuration = 0;
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const weight = lineWeights[lineIndex];
+    const duration =
+      totalWeight > 0
+        ? Math.max(1, (baseDuration * weight) / totalWeight)
+        : baseDuration;
+    const startTime = Math.max(0, nextStartTime);
+    const endTime = startTime + duration;
+
+    timedLines.push({
+      ...lines[lineIndex],
+      startTime,
+      endTime,
+      duration,
+    });
+
+    totalDuration = Math.max(totalDuration, endTime);
+    nextStartTime =
+      endTime - duration * softWipe.lineOverlap + softWipe.lineDelay;
+  }
+
+  return {
+    timedLines,
+    duration: Math.max(1, Math.ceil(totalDuration)),
+  };
+};
+
+const getSoftWipeLineProgress = ({ currentTime, line, easing }) => {
+  const rawProgress =
+    line.duration > 0 ? (currentTime - line.startTime) / line.duration : 1;
+
+  return easing(Math.max(0, Math.min(rawProgress, 1)));
+};
+
 const runSoftWipeReveal = ({
   container,
   contentContainer,
@@ -445,39 +498,19 @@ const runSoftWipeReveal = ({
     return false;
   }
 
-  const edgeWidth = Math.max(
-    MIN_SOFT_WIPE_EDGE,
-    Math.min(
-      MAX_SOFT_WIPE_EDGE,
-      Math.round(maxLineHeight * SOFT_WIPE_EDGE_MULTIPLIER),
-    ),
-  );
-  const duration = Math.max(
+  const softWipe = normalizeSoftWipeConfig(element.softWipe);
+  const easing = getSoftWipeEasing(softWipe.easing);
+  const edgeWidth = getSoftWipeEdgeWidth({ maxLineHeight, softWipe });
+  const baseDuration = Math.max(
     1,
     Math.round((totalCharacters / effectiveSpeed) * 1000),
   );
-  const lineWeights = lines.map((line) => {
-    const baseWeight = Math.max(1, line.totalCharacters);
-    const tailFactor = 1 + edgeWidth / Math.max(1, line.bounds.width);
-
-    return baseWeight * tailFactor;
+  const { timedLines, duration } = createSoftWipeLineTimings({
+    lines,
+    edgeWidth,
+    baseDuration,
+    softWipe,
   });
-  const totalWeight = lineWeights.reduce((sum, weight) => sum + weight, 0);
-  const timedLines = [];
-  let accumulatedWeight = 0;
-
-  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
-    const weight = lineWeights[lineIndex];
-    const start = totalWeight > 0 ? accumulatedWeight / totalWeight : 0;
-
-    accumulatedWeight += weight;
-
-    timedLines.push({
-      ...lines[lineIndex],
-      startProgress: start,
-      endProgress: totalWeight > 0 ? accumulatedWeight / totalWeight : 1,
-    });
-  }
 
   const stateVersion = completionTracker.getVersion();
   const animationId = `${element.id}-soft-wipe`;
@@ -496,7 +529,11 @@ const runSoftWipeReveal = ({
     const texture = getCanvasTexture(canvas);
     const sprite = new Sprite(texture);
 
-    sprite.x = Math.floor(line.bounds.x - edgeWidth);
+    sprite.x = Math.floor(
+      softWipe.direction === "rightToLeft"
+        ? line.bounds.x
+        : line.bounds.x - edgeWidth,
+    );
     sprite.y = Math.floor(line.bounds.y);
     line.container.mask = sprite;
     contentContainer.addChild(sprite);
@@ -591,21 +628,20 @@ const runSoftWipeReveal = ({
       driver: "custom",
       duration,
       applyFrame: (currentTime) => {
-        const progress = duration > 0 ? Math.min(currentTime / duration, 1) : 1;
         let activeLine = timedLines[0];
-        let activeLineProgress = 0;
+        let activeLineLeadingEdgeX =
+          softWipe.direction === "rightToLeft"
+            ? activeLine.bounds.x + activeLine.bounds.width
+            : activeLine.bounds.x;
 
         for (let lineIndex = 0; lineIndex < timedLines.length; lineIndex++) {
           const line = timedLines[lineIndex];
           const lineMask = lineMasks[lineIndex];
-          const lineSpan = Math.max(
-            0.000001,
-            line.endProgress - line.startProgress,
-          );
-          const lineProgress = Math.max(
-            0,
-            Math.min((progress - line.startProgress) / lineSpan, 1),
-          );
+          const lineProgress = getSoftWipeLineProgress({
+            currentTime,
+            line,
+            easing,
+          });
           const { context, canvas, texture } = lineMask;
 
           context.clearRect(0, 0, canvas.width, canvas.height);
@@ -615,59 +651,106 @@ const runSoftWipeReveal = ({
             continue;
           }
 
-          const lineStart = edgeWidth;
           const lineY = 0;
           const lineTravelDistance = line.bounds.width + edgeWidth;
-          const lineLeadingEdge = lineStart + lineProgress * lineTravelDistance;
-          const hardEnd = Math.max(lineStart, lineLeadingEdge - edgeWidth);
+          let leadingEdgeX;
 
-          if (hardEnd > lineStart) {
-            context.fillStyle = "#ffffff";
-            context.fillRect(
+          if (softWipe.direction === "rightToLeft") {
+            const lineStart = 0;
+            const lineEnd = line.bounds.width;
+            const lineLeadingEdge = lineEnd - lineProgress * lineTravelDistance;
+            const hardStart = Math.min(lineEnd, lineLeadingEdge + edgeWidth);
+
+            if (hardStart < lineEnd) {
+              context.fillStyle = "#ffffff";
+              context.fillRect(
+                Math.max(lineStart, hardStart),
+                lineY,
+                lineEnd - Math.max(lineStart, hardStart),
+                line.bounds.height,
+              );
+            }
+
+            const gradientStart = Math.max(lineStart, lineLeadingEdge);
+            const gradientEnd = Math.min(lineEnd, lineLeadingEdge + edgeWidth);
+
+            if (gradientEnd > gradientStart) {
+              const gradient = context.createLinearGradient(
+                gradientStart,
+                0,
+                gradientEnd,
+                0,
+              );
+
+              gradient.addColorStop(0, "rgba(255, 255, 255, 0)");
+              gradient.addColorStop(1, "rgba(255, 255, 255, 1)");
+              context.fillStyle = gradient;
+              context.fillRect(
+                gradientStart,
+                lineY,
+                gradientEnd - gradientStart,
+                line.bounds.height,
+              );
+            }
+
+            leadingEdgeX =
+              line.bounds.x +
+              Math.max(0, Math.min(line.bounds.width, lineLeadingEdge));
+          } else {
+            const lineStart = edgeWidth;
+            const lineLeadingEdge =
+              lineStart + lineProgress * lineTravelDistance;
+            const hardEnd = Math.max(lineStart, lineLeadingEdge - edgeWidth);
+
+            if (hardEnd > lineStart) {
+              context.fillStyle = "#ffffff";
+              context.fillRect(
+                lineStart,
+                lineY,
+                Math.min(hardEnd - lineStart, line.bounds.width),
+                line.bounds.height,
+              );
+            }
+
+            const gradientStart = Math.max(
               lineStart,
-              lineY,
-              Math.min(hardEnd - lineStart, line.bounds.width),
-              line.bounds.height,
+              lineLeadingEdge - edgeWidth,
             );
-          }
-
-          const gradientStart = Math.max(
-            lineStart,
-            lineLeadingEdge - edgeWidth,
-          );
-          const gradientEnd = Math.min(
-            lineStart + line.bounds.width,
-            lineLeadingEdge,
-          );
-
-          if (gradientEnd > gradientStart) {
-            const gradient = context.createLinearGradient(
-              gradientStart,
-              0,
-              gradientEnd,
-              0,
+            const gradientEnd = Math.min(
+              lineStart + line.bounds.width,
+              lineLeadingEdge,
             );
 
-            gradient.addColorStop(0, "rgba(255, 255, 255, 1)");
-            gradient.addColorStop(1, "rgba(255, 255, 255, 0)");
-            context.fillStyle = gradient;
-            context.fillRect(
-              gradientStart,
-              lineY,
-              gradientEnd - gradientStart,
-              line.bounds.height,
-            );
+            if (gradientEnd > gradientStart) {
+              const gradient = context.createLinearGradient(
+                gradientStart,
+                0,
+                gradientEnd,
+                0,
+              );
+
+              gradient.addColorStop(0, "rgba(255, 255, 255, 1)");
+              gradient.addColorStop(1, "rgba(255, 255, 255, 0)");
+              context.fillStyle = gradient;
+              context.fillRect(
+                gradientStart,
+                lineY,
+                gradientEnd - gradientStart,
+                line.bounds.height,
+              );
+            }
+
+            leadingEdgeX =
+              line.bounds.x +
+              Math.min(
+                line.bounds.width,
+                Math.max(0, lineLeadingEdge - lineStart),
+              );
           }
 
           texture.source.update();
-
-          if (lineProgress < 1 || lineIndex === timedLines.length - 1) {
-            activeLine = line;
-            activeLineProgress = Math.min(
-              1,
-              (lineLeadingEdge - lineStart) / Math.max(1, line.bounds.width),
-            );
-          }
+          activeLine = line;
+          activeLineLeadingEdgeX = leadingEdgeX;
         }
 
         positionIndicatorForChunk(
@@ -676,12 +759,9 @@ const runSoftWipeReveal = ({
           indicatorOffset,
         );
         indicatorSprite.x =
-          activeLine.bounds.x +
-          Math.min(
-            activeLine.bounds.width,
-            activeLine.bounds.width * activeLineProgress,
-          ) +
-          indicatorOffset;
+          softWipe.direction === "rightToLeft"
+            ? activeLineLeadingEdgeX - indicatorOffset - indicatorSprite.width
+            : activeLineLeadingEdgeX + indicatorOffset;
       },
       applyTargetState: () => {
         finalize(false);

--- a/src/plugins/elements/text-revealing/updateTextRevealing.js
+++ b/src/plugins/elements/text-revealing/updateTextRevealing.js
@@ -4,11 +4,16 @@ import {
   runTextReveal,
   shouldRenderTextRevealImmediately,
 } from "./textRevealingRuntime.js";
+import { normalizeSoftWipeConfig } from "./softWipeConfig.js";
 
 const getRevealIdentity = (element = {}) =>
   JSON.stringify({
     content: element.content ?? null,
     revealEffect: element.revealEffect ?? "typewriter",
+    softWipe:
+      (element.revealEffect ?? "typewriter") === "softWipe"
+        ? normalizeSoftWipeConfig(element.softWipe)
+        : null,
     speed: element.speed ?? 50,
     width: element.width ?? null,
     indicator: element.indicator ?? null,

--- a/src/schemas/elements/text-revealing.computed.yaml
+++ b/src/schemas/elements/text-revealing.computed.yaml
@@ -44,11 +44,6 @@ $def:
     type: object
     description: Parameters for the softWipe reveal effect.
     properties:
-      direction:
-        type: string
-        enum: [leftToRight,rightToLeft]
-        description: Horizontal direction of the wipe.
-        default: leftToRight
       softness:
         type: number
         minimum: 0

--- a/src/schemas/elements/text-revealing.computed.yaml
+++ b/src/schemas/elements/text-revealing.computed.yaml
@@ -40,6 +40,36 @@ $def:
       strokeWidth:
         type: number
         description: Text stroke/outline width
+  softWipe:
+    type: object
+    description: Parameters for the softWipe reveal effect.
+    properties:
+      direction:
+        type: string
+        enum: [leftToRight,rightToLeft]
+        description: Horizontal direction of the wipe.
+        default: leftToRight
+      softness:
+        type: number
+        minimum: 0
+        description: Multiplier applied to line height to determine the feathered edge width.
+        default: 1.25
+      easing:
+        type: string
+        enum: [linear,easeOutCubic]
+        description: Easing curve applied to each line wipe.
+        default: linear
+      lineOverlap:
+        type: number
+        minimum: 0
+        maximum: 0.95
+        description: Fraction of a line's duration that the next line may overlap.
+        default: 0
+      lineDelay:
+        type: number
+        minimum: 0
+        description: Delay in milliseconds before the next line starts after overlap is applied.
+        default: 0
 required:
   - id
   - type
@@ -158,3 +188,5 @@ properties:
     enum: [typewriter,softWipe,none]
     description: Text animation.
     default: typewriter
+  softWipe:
+    "$ref": "#/$def/softWipe"

--- a/src/schemas/elements/text-revealing.element.yaml
+++ b/src/schemas/elements/text-revealing.element.yaml
@@ -49,11 +49,6 @@ $def:
     type: object
     description: Parameters for the softWipe reveal effect.
     properties:
-      direction:
-        type: string
-        enum: [leftToRight,rightToLeft]
-        description: Horizontal direction of the wipe.
-        default: leftToRight
       softness:
         type: number
         minimum: 0

--- a/src/schemas/elements/text-revealing.element.yaml
+++ b/src/schemas/elements/text-revealing.element.yaml
@@ -45,6 +45,36 @@ $def:
       strokeWidth:
         type: number
         description: Text stroke/outline width
+  softWipe:
+    type: object
+    description: Parameters for the softWipe reveal effect.
+    properties:
+      direction:
+        type: string
+        enum: [leftToRight,rightToLeft]
+        description: Horizontal direction of the wipe.
+        default: leftToRight
+      softness:
+        type: number
+        minimum: 0
+        description: Multiplier applied to line height to determine the feathered edge width.
+        default: 1.25
+      easing:
+        type: string
+        enum: [linear,easeOutCubic]
+        description: Easing curve applied to each line wipe.
+        default: linear
+      lineOverlap:
+        type: number
+        minimum: 0
+        maximum: 0.95
+        description: Fraction of a line's duration that the next line may overlap.
+        default: 0
+      lineDelay:
+        type: number
+        minimum: 0
+        description: Delay in milliseconds before the next line starts after overlap is applied.
+        default: 0
 properties:
   id:
     type: string
@@ -132,6 +162,8 @@ properties:
     enum: [typewriter,softWipe,none]
     description: Text animation.
     default: typewriter
+  softWipe:
+    "$ref": "#/$def/softWipe"
   textStyle:
   complete:
     type: object

--- a/src/types.js
+++ b/src/types.js
@@ -440,6 +440,15 @@
  */
 
 /**
+ * @typedef {Object} SoftWipeConfig
+ * @property {'leftToRight' | 'rightToLeft'} [direction='leftToRight'] - Horizontal direction of the soft wipe
+ * @property {number} [softness=1.25] - Multiplier applied to line height to determine feathered edge width
+ * @property {'linear' | 'easeOutCubic'} [easing='linear'] - Easing curve applied to each line wipe
+ * @property {number} [lineOverlap=0] - Fraction of a line's duration that the next line may overlap
+ * @property {number} [lineDelay=0] - Delay in milliseconds before the next line starts after overlap is applied
+ */
+
+/**
  * @typedef {Object} TextRevealingComputedProps
  * @property {Array<TextChunk>} content - Array of processed text chunks (lines)
  * @property {number} [width] - Width constraint for text wrapping
@@ -457,6 +466,7 @@
  * @property {number} [indicator.complete.width] - Width of the indicator image when complete
  * @property {number} [indicator.complete.height] - Height of the indicator image when complete
  * @property {'typewriter' | 'softWipe' | 'none'} [revealEffect='typewriter'] - Text reveal effect (typewriter = per-character reveal, softWipe = full-text soft mask wipe, none = skip animation)
+ * @property {SoftWipeConfig} [softWipe] - Parameters for the softWipe reveal effect
  * @typedef {ComputedNode & TextRevealingComputedProps} TextRevealingComputedNode
  */
 

--- a/src/types.js
+++ b/src/types.js
@@ -441,7 +441,6 @@
 
 /**
  * @typedef {Object} SoftWipeConfig
- * @property {'leftToRight' | 'rightToLeft'} [direction='leftToRight'] - Horizontal direction of the soft wipe
  * @property {number} [softness=1.25] - Multiplier applied to line height to determine feathered edge width
  * @property {'linear' | 'easeOutCubic'} [easing='linear'] - Easing curve applied to each line wipe
  * @property {number} [lineOverlap=0] - Fraction of a line's duration that the next line may overlap

--- a/vt/reference/textrevealing/text-revealing-soft-wipe-parameters-01.webp
+++ b/vt/reference/textrevealing/text-revealing-soft-wipe-parameters-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e0df513288a063252be6266f416e1e6af09b0fdca30e9bb33f92f76848947da
+size 1874

--- a/vt/reference/textrevealing/text-revealing-soft-wipe-parameters-02.webp
+++ b/vt/reference/textrevealing/text-revealing-soft-wipe-parameters-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e0df513288a063252be6266f416e1e6af09b0fdca30e9bb33f92f76848947da
+size 1874

--- a/vt/reference/textrevealing/text-revealing-soft-wipe-parameters-03.webp
+++ b/vt/reference/textrevealing/text-revealing-soft-wipe-parameters-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a23274d3e48544c612c66ada206114d25b68b66b67efc40bdf3a2df50732c441
+size 4782

--- a/vt/reference/textrevealing/text-revealing-soft-wipe-parameters-04.webp
+++ b/vt/reference/textrevealing/text-revealing-soft-wipe-parameters-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfd0e74efc637564189e3a789a5bf92888295074916815c73ddebe0c42538de5
+size 6414

--- a/vt/specs/textrevealing/text-revealing-soft-wipe-parameters.yaml
+++ b/vt/specs/textrevealing/text-revealing-soft-wipe-parameters.yaml
@@ -1,0 +1,74 @@
+---
+title: Text Revealing - Soft Wipe Parameters
+description: Exercises configurable softWipe direction, softness, easing, line overlap, and line delay.
+specs:
+  - first state should show only the background before reveal starts
+  - softWipe should reveal left-to-right with a broader feathered edge
+  - easeOutCubic should accelerate the leading edge early in the wipe
+  - lineOverlap and lineDelay should produce staggered multi-line reveal timing
+steps:
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 650
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 950
+  - action: screenshot
+---
+states:
+  - id: soft-wipe-parameters-blank
+    elements:
+      - id: soft-wipe-parameters-bg
+        type: rect
+        x: 0
+        "y": 0
+        width: 800
+        height: 360
+        fill: "#111417"
+  - id: soft-wipe-parameters-text
+    elements:
+      - id: soft-wipe-parameters-bg
+        type: rect
+        x: 0
+        "y": 0
+        width: 800
+        height: 360
+        fill: "#111417"
+      - id: soft-wipe-parameters-line
+        type: text-revealing
+        x: 72
+        "y": 76
+        width: 610
+        speed: 24
+        revealEffect: softWipe
+        softWipe:
+          direction: leftToRight
+          softness: 1.85
+          easing: easeOutCubic
+          lineOverlap: 0.35
+          lineDelay: 140
+        content:
+          - text: "A richer soft wipe can feather the reveal,"
+            textStyle:
+              fontSize: 30
+              fill: "#F8FAFC"
+              fontFamily: Arial
+              lineHeight: 1.35
+          - text: " overlap wrapped lines,"
+            textStyle:
+              fontSize: 30
+              fill: "#B8F7D4"
+              fontFamily: Arial
+              lineHeight: 1.35
+          - text: " and carry a subtle highlighted leading edge."
+            textStyle:
+              fontSize: 30
+              fill: "#CBD5E1"
+              fontFamily: Arial
+              lineHeight: 1.35

--- a/vt/specs/textrevealing/text-revealing-soft-wipe-parameters.yaml
+++ b/vt/specs/textrevealing/text-revealing-soft-wipe-parameters.yaml
@@ -1,9 +1,9 @@
 ---
 title: Text Revealing - Soft Wipe Parameters
-description: Exercises configurable softWipe direction, softness, easing, line overlap, and line delay.
+description: Exercises configurable softWipe softness, easing, line overlap, and line delay.
 specs:
   - first state should show only the background before reveal starts
-  - softWipe should reveal left-to-right with a broader feathered edge
+  - softWipe should reveal with a broader feathered edge
   - easeOutCubic should accelerate the leading edge early in the wipe
   - lineOverlap and lineDelay should produce staggered multi-line reveal timing
 steps:
@@ -48,7 +48,6 @@ states:
         speed: 24
         revealEffect: softWipe
         softWipe:
-          direction: leftToRight
           softness: 1.85
           easing: easeOutCubic
           lineOverlap: 0.35


### PR DESCRIPTION
## Summary
- add a normalized `softWipe` config for text-revealing nodes
- support configurable direction, softness, easing, line overlap, and line delay
- preserve legacy default softWipe behavior when no config is provided
- restart reveal playback when softWipe parameters change
- add parser/runtime/update coverage plus a VT spec for the new parameters

## Validation
- `bunx vitest run spec/parser/parseTextRevealing.softWipe.spec.js spec/elements/textRevealingRuntime.softWipe.spec.js spec/elements/updateTextRevealing.spec.js spec/elements/textRevealingRuntime.instant.spec.js spec/elements/textRevealingRuntime.resume.spec.js spec/parser/parseTextRevealing.test.yaml`
- `bun run test`
- `bun run lint`
- `bun run build`
- `bun run vt:screenshot` (136/136 captures succeeded)