### PR TITLE
fix(container): normalize absolute direction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/pages/docs/nodes/container.md
+++ b/playground/pages/docs/nodes/container.md
@@ -27,7 +27,7 @@ Try it in the [Playground](/playground/?template=container-layout).
 | `anchorY`    | number                                   | No                  | `0`                      | For containers, use `0`, `0.5`, or `1`.                             |
 | `alpha`      | number                                   | No                  | `1`                      | Opacity `0..1`.                                                     |
 | `children`   | array                                    | No                  | `[]`                     | Any registered element plugin type can be nested.                   |
-| `direction`  | `absolute` \| `horizontal` \| `vertical` | No                  | `""` (absolute behavior) | Auto-positioning for children in non-absolute modes.                |
+| `direction`  | `absolute` \| `horizontal` \| `vertical` | No                  | `absolute`               | Auto-positioning for children in non-absolute modes.                |
 | `gapX`       | number                                   | No                  | `0`                      | Horizontal spacing between children, and between wrapped columns.   |
 | `gapY`       | number                                   | No                  | `0`                      | Vertical spacing between children, and between wrapped rows.        |
 | `rotation`   | number                                   | No                  | `0`                      | Degrees.                                                            |

--- a/spec/parser/parseContainer.test.yaml
+++ b/spec/parser/parseContainer.test.yaml
@@ -122,7 +122,7 @@ in:
 out:
   id: hover-container
   type: container
-  direction: ""
+  direction: absolute
   gapX: 0
   gapY: 0
   width: 120
@@ -146,6 +146,50 @@ out:
       originX: 0
       originY: 0
       fill: red
+      rotation: 0
+      alpha: 1
+---
+case: Test parsing container with explicit absolute direction
+in:
+  - state:
+      id: absolute-container
+      type: container
+      direction: absolute
+      x: 5
+      "y": 6
+      children:
+        - id: rect-1
+          type: rect
+          x: 12
+          "y": 18
+          width: 40
+          height: 20
+          fill: green
+out:
+  id: absolute-container
+  type: container
+  direction: absolute
+  gapX: 0
+  gapY: 0
+  width: 52
+  height: 38
+  x: 5
+  "y": 6
+  originX: 0
+  originY: 0
+  scroll: false
+  rotation: 0
+  alpha: 1
+  children:
+    - id: rect-1
+      type: rect
+      width: 40
+      height: 20
+      x: 12
+      "y": 18
+      originX: 0
+      originY: 0
+      fill: green
       rotation: 0
       alpha: 1
 ---
@@ -770,7 +814,7 @@ in:
 out:
   id: outer-container
   type: container
-  direction: ""
+  direction: absolute
   alpha: 1
   gapX: 0
   gapY: 0
@@ -785,7 +829,7 @@ out:
   children:
     - id: inner-container
       type: container
-      direction: ""
+      direction: absolute
       height: 100
       width: 100
       x: 250
@@ -1524,7 +1568,7 @@ in:
 out:
   id: inventory
   type: container
-  direction: ""
+  direction: absolute
   gapX: 0
   gapY: 0
   width: 200

--- a/src/plugins/elements/container/parseContainer.js
+++ b/src/plugins/elements/container/parseContainer.js
@@ -18,7 +18,11 @@ import { parseCommonObject } from "../util/parseCommonObject.js";
  * If direction is set and the width/height is set than the container will wrap the element based on the setted width/height
  */
 export const parseContainer = ({ state, parserPlugins = [] }) => {
-  const direction = state.direction ?? "";
+  // Treat missing or legacy empty direction as explicit absolute positioning.
+  const direction =
+    state.direction === "horizontal" || state.direction === "vertical"
+      ? state.direction
+      : "absolute";
   const scroll = state.scroll ? true : false;
   const gapX = state.gapX ?? 0;
   const gapY = state.gapY ?? 0;

--- a/src/schemas/elements/container.computed.yaml
+++ b/src/schemas/elements/container.computed.yaml
@@ -53,8 +53,9 @@ properties:
         - $ref: "./container.computed.yaml"
   direction:
     type: string
-    enum: [horizontal, vertical]
-    description: Layout direction for children
+    enum: [absolute, horizontal, vertical]
+    description: Layout direction for children. Absolute preserves child x/y, horizontal arranges left-to-right, vertical arranges top-to-bottom.
+    default: absolute
   alpha:
     type: number
     description: Opacity/transparency of the container (0-1)

--- a/src/types.js
+++ b/src/types.js
@@ -305,7 +305,7 @@
 /**
  * @typedef {Object} ContainerComputedProps
  * @property {'container'} type
- * @property {'horizontal' | 'vertical'} direction
+ * @property {'absolute' | 'horizontal' | 'vertical'} direction
  * @property {SpriteComputedNode | TextComputedNode | RectComputedNode | ContainerComputedNode} children
  * @property {number} gapX
  * @property {number} gapY


### PR DESCRIPTION
## Summary
- normalize container `direction` so omitted, empty, and explicit `absolute` all resolve to `absolute`
- update computed types/schema/docs to treat `absolute` as a first-class value
- bump the package version from `1.8.2` to `1.8.3`

## Testing
- `npx vitest run spec/parser/parseContainer.test.yaml spec/elements/containerHoverInheritance.spec.js`
- `vitest run` (via pre-push hook)