### PR TITLE
Add persistent animation continuity across renders

### DIFF
--- a/docs/animation-implementation-plan.md
+++ b/docs/animation-implementation-plan.md
@@ -1,6 +1,6 @@
 # Animation Implementation Plan
 
-Last updated: 2026-03-23
+Last updated: 2026-04-23
 
 ## Goal
 
@@ -20,6 +20,7 @@ Current runtime shape:
 
 - public normalization still expects `type: live | replace`
 - live element animation is driven through one central animation bus
+- every changed render cancels all active update animations before planning the next state
 - replace supports add, update, and delete lifecycles through diff planning
 - replace supports `prev` and `next` tween composition with optional `mask`
 - shader-backed replace has been removed for now
@@ -92,6 +93,7 @@ animations:
 Key rules:
 
 - `update` uses `tween`
+- `update` and `transition` support optional `playback.continuity: persistent`
 - `transition` uses `prev`, `next`, and optional `mask`
 - `transition` may define:
   - `prev` only
@@ -188,6 +190,81 @@ Work:
 - keep update-time motion on one live display object
 - use `transition` for enter/exit/swap even when the effect is a simple fade
 - use `update` only for elements that persist across the state change
+
+## Step 5A: Add Persistent Playback Continuity
+
+Goal:
+
+- allow selected `update` and `transition` animations to continue across later
+  renders without adding a third top-level animation type
+
+Specified public interface:
+
+```yaml
+animations:
+  - id: "bg-breathe"
+    targetId: "bg"
+    type: "update"
+    playback:
+      continuity: "persistent"
+    tween:
+      scaleX:
+        keyframes:
+          - duration: 3000
+            value: 1.05
+            easing: "easeInOutSine"
+          - duration: 3000
+            value: 1
+            easing: "easeInOutSine"
+```
+
+Implemented contract:
+
+- `playback` is optional on `update` and `transition`
+- `playback.continuity` currently supports one value:
+  - `persistent`
+- when omitted, `update` keeps current render-scoped behavior
+- when omitted, `transition` keeps current render-scoped behavior
+- when present on `update`, the same animation should continue across later
+  renders if `id`, `targetId`, and normalized config are unchanged
+- when present on `transition`, the same in-flight handoff should continue
+  across later renders if `id`, `targetId`, and normalized `prev` / `next` /
+  `mask` / `playback` config are unchanged
+- if a later render omits the animation, it stops
+- if a later render changes the animation config, it restarts
+- a persistent animation should still count toward the originating render's
+  `renderComplete` if it finishes before continuity carries it into a later
+  render
+- once continuity carries that in-flight animation into a later render, it
+  must be detached from render completion tracking
+- persistent transition continuity keeps the same active handoff alive; it does
+  not retarget the transition mid-flight
+
+Implemented work:
+
+- extend normalization and schema for optional `playback.continuity`
+- reconcile persistent update animations by stable animation `id` instead of
+  cancelling them unconditionally on every changed render
+- reconcile persistent transitions by stable animation `id` and keep the
+  existing overlay / hidden-next handoff alive across unrelated later renders
+- keep render-scoped animations on current reset behavior when continuity is not
+  requested
+- preserve completion for the originating render when a persistent animation
+  finishes before any later render adopts it
+- detach completion tracking when an in-flight persistent animation is adopted
+  by a later render, so its eventual finish no longer emits `renderComplete`
+- keep the restart rules simple: changed config or changed owned target/subtree
+  breaks continuity and starts a new animation instance
+
+Primary runtime files:
+
+- `src/util/normalizeAnimations.js`
+- `src/schemas/animations/animation.yaml`
+- `src/RouteGraphics.js`
+- `src/plugins/animations/animationBus.js`
+- `src/plugins/animations/planAnimations.js`
+- `src/plugins/animations/updateAnimationDispatch.js`
+- `src/util/diffElements.js`
 
 ## Step 6: Keep Mask Transition As The Reveal Primitive
 

--- a/docs/animation-model.md
+++ b/docs/animation-model.md
@@ -1,6 +1,6 @@
 # Animation Model
 
-Last updated: 2026-04-02
+Last updated: 2026-04-23
 
 See also:
 
@@ -24,6 +24,7 @@ The runtime now exposes:
 - required `type: update | transition`
 - `tween` as the motion payload
 - `mask` only inside `transition`
+- optional `playback.continuity: persistent` on `update` and `transition`
 
 Current known runtime limitations are tracked in
 `docs/animation-implementation-plan.md`.
@@ -104,6 +105,7 @@ instead.
 `update` supports:
 
 - `tween`
+- `playback.continuity`
 
 `update` does not support:
 
@@ -135,6 +137,7 @@ Use it for:
 - `prev.tween`
 - `next.tween`
 - `mask`
+- `playback.continuity`
 - future `shader`
 
 `transition` may define:
@@ -219,6 +222,111 @@ animations:
           duration: 600
           easing: "easeOutQuad"
 ```
+
+## Playback Continuity
+
+```yaml
+animations:
+  - id: "bg-breathe"
+    targetId: "bg"
+    type: "update"
+    playback:
+      continuity: "persistent"
+    tween:
+      scaleX:
+        keyframes:
+          - duration: 3000
+            value: 1.05
+            easing: "easeInOutSine"
+          - duration: 3000
+            value: 1
+            easing: "easeInOutSine"
+      scaleY:
+        keyframes:
+          - duration: 3000
+            value: 1.05
+            easing: "easeInOutSine"
+          - duration: 3000
+            value: 1
+            easing: "easeInOutSine"
+```
+
+### Shape
+
+- `playback` is optional
+- `playback` is valid on `type: update` and `type: transition`
+- `playback.continuity` currently supports one value:
+  - `persistent`
+
+### Meaning For `update`
+
+Without `playback.continuity: persistent`, `update` keeps the current
+render-scoped behavior:
+
+- a later changed render may cancel the current update animation
+- if the same animation appears again in that later render, it starts again
+
+With `playback.continuity: persistent`, the runtime lets the same update
+animation continue across later renders instead of restarting, as long as all
+of these remain true:
+
+- the animation `id` is the same
+- the `targetId` is the same
+- the normalized `tween` and `playback` config are the same
+- the target element still exists as the same live display object
+
+### Meaning For `transition`
+
+Without `playback.continuity: persistent`, `transition` keeps the current
+render-scoped behavior:
+
+- a later changed render cancels the in-flight transition
+- if the same transition appears again in that later render, it starts again
+
+With `playback.continuity: persistent`, the runtime lets the same in-flight
+transition continue across later renders instead of restarting, as long as all
+of these remain true:
+
+- the animation `id` is the same
+- the `targetId` is the same
+- the normalized `prev`, `next`, `mask`, and `playback` config are the same
+- the transition still owns the same target subtree handoff
+
+This is continuity of one already-started transition.
+
+It is not a live retargeting model.
+
+That means:
+
+- the runtime does not rebuild the transition's snapshots just because a later unrelated render happened
+- the runtime does not reinterpret the active transition against newly changed target content mid-flight
+
+### Restart And Stop Rules
+
+- if a later render omits that animation, it stops
+- if a later render changes that animation's `tween` or `playback` config, it restarts from the beginning
+- if a later render changes a persistent transition's `prev`, `next`, or `mask` config, it restarts from the beginning
+- if the target element or target subtree is deleted, replaced, or otherwise no longer matches the active handoff, it stops or restarts
+
+### Transition Ownership Rule
+
+Persistent transition continuity follows the same subtree ownership rule as
+normal `transition`:
+
+- the active transition continues to own the target subtree surface while it is running
+- later unrelated renders may proceed around that target
+- later renders that need to change that same target must cancel or restart the transition rather than mutate it in place
+
+### Render Completion Rule
+
+Persistent continuity should not keep the current render open forever.
+
+So the contract is:
+
+- a persistent animation still starts as tracked work for the render that started it
+- if that animation finishes before any later render carries it forward, it completes normally and contributes to that render's `renderComplete`
+- if a later render reuses that in-flight animation through `playback.continuity: persistent`, that animation stops contributing to render completion from that point onward
+- after continuity has carried it into a later render, its eventual finish must not trigger `renderComplete` for either the old render or the newer render
 
 ## Transition Examples
 
@@ -361,7 +469,9 @@ It should live next to `mask`, not on `update`.
 ## Validation Rules
 
 - `update` requires `tween`
+- `update` may optionally define `playback.continuity: persistent`
 - `update` cannot define `prev`, `next`, or `mask`
+- `transition` may optionally define `playback.continuity: persistent`
 - `transition` requires at least one of:
   - `prev`
   - `next`
@@ -374,6 +484,7 @@ It should live next to `mask`, not on `update`.
 - keep `animations` as the top-level field
 - use required `type: update | transition`
 - use `tween` instead of generic `properties`
+- allow optional `playback.continuity: persistent`
 - let `transition` define `prev` and/or `next`
 - keep `mask` as a transition-only primitive
 - keep future `shader` transition-only as well

--- a/docs/animation-model.md
+++ b/docs/animation-model.md
@@ -24,7 +24,7 @@ The runtime now exposes:
 - required `type: update | transition`
 - `tween` as the motion payload
 - `mask` only inside `transition`
-- optional `playback.continuity: persistent` on `update` and `transition`
+- optional `playback.continuity: render | persistent` on `update` and `transition`
 
 Current known runtime limitations are tracked in
 `docs/animation-implementation-plan.md`.
@@ -255,12 +255,15 @@ animations:
 
 - `playback` is optional
 - `playback` is valid on `type: update` and `type: transition`
-- `playback.continuity` currently supports one value:
+- `playback.continuity` currently supports two values:
+  - `render`
   - `persistent`
+- `render` is explicit render-scoped behavior and is equivalent to omitting
+  `playback`
 
 ### Meaning For `update`
 
-Without `playback.continuity: persistent`, `update` keeps the current
+Without `playback`, or with `playback.continuity: render`, `update` keeps the current
 render-scoped behavior:
 
 - a later changed render may cancel the current update animation
@@ -277,7 +280,7 @@ of these remain true:
 
 ### Meaning For `transition`
 
-Without `playback.continuity: persistent`, `transition` keeps the current
+Without `playback`, or with `playback.continuity: render`, `transition` keeps the current
 render-scoped behavior:
 
 - a later changed render cancels the in-flight transition
@@ -469,9 +472,9 @@ It should live next to `mask`, not on `update`.
 ## Validation Rules
 
 - `update` requires `tween`
-- `update` may optionally define `playback.continuity: persistent`
+- `update` may optionally define `playback.continuity: render | persistent`
 - `update` cannot define `prev`, `next`, or `mask`
-- `transition` may optionally define `playback.continuity: persistent`
+- `transition` may optionally define `playback.continuity: render | persistent`
 - `transition` requires at least one of:
   - `prev`
   - `next`
@@ -484,7 +487,7 @@ It should live next to `mask`, not on `update`.
 - keep `animations` as the top-level field
 - use required `type: update | transition`
 - use `tween` instead of generic `properties`
-- allow optional `playback.continuity: persistent`
+- allow optional `playback.continuity: render | persistent`
 - let `transition` define `prev` and/or `next`
 - keep `mask` as a transition-only primitive
 - keep future `shader` transition-only as well

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/pages/docs/nodes/tween.md
+++ b/playground/pages/docs/nodes/tween.md
@@ -9,8 +9,8 @@ sidebarId: node-tween
 
 Try it in the [Playground](/playground/?template=animations-showcase).
 
-`playback.continuity: persistent` enables cross-render continuity on `update`
-and `transition`.
+`playback.continuity` controls whether an animation is render-scoped or can
+continue across later renders on `update` and `transition`.
 
 ## Used In
 
@@ -18,17 +18,17 @@ and `transition`.
 
 ## Field Reference
 
-| Field      | Type   | Required   | Default | Notes                                                                 |
-| ---------- | ------ | ---------- | ------- | --------------------------------------------------------------------- |
-| `id`       | string | Yes        | -       | Animation id.                                                         |
-| `targetId` | string | Yes        | -       | Must match an element id in the same render state.                    |
-| `type`     | string | Yes        | -       | One of `update` or `transition`.                                      |
-| `tween`    | object | Update     | -       | Required for `type: update`.                                          |
+| Field      | Type   | Required   | Default | Notes                                                                    |
+| ---------- | ------ | ---------- | ------- | ------------------------------------------------------------------------ |
+| `id`       | string | Yes        | -       | Animation id.                                                            |
+| `targetId` | string | Yes        | -       | Must match an element id in the same render state.                       |
+| `type`     | string | Yes        | -       | One of `update` or `transition`.                                         |
+| `tween`    | object | Update     | -       | Required for `type: update`.                                             |
 | `playback` | object | No         | -       | Optional cross-render continuity contract for `update` and `transition`. |
-| `prev`     | object | Transition | -       | Optional for `type: transition`; drives the previous captured visual. |
-| `next`     | object | Transition | -       | Optional for `type: transition`; drives the next captured visual.     |
-| `mask`     | object | Transition | -       | Optional for `type: transition`; image-driven reveal field.           |
-| `complete` | object | No         | -       | Schema supports it, runtime completion is still tracked globally.     |
+| `prev`     | object | Transition | -       | Optional for `type: transition`; drives the previous captured visual.    |
+| `next`     | object | Transition | -       | Optional for `type: transition`; drives the next captured visual.        |
+| `mask`     | object | Transition | -       | Optional for `type: transition`; image-driven reveal field.              |
+| `complete` | object | No         | -       | Schema supports it, runtime completion is still tracked globally.        |
 
 ## Types
 
@@ -94,7 +94,8 @@ playback:
 Rules:
 
 - `playback` is valid on `type: update` and `type: transition`
-- `continuity` currently supports one value: `persistent`
+- `continuity` supports two values: `render` and `persistent`
+- `render` is explicit render-scoped behavior and is equivalent to omitting `playback`
 - when omitted, `update` and `transition` keep current render-scoped behavior
 - on `update`, the same animation should continue across later renders instead of restarting, as long as `id`, `targetId`, and normalized config stay the same
 - on `transition`, the same in-flight prev/next handoff should continue across later renders instead of restarting, as long as `id`, `targetId`, and normalized `prev`/`next`/`mask`/`playback` config stay the same
@@ -147,6 +148,7 @@ Supported mask channels:
 ## Behavior Notes
 
 - Update animations are driven by the central animation bus.
+- `playback.continuity: render` keeps the default render-scoped behavior and is equivalent to omitting `playback`.
 - `playback.continuity: persistent` keeps qualifying `update` and `transition` animations alive across later renders instead of restarting them.
 - `transition` animations snapshot the previous and next visuals for the same `targetId`.
 - `transition` may define `prev` only, `next` only, or both.

--- a/playground/pages/docs/nodes/tween.md
+++ b/playground/pages/docs/nodes/tween.md
@@ -9,6 +9,9 @@ sidebarId: node-tween
 
 Try it in the [Playground](/playground/?template=animations-showcase).
 
+`playback.continuity: persistent` enables cross-render continuity on `update`
+and `transition`.
+
 ## Used In
 
 - `animations[]`
@@ -21,6 +24,7 @@ Try it in the [Playground](/playground/?template=animations-showcase).
 | `targetId` | string | Yes        | -       | Must match an element id in the same render state.                    |
 | `type`     | string | Yes        | -       | One of `update` or `transition`.                                      |
 | `tween`    | object | Update     | -       | Required for `type: update`.                                          |
+| `playback` | object | No         | -       | Optional cross-render continuity contract for `update` and `transition`. |
 | `prev`     | object | Transition | -       | Optional for `type: transition`; drives the previous captured visual. |
 | `next`     | object | Transition | -       | Optional for `type: transition`; drives the next captured visual.     |
 | `mask`     | object | Transition | -       | Optional for `type: transition`; image-driven reveal field.           |
@@ -78,6 +82,25 @@ Each keyframe accepts:
 `update` is update-only. Do not use it for enter, exit, or replace lifecycles.
 Higher-level adapters should reject that and require `transition` instead.
 
+## Playback Continuity
+
+Specified interface:
+
+```yaml
+playback:
+  continuity: persistent
+```
+
+Rules:
+
+- `playback` is valid on `type: update` and `type: transition`
+- `continuity` currently supports one value: `persistent`
+- when omitted, `update` and `transition` keep current render-scoped behavior
+- on `update`, the same animation should continue across later renders instead of restarting, as long as `id`, `targetId`, and normalized config stay the same
+- on `transition`, the same in-flight prev/next handoff should continue across later renders instead of restarting, as long as `id`, `targetId`, and normalized `prev`/`next`/`mask`/`playback` config stay the same
+- if a later render omits the animation, or changes its config, it stops or restarts
+- persistent `transition` continuity keeps the same active handoff alive; it does not retarget the transition mid-flight
+
 ## Transition Prev/Next
 
 `transition` animations can drive `prev` and `next` separately.
@@ -124,10 +147,13 @@ Supported mask channels:
 ## Behavior Notes
 
 - Update animations are driven by the central animation bus.
+- `playback.continuity: persistent` keeps qualifying `update` and `transition` animations alive across later renders instead of restarting them.
 - `transition` animations snapshot the previous and next visuals for the same `targetId`.
 - `transition` may define `prev` only, `next` only, or both.
 - Missing `prev` or `next` is treated as transparent.
 - On render interruption, pending animations are canceled and the current render is marked aborted through `renderComplete`.
+- A persistent animation still contributes to `renderComplete` for the render that started it if it finishes before continuity carries it into a later render.
+- Once continuity carries that in-flight animation into a later render, it stops contributing to `renderComplete`, and its eventual finish should not fire `renderComplete` for either render.
 - Per-animation callbacks are not exposed through `eventHandler`; use the global `renderComplete` event to know when tracked animations and reveals settle.
 
 ## Example: Enter Fade
@@ -188,6 +214,53 @@ animations:
         auto:
           duration: 450
           easing: easeOutQuad
+```
+
+## Example: Planned Persistent Update
+
+```yaml
+animations:
+  - id: bg-breathe
+    targetId: bg
+    type: update
+    playback:
+      continuity: persistent
+    tween:
+      scaleX:
+        keyframes:
+          - value: 1.05
+            duration: 3000
+            easing: easeInOutSine
+          - value: 1
+            duration: 3000
+            easing: easeInOutSine
+      scaleY:
+        keyframes:
+          - value: 1.05
+            duration: 3000
+            easing: easeInOutSine
+          - value: 1
+            duration: 3000
+            easing: easeInOutSine
+```
+
+## Example: Planned Persistent Transition
+
+```yaml
+animations:
+  - id: bg-fade-in
+    targetId: bg
+    type: transition
+    playback:
+      continuity: persistent
+    next:
+      tween:
+        alpha:
+          initialValue: 0
+          keyframes:
+            - value: 1
+              duration: 900
+              easing: linear
 ```
 
 ## Example: Relative Keyframes

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -48,6 +48,10 @@ const createPixiModuleMock = () => {
     on() {
       return this;
     }
+
+    removeAllListeners() {
+      return this;
+    }
   }
 
   class MockGraphics extends MockDisplayObject {
@@ -270,6 +274,19 @@ const setupRouteGraphics = async ({
   return { app, pixiMock };
 };
 
+const getAutoAnimationTick = (pixiMock) =>
+  pixiMock.__getLastApplication().ticker.add.mock.calls.at(-1)?.[0];
+
+const findTransitionOverlay = (pixiMock) =>
+  pixiMock
+    .__getLastApplication()
+    .stage.children.find(
+      (child) =>
+        (child.label === null || child.label === undefined) &&
+        Array.isArray(child.children) &&
+        child.children.length > 0,
+    ) ?? null;
+
 describe("RouteGraphics public API", () => {
   afterEach(() => {
     currentApp?.destroy();
@@ -359,6 +376,738 @@ describe("RouteGraphics public API", () => {
     app.setAnimationTime(150);
 
     expect(app.findElementByLabel("preview-rect")?.x).toBeCloseTo(37.5);
+  });
+
+  it("continues persistent update animations across unrelated renders without restarting", async () => {
+    const { app, pixiMock } = await setupRouteGraphics({
+      pluginsFactory: async () => {
+        const [{ rectPlugin }, { tweenPlugin }] = await Promise.all([
+          import("../src/plugins/elements/rect/index.js"),
+          import("../src/plugins/animations/tween/index.js"),
+        ]);
+
+        return {
+          elements: [rectPlugin],
+          animations: [tweenPlugin],
+          audio: [],
+        };
+      },
+    });
+
+    const frameTick = getAutoAnimationTick(pixiMock);
+
+    app.render({
+      id: "baseline",
+      elements: [
+        {
+          id: "bg",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+        {
+          id: "front",
+          type: "rect",
+          x: 120,
+          y: 0,
+          width: 40,
+          height: 40,
+          fill: "#999999",
+        },
+      ],
+    });
+
+    app.render({
+      id: "persistent-update-1",
+      elements: [
+        {
+          id: "bg",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+        {
+          id: "front",
+          type: "rect",
+          x: 120,
+          y: 0,
+          width: 40,
+          height: 40,
+          fill: "#999999",
+        },
+      ],
+      animations: [
+        {
+          id: "bg-breathe",
+          targetId: "bg",
+          type: "update",
+          playback: {
+            continuity: "persistent",
+          },
+          tween: {
+            scaleX: {
+              initialValue: 1,
+              keyframes: [{ duration: 1000, value: 2, easing: "linear" }],
+            },
+            scaleY: {
+              initialValue: 1,
+              keyframes: [{ duration: 1000, value: 2, easing: "linear" }],
+            },
+          },
+        },
+      ],
+    });
+
+    frameTick({ deltaMS: 400 });
+    expect(app.findElementByLabel("bg")?.scale.x).toBeCloseTo(1.4);
+    expect(app.findElementByLabel("bg")?.scale.y).toBeCloseTo(1.4);
+
+    app.render({
+      id: "persistent-update-2",
+      elements: [
+        {
+          id: "bg",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+        {
+          id: "front",
+          type: "rect",
+          x: 180,
+          y: 0,
+          width: 40,
+          height: 40,
+          fill: "#999999",
+        },
+      ],
+      animations: [
+        {
+          id: "bg-breathe",
+          targetId: "bg",
+          type: "update",
+          playback: {
+            continuity: "persistent",
+          },
+          tween: {
+            scaleX: {
+              initialValue: 1,
+              keyframes: [{ duration: 1000, value: 2, easing: "linear" }],
+            },
+            scaleY: {
+              initialValue: 1,
+              keyframes: [{ duration: 1000, value: 2, easing: "linear" }],
+            },
+          },
+        },
+      ],
+    });
+
+    expect(app.findElementByLabel("bg")?.scale.x).toBeCloseTo(1.4);
+    expect(app.findElementByLabel("bg")?.scale.y).toBeCloseTo(1.4);
+
+    frameTick({ deltaMS: 100 });
+    expect(app.findElementByLabel("bg")?.scale.x).toBeCloseTo(1.5);
+    expect(app.findElementByLabel("bg")?.scale.y).toBeCloseTo(1.5);
+  });
+
+  it("still completes the originating render when a persistent update finishes before any later render adopts it", async () => {
+    const eventHandler = vi.fn();
+    const { app, pixiMock } = await setupRouteGraphics({
+      initOptions: {
+        eventHandler,
+      },
+      pluginsFactory: async () => {
+        const [{ rectPlugin }, { tweenPlugin }] = await Promise.all([
+          import("../src/plugins/elements/rect/index.js"),
+          import("../src/plugins/animations/tween/index.js"),
+        ]);
+
+        return {
+          elements: [rectPlugin],
+          animations: [tweenPlugin],
+          audio: [],
+        };
+      },
+    });
+
+    const frameTick = getAutoAnimationTick(pixiMock);
+
+    app.render({
+      id: "baseline",
+      elements: [
+        {
+          id: "bg",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+      ],
+    });
+
+    eventHandler.mockClear();
+
+    app.render({
+      id: "persistent-update-finish",
+      elements: [
+        {
+          id: "bg",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+      ],
+      animations: [
+        {
+          id: "bg-breathe",
+          targetId: "bg",
+          type: "update",
+          playback: {
+            continuity: "persistent",
+          },
+          tween: {
+            alpha: {
+              initialValue: 0,
+              keyframes: [{ duration: 300, value: 1, easing: "linear" }],
+            },
+          },
+        },
+      ],
+    });
+
+    expect(eventHandler).not.toHaveBeenCalledWith("renderComplete", {
+      id: "persistent-update-finish",
+      aborted: false,
+    });
+
+    frameTick({ deltaMS: 300 });
+
+    expect(eventHandler).toHaveBeenCalledWith("renderComplete", {
+      id: "persistent-update-finish",
+      aborted: false,
+    });
+  });
+
+  it("detaches persistent updates from renderComplete after a later render adopts them", async () => {
+    const eventHandler = vi.fn();
+    const { app, pixiMock } = await setupRouteGraphics({
+      initOptions: {
+        eventHandler,
+      },
+      pluginsFactory: async () => {
+        const [{ rectPlugin }, { tweenPlugin }] = await Promise.all([
+          import("../src/plugins/elements/rect/index.js"),
+          import("../src/plugins/animations/tween/index.js"),
+        ]);
+
+        return {
+          elements: [rectPlugin],
+          animations: [tweenPlugin],
+          audio: [],
+        };
+      },
+    });
+
+    const frameTick = getAutoAnimationTick(pixiMock);
+
+    app.render({
+      id: "baseline",
+      elements: [
+        {
+          id: "bg",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+        {
+          id: "front",
+          type: "rect",
+          x: 120,
+          y: 0,
+          width: 40,
+          height: 40,
+          fill: "#999999",
+        },
+      ],
+    });
+
+    eventHandler.mockClear();
+
+    app.render({
+      id: "persistent-update-old",
+      elements: [
+        {
+          id: "bg",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+        {
+          id: "front",
+          type: "rect",
+          x: 120,
+          y: 0,
+          width: 40,
+          height: 40,
+          fill: "#999999",
+        },
+      ],
+      animations: [
+        {
+          id: "bg-breathe",
+          targetId: "bg",
+          type: "update",
+          playback: {
+            continuity: "persistent",
+          },
+          tween: {
+            alpha: {
+              initialValue: 0,
+              keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+            },
+          },
+        },
+      ],
+    });
+
+    frameTick({ deltaMS: 400 });
+    eventHandler.mockClear();
+
+    app.render({
+      id: "persistent-update-new",
+      elements: [
+        {
+          id: "bg",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+        {
+          id: "front",
+          type: "rect",
+          x: 180,
+          y: 0,
+          width: 40,
+          height: 40,
+          fill: "#999999",
+        },
+      ],
+      animations: [
+        {
+          id: "bg-breathe",
+          targetId: "bg",
+          type: "update",
+          playback: {
+            continuity: "persistent",
+          },
+          tween: {
+            alpha: {
+              initialValue: 0,
+              keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+            },
+          },
+        },
+      ],
+    });
+
+    expect(eventHandler).toHaveBeenCalledWith("renderComplete", {
+      id: "persistent-update-old",
+      aborted: true,
+    });
+    expect(eventHandler).toHaveBeenCalledWith("renderComplete", {
+      id: "persistent-update-new",
+      aborted: false,
+    });
+
+    const eventCountAfterAdoption = eventHandler.mock.calls.length;
+    frameTick({ deltaMS: 600 });
+
+    expect(eventHandler.mock.calls).toHaveLength(eventCountAfterAdoption);
+    expect(eventHandler).not.toHaveBeenCalledWith("renderComplete", {
+      id: "persistent-update-old",
+      aborted: false,
+    });
+  });
+
+  it("continues persistent transition overlays across unrelated renders without restarting", async () => {
+    const { app, pixiMock } = await setupRouteGraphics({
+      pluginsFactory: async () => {
+        const [{ rectPlugin }, { tweenPlugin }] = await Promise.all([
+          import("../src/plugins/elements/rect/index.js"),
+          import("../src/plugins/animations/tween/index.js"),
+        ]);
+
+        return {
+          elements: [rectPlugin],
+          animations: [tweenPlugin],
+          audio: [],
+        };
+      },
+    });
+
+    const frameTick = getAutoAnimationTick(pixiMock);
+
+    app.render({
+      id: "baseline",
+      elements: [
+        {
+          id: "front",
+          type: "rect",
+          x: 120,
+          y: 0,
+          width: 40,
+          height: 40,
+          fill: "#999999",
+        },
+      ],
+    });
+
+    app.render({
+      id: "persistent-transition-1",
+      elements: [
+        {
+          id: "scene",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+        {
+          id: "front",
+          type: "rect",
+          x: 120,
+          y: 0,
+          width: 40,
+          height: 40,
+          fill: "#999999",
+        },
+      ],
+      animations: [
+        {
+          id: "scene-fade",
+          targetId: "scene",
+          type: "transition",
+          playback: {
+            continuity: "persistent",
+          },
+          next: {
+            tween: {
+              alpha: {
+                initialValue: 0,
+                keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    frameTick({ deltaMS: 400 });
+    let overlay = findTransitionOverlay(pixiMock);
+    expect(overlay?.children).toHaveLength(1);
+    expect(overlay?.children[0].alpha).toBeCloseTo(0.4);
+
+    app.render({
+      id: "persistent-transition-2",
+      elements: [
+        {
+          id: "scene",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+        {
+          id: "front",
+          type: "rect",
+          x: 180,
+          y: 0,
+          width: 40,
+          height: 40,
+          fill: "#999999",
+        },
+      ],
+      animations: [
+        {
+          id: "scene-fade",
+          targetId: "scene",
+          type: "transition",
+          playback: {
+            continuity: "persistent",
+          },
+          next: {
+            tween: {
+              alpha: {
+                initialValue: 0,
+                keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    overlay = findTransitionOverlay(pixiMock);
+    expect(overlay?.children[0].alpha).toBeCloseTo(0.4);
+
+    frameTick({ deltaMS: 100 });
+    overlay = findTransitionOverlay(pixiMock);
+    expect(overlay?.children[0].alpha).toBeCloseTo(0.5);
+  });
+
+  it("detaches persistent transitions from renderComplete after a later render adopts them", async () => {
+    const eventHandler = vi.fn();
+    const { app, pixiMock } = await setupRouteGraphics({
+      initOptions: {
+        eventHandler,
+      },
+      pluginsFactory: async () => {
+        const [{ rectPlugin }, { tweenPlugin }] = await Promise.all([
+          import("../src/plugins/elements/rect/index.js"),
+          import("../src/plugins/animations/tween/index.js"),
+        ]);
+
+        return {
+          elements: [rectPlugin],
+          animations: [tweenPlugin],
+          audio: [],
+        };
+      },
+    });
+
+    const frameTick = getAutoAnimationTick(pixiMock);
+
+    app.render({
+      id: "baseline",
+      elements: [],
+    });
+
+    eventHandler.mockClear();
+
+    app.render({
+      id: "persistent-transition-old",
+      elements: [
+        {
+          id: "scene",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+      ],
+      animations: [
+        {
+          id: "scene-fade",
+          targetId: "scene",
+          type: "transition",
+          playback: {
+            continuity: "persistent",
+          },
+          next: {
+            tween: {
+              alpha: {
+                initialValue: 0,
+                keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    frameTick({ deltaMS: 400 });
+    eventHandler.mockClear();
+
+    app.render({
+      id: "persistent-transition-new",
+      elements: [
+        {
+          id: "scene",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+      ],
+      animations: [
+        {
+          id: "scene-fade",
+          targetId: "scene",
+          type: "transition",
+          playback: {
+            continuity: "persistent",
+          },
+          next: {
+            tween: {
+              alpha: {
+                initialValue: 0,
+                keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(eventHandler).toHaveBeenCalledWith("renderComplete", {
+      id: "persistent-transition-old",
+      aborted: true,
+    });
+    expect(eventHandler).toHaveBeenCalledWith("renderComplete", {
+      id: "persistent-transition-new",
+      aborted: false,
+    });
+
+    const eventCountAfterAdoption = eventHandler.mock.calls.length;
+    frameTick({ deltaMS: 600 });
+
+    expect(eventHandler.mock.calls).toHaveLength(eventCountAfterAdoption);
+    expect(eventHandler).not.toHaveBeenCalledWith("renderComplete", {
+      id: "persistent-transition-old",
+      aborted: false,
+    });
+  });
+
+  it("preserves pending persistent transitions across later renders before async mount resolves", async () => {
+    let resolveAdd;
+    const addPromise = new Promise((resolve) => {
+      resolveAdd = resolve;
+    });
+
+    const { app, pixiMock } = await setupRouteGraphics({
+      pluginsFactory: async ({ pixiMock: activePixiMock }) => {
+        const asyncNodePlugin = {
+          type: "async-node",
+          parse: ({ state }) => state,
+          add: vi.fn(({ parent, element, signal }) =>
+            addPromise.then(() => {
+              if (signal?.aborted || parent.destroyed) {
+                return;
+              }
+
+              const container = new activePixiMock.Container();
+              container.label = element.id;
+              parent.addChild(container);
+            }),
+          ),
+          update: vi.fn(),
+          delete: vi.fn(),
+        };
+
+        return {
+          elements: [asyncNodePlugin],
+          animations: [],
+          audio: [],
+        };
+      },
+    });
+
+    const frameTick = getAutoAnimationTick(pixiMock);
+
+    app.render({
+      id: "persistent-async-old",
+      elements: [
+        {
+          id: "delayed-scene",
+          type: "async-node",
+        },
+      ],
+      animations: [
+        {
+          id: "scene-enter",
+          targetId: "delayed-scene",
+          type: "transition",
+          playback: {
+            continuity: "persistent",
+          },
+          next: {
+            tween: {
+              alpha: {
+                initialValue: 0,
+                keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    app.render({
+      id: "persistent-async-new",
+      elements: [
+        {
+          id: "delayed-scene",
+          type: "async-node",
+        },
+      ],
+      animations: [
+        {
+          id: "scene-enter",
+          targetId: "delayed-scene",
+          type: "transition",
+          playback: {
+            continuity: "persistent",
+          },
+          next: {
+            tween: {
+              alpha: {
+                initialValue: 0,
+                keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    resolveAdd();
+    await addPromise;
+
+    await vi.waitFor(() => {
+      const mounted = app.findElementByLabel("delayed-scene");
+      const overlay = findTransitionOverlay(pixiMock);
+
+      expect(mounted).not.toBeNull();
+      expect(mounted?.visible).toBe(false);
+      expect(overlay).not.toBeNull();
+    });
+
+    frameTick({ deltaMS: 200 });
+
+    const overlay = findTransitionOverlay(pixiMock);
+    expect(overlay?.children[0].alpha).toBeCloseTo(0.2);
   });
 
   it("applies remembered manual time to transitions that start asynchronously", async () => {

--- a/spec/animations/animationBus.spec.js
+++ b/spec/animations/animationBus.spec.js
@@ -280,4 +280,114 @@ describe("animationBus auto tween shorthand", () => {
     expect(onCancel).not.toHaveBeenCalled();
     expect(animationBus.getState().activeCount).toBe(0);
   });
+
+  it("keeps explicitly preserved persistent animations active across selective cancellation", () => {
+    const animationBus = createAnimationBus();
+    const onCancel = vi.fn();
+    const element = {
+      x: 10,
+      scale: { x: 1, y: 1 },
+    };
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "persistent-update",
+        animationType: "update",
+        targetId: "bg",
+        continuity: "persistent",
+        signature: '{"type":"update"}',
+        element,
+        properties: {
+          x: {
+            keyframes: [{ duration: 1000, value: 110, easing: "linear" }],
+          },
+        },
+        onCancel,
+      },
+    });
+
+    animationBus.flush();
+    animationBus.tick(300);
+    expect(element.x).toBeCloseTo(40);
+
+    animationBus.cancelAllExcept(new Set(["persistent-update"]));
+    animationBus.tick(100);
+
+    expect(element.x).toBeCloseTo(50);
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(animationBus.isAnimating("persistent-update")).toBe(true);
+  });
+
+  it("exposes pending persistent contexts for continuity planning and cancels unkept ones", () => {
+    const animationBus = createAnimationBus();
+    const onCancel = vi.fn();
+
+    animationBus.registerPending({
+      id: "pending-transition",
+      animationType: "transition",
+      targetId: "scene-root",
+      continuity: "persistent",
+      signature: '{"type":"transition"}',
+      onCancel,
+    });
+
+    expect(animationBus.hasContext("pending-transition")).toBe(true);
+    expect(animationBus.getContinuableAnimations()).toEqual(
+      new Map([
+        [
+          "pending-transition",
+          {
+            id: "pending-transition",
+            type: "transition",
+            targetId: "scene-root",
+            signature: '{"type":"transition"}',
+            continuity: "persistent",
+            pending: true,
+          },
+        ],
+      ]),
+    );
+
+    animationBus.cancelAllExcept(new Set());
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(animationBus.hasContext("pending-transition")).toBe(false);
+  });
+
+  it("updates continuation metadata for active and pending contexts", () => {
+    const animationBus = createAnimationBus();
+    const activeUpdate = vi.fn();
+    const pendingUpdate = vi.fn();
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "active-transition",
+        driver: "custom",
+        animationType: "transition",
+        targetId: "scene-root",
+        continuity: "persistent",
+        signature: '{"type":"transition"}',
+        duration: 500,
+        onContinuationUpdate: activeUpdate,
+      },
+    });
+    animationBus.flush();
+
+    animationBus.registerPending({
+      id: "pending-transition",
+      animationType: "transition",
+      targetId: "scene-root",
+      continuity: "persistent",
+      signature: '{"type":"transition"}',
+      onContinuationUpdate: pendingUpdate,
+    });
+
+    animationBus.updateContinuation("active-transition", { zIndex: 7 });
+    animationBus.updateContinuation("pending-transition", { zIndex: 3 });
+
+    expect(activeUpdate).toHaveBeenCalledWith({ zIndex: 7 });
+    expect(pendingUpdate).toHaveBeenCalledWith({ zIndex: 3 });
+  });
 });

--- a/spec/animations/planAnimations.spec.js
+++ b/spec/animations/planAnimations.spec.js
@@ -1,12 +1,177 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildAnimationContinuityPlan,
   dispatchUpdateAnimations,
+  getAnimationContinuitySignature,
   groupAnimationsByTarget,
 } from "../../src/plugins/animations/planAnimations.js";
 import {
   createRenderContext,
   flushDeferredMountOperations,
 } from "../../src/plugins/elements/renderContext.js";
+
+describe("buildAnimationContinuityPlan", () => {
+  it("continues a persistent update when the target is unchanged", () => {
+    const animation = {
+      id: "bg-breathe",
+      targetId: "bg",
+      type: "update",
+      playback: { continuity: "persistent" },
+      tween: {
+        scaleX: {
+          keyframes: [{ duration: 1000, value: 1.2, easing: "linear" }],
+        },
+      },
+    };
+
+    const plan = buildAnimationContinuityPlan({
+      prevState: {
+        elements: [{ id: "bg", type: "rect", x: 0, y: 0, width: 10, height: 10 }],
+      },
+      nextState: {
+        elements: [{ id: "bg", type: "rect", x: 0, y: 0, width: 10, height: 10 }],
+        animations: [animation],
+      },
+      activeAnimations: new Map([
+        [
+          "bg-breathe",
+          {
+            id: "bg-breathe",
+            type: "update",
+            targetId: "bg",
+            signature: getAnimationContinuitySignature(animation),
+            continuity: "persistent",
+          },
+        ],
+      ]),
+    });
+
+    expect(plan.continuedAnimationIds).toEqual(new Set(["bg-breathe"]));
+  });
+
+  it("does not continue a persistent update when the target changed", () => {
+    const animation = {
+      id: "bg-breathe",
+      targetId: "bg",
+      type: "update",
+      playback: { continuity: "persistent" },
+      tween: {
+        scaleX: {
+          keyframes: [{ duration: 1000, value: 1.2, easing: "linear" }],
+        },
+      },
+    };
+
+    const plan = buildAnimationContinuityPlan({
+      prevState: {
+        elements: [{ id: "bg", type: "rect", x: 0, y: 0, width: 10, height: 10 }],
+      },
+      nextState: {
+        elements: [{ id: "bg", type: "rect", x: 5, y: 0, width: 10, height: 10 }],
+        animations: [animation],
+      },
+      activeAnimations: new Map([
+        [
+          "bg-breathe",
+          {
+            id: "bg-breathe",
+            type: "update",
+            targetId: "bg",
+            signature: getAnimationContinuitySignature(animation),
+            continuity: "persistent",
+          },
+        ],
+      ]),
+    });
+
+    expect(plan.continuedAnimationIds).toEqual(new Set());
+  });
+
+  it("continues a persistent transition when the target subtree is unchanged", () => {
+    const animation = {
+      id: "scene-fade",
+      targetId: "scene-root",
+      type: "transition",
+      playback: { continuity: "persistent" },
+      next: {
+        tween: {
+          alpha: {
+            keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+          },
+        },
+      },
+    };
+
+    const sceneNode = {
+      id: "scene-root",
+      type: "container",
+      children: [{ id: "bg", type: "rect", x: 0, y: 0, width: 10, height: 10 }],
+    };
+    const plan = buildAnimationContinuityPlan({
+      prevState: {
+        elements: [sceneNode],
+      },
+      nextState: {
+        elements: [sceneNode],
+        animations: [animation],
+      },
+      activeAnimations: new Map([
+        [
+          "scene-fade",
+          {
+            id: "scene-fade",
+            type: "transition",
+            targetId: "scene-root",
+            signature: getAnimationContinuitySignature(animation),
+            continuity: "persistent",
+          },
+        ],
+      ]),
+    });
+
+    expect(plan.continuedAnimationIds).toEqual(new Set(["scene-fade"]));
+  });
+
+  it("continues a persistent delete-only transition when the target remains absent", () => {
+    const animation = {
+      id: "fade-out",
+      targetId: "portrait",
+      type: "transition",
+      playback: { continuity: "persistent" },
+      prev: {
+        tween: {
+          alpha: {
+            keyframes: [{ duration: 1000, value: 0, easing: "linear" }],
+          },
+        },
+      },
+    };
+
+    const plan = buildAnimationContinuityPlan({
+      prevState: {
+        elements: [],
+      },
+      nextState: {
+        elements: [],
+        animations: [animation],
+      },
+      activeAnimations: new Map([
+        [
+          "fade-out",
+          {
+            id: "fade-out",
+            type: "transition",
+            targetId: "portrait",
+            signature: getAnimationContinuitySignature(animation),
+            continuity: "persistent",
+          },
+        ],
+      ]),
+    });
+
+    expect(plan.continuedAnimationIds).toEqual(new Set(["fade-out"]));
+  });
+});
 
 describe("dispatchUpdateAnimations", () => {
   it("returns false when the target has no update animations", () => {
@@ -204,6 +369,43 @@ describe("dispatchUpdateAnimations", () => {
         }),
       }),
     );
+  });
+
+  it("treats already-running persistent update animations as dispatched without restarting them", () => {
+    const animationBus = {
+      dispatch: vi.fn(),
+      hasContext: vi.fn().mockReturnValue(true),
+    };
+    const completionTracker = {
+      getVersion: vi.fn(),
+      track: vi.fn(),
+      complete: vi.fn(),
+    };
+
+    const dispatched = dispatchUpdateAnimations({
+      animations: groupAnimationsByTarget([
+        {
+          id: "bg-breathe",
+          targetId: "bg",
+          type: "update",
+          playback: { continuity: "persistent" },
+          tween: {
+            scaleX: {
+              keyframes: [{ duration: 300, value: 1.2, easing: "linear" }],
+            },
+          },
+        },
+      ]),
+      targetId: "bg",
+      animationBus,
+      completionTracker,
+      element: { scale: { x: 1, y: 1 } },
+      targetState: { scaleX: 1.2 },
+    });
+
+    expect(dispatched).toBe(true);
+    expect(animationBus.dispatch).not.toHaveBeenCalled();
+    expect(completionTracker.track).not.toHaveBeenCalled();
   });
 
   it("throws when deferred update animations receive an onComplete hook", () => {

--- a/spec/animations/planAnimations.spec.js
+++ b/spec/animations/planAnimations.spec.js
@@ -26,10 +26,14 @@ describe("buildAnimationContinuityPlan", () => {
 
     const plan = buildAnimationContinuityPlan({
       prevState: {
-        elements: [{ id: "bg", type: "rect", x: 0, y: 0, width: 10, height: 10 }],
+        elements: [
+          { id: "bg", type: "rect", x: 0, y: 0, width: 10, height: 10 },
+        ],
       },
       nextState: {
-        elements: [{ id: "bg", type: "rect", x: 0, y: 0, width: 10, height: 10 }],
+        elements: [
+          { id: "bg", type: "rect", x: 0, y: 0, width: 10, height: 10 },
+        ],
         animations: [animation],
       },
       activeAnimations: new Map([
@@ -64,12 +68,99 @@ describe("buildAnimationContinuityPlan", () => {
 
     const plan = buildAnimationContinuityPlan({
       prevState: {
-        elements: [{ id: "bg", type: "rect", x: 0, y: 0, width: 10, height: 10 }],
+        elements: [
+          { id: "bg", type: "rect", x: 0, y: 0, width: 10, height: 10 },
+        ],
       },
       nextState: {
-        elements: [{ id: "bg", type: "rect", x: 5, y: 0, width: 10, height: 10 }],
+        elements: [
+          { id: "bg", type: "rect", x: 5, y: 0, width: 10, height: 10 },
+        ],
         animations: [animation],
       },
+      activeAnimations: new Map([
+        [
+          "bg-breathe",
+          {
+            id: "bg-breathe",
+            type: "update",
+            targetId: "bg",
+            signature: getAnimationContinuitySignature(animation),
+            continuity: "persistent",
+          },
+        ],
+      ]),
+    });
+
+    expect(plan.continuedAnimationIds).toEqual(new Set());
+  });
+
+  it("does not continue a persistent update when the target is reparented", () => {
+    const animation = {
+      id: "bg-breathe",
+      targetId: "bg",
+      type: "update",
+      playback: { continuity: "persistent" },
+      tween: {
+        scaleX: {
+          keyframes: [{ duration: 1000, value: 1.2, easing: "linear" }],
+        },
+      },
+    };
+
+    const bgNode = {
+      id: "bg",
+      type: "rect",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    };
+    const prevState = {
+      elements: [
+        {
+          id: "left",
+          type: "container",
+          x: 0,
+          y: 0,
+          alpha: 1,
+          children: [bgNode],
+        },
+        {
+          id: "right",
+          type: "container",
+          x: 20,
+          y: 0,
+          alpha: 1,
+          children: [],
+        },
+      ],
+    };
+    const nextState = {
+      elements: [
+        {
+          id: "left",
+          type: "container",
+          x: 0,
+          y: 0,
+          alpha: 1,
+          children: [],
+        },
+        {
+          id: "right",
+          type: "container",
+          x: 20,
+          y: 0,
+          alpha: 1,
+          children: [{ ...bgNode }],
+        },
+      ],
+      animations: [animation],
+    };
+
+    const plan = buildAnimationContinuityPlan({
+      prevState,
+      nextState,
       activeAnimations: new Map([
         [
           "bg-breathe",
@@ -170,6 +261,64 @@ describe("buildAnimationContinuityPlan", () => {
     });
 
     expect(plan.continuedAnimationIds).toEqual(new Set(["fade-out"]));
+  });
+
+  it("does not continue a persistent transition when a descendant animation is introduced", () => {
+    const transitionAnimation = {
+      id: "scene-fade",
+      targetId: "scene-root",
+      type: "transition",
+      playback: { continuity: "persistent" },
+      next: {
+        tween: {
+          alpha: {
+            keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+          },
+        },
+      },
+    };
+    const descendantAnimation = {
+      id: "bg-pulse",
+      targetId: "bg",
+      type: "update",
+      tween: {
+        alpha: {
+          keyframes: [{ duration: 1000, value: 0.5, easing: "linear" }],
+        },
+      },
+    };
+
+    const sceneNode = {
+      id: "scene-root",
+      type: "container",
+      x: 0,
+      y: 0,
+      alpha: 1,
+      children: [{ id: "bg", type: "rect", x: 0, y: 0, width: 10, height: 10 }],
+    };
+    const plan = buildAnimationContinuityPlan({
+      prevState: {
+        elements: [sceneNode],
+      },
+      nextState: {
+        elements: [{ ...sceneNode, children: [...sceneNode.children] }],
+        animations: [transitionAnimation, descendantAnimation],
+      },
+      activeAnimations: new Map([
+        [
+          "scene-fade",
+          {
+            id: "scene-fade",
+            type: "transition",
+            targetId: "scene-root",
+            signature: getAnimationContinuitySignature(transitionAnimation),
+            continuity: "persistent",
+          },
+        ],
+      ]),
+    });
+
+    expect(plan.continuedAnimationIds).toEqual(new Set());
   });
 });
 

--- a/spec/animations/planAnimations.spec.js
+++ b/spec/animations/planAnimations.spec.js
@@ -95,6 +95,48 @@ describe("buildAnimationContinuityPlan", () => {
     expect(plan.continuedAnimationIds).toEqual(new Set());
   });
 
+  it("does not continue an update when playback continuity is explicitly render-scoped", () => {
+    const animation = {
+      id: "bg-breathe",
+      targetId: "bg",
+      type: "update",
+      playback: { continuity: "render" },
+      tween: {
+        scaleX: {
+          keyframes: [{ duration: 1000, value: 1.2, easing: "linear" }],
+        },
+      },
+    };
+
+    const plan = buildAnimationContinuityPlan({
+      prevState: {
+        elements: [
+          { id: "bg", type: "rect", x: 0, y: 0, width: 10, height: 10 },
+        ],
+      },
+      nextState: {
+        elements: [
+          { id: "bg", type: "rect", x: 0, y: 0, width: 10, height: 10 },
+        ],
+        animations: [animation],
+      },
+      activeAnimations: new Map([
+        [
+          "bg-breathe",
+          {
+            id: "bg-breathe",
+            type: "update",
+            targetId: "bg",
+            signature: getAnimationContinuitySignature(animation),
+            continuity: "render",
+          },
+        ],
+      ]),
+    });
+
+    expect(plan.continuedAnimationIds).toEqual(new Set());
+  });
+
   it("does not continue a persistent update when the target is reparented", () => {
     const animation = {
       id: "bg-breathe",

--- a/spec/animations/runReplaceAnimation.spec.js
+++ b/spec/animations/runReplaceAnimation.spec.js
@@ -350,6 +350,102 @@ describe("runReplaceAnimation", () => {
     });
   });
 
+  it("preserves continuation zIndex updates while an async persistent transition is pending", async () => {
+    const parent = createParent();
+    const nextDisplayObject = createDisplayObject("scene-root");
+
+    let resolveAdd;
+    const addPromise = new Promise((resolve) => {
+      resolveAdd = resolve;
+    });
+    /** @type {{ onContinuationUpdate?: Function } | null} */
+    let pendingContext = null;
+
+    const plugin = {
+      add: vi.fn(({ parent: targetParent, element, renderContext }) => {
+        expect(renderContext.suppressAnimations).toBe(true);
+        return addPromise.then(() => {
+          nextDisplayObject.label = element.id;
+          targetParent.addChild(nextDisplayObject);
+        });
+      }),
+      delete: vi.fn(),
+    };
+
+    const tracker = {
+      getVersion: () => 11,
+      track: vi.fn(),
+      complete: vi.fn(),
+    };
+
+    const animationBus = {
+      dispatch: vi.fn(),
+      registerPending: vi.fn((payload) => {
+        pendingContext = payload;
+      }),
+      removePending: vi.fn(),
+      activatePending: vi.fn().mockReturnValue(false),
+    };
+
+    const app = {
+      renderer: {
+        width: 1280,
+        height: 720,
+        generateTexture: vi.fn(() => Texture.EMPTY),
+      },
+    };
+
+    runReplaceAnimation({
+      app,
+      parent,
+      prevElement: null,
+      nextElement: {
+        id: "scene-root",
+        type: "container",
+        children: [],
+      },
+      animation: {
+        id: "scene-transition",
+        targetId: "scene-root",
+        type: "transition",
+        playback: { continuity: "persistent" },
+        next: {
+          tween: {
+            alpha: {
+              initialValue: 0,
+              keyframes: [{ duration: 300, value: 1, easing: "linear" }],
+            },
+          },
+        },
+      },
+      animations: new Map(),
+      animationBus,
+      completionTracker: tracker,
+      eventHandler: vi.fn(),
+      elementPlugins: [],
+      plugin,
+      zIndex: 0,
+      signal: new AbortController().signal,
+    });
+
+    expect(animationBus.registerPending).toHaveBeenCalledTimes(1);
+
+    pendingContext?.onContinuationUpdate?.({ zIndex: 7 });
+
+    resolveAdd();
+    await addPromise;
+    await vi.waitFor(() => {
+      expect(animationBus.dispatch).toHaveBeenCalledTimes(1);
+    });
+
+    const overlay = parent.children.find(
+      (child) => child !== nextDisplayObject,
+    );
+
+    expect(nextDisplayObject.zIndex).toBe(7);
+    expect(overlay?.zIndex).toBe(7);
+  });
+
   it("reuses plugin delete/add so transition keeps child setup and deferred activation", () => {
     const prevDisplayObject = createDisplayObject("scene-root");
     const nextDisplayObject = createDisplayObject("scene-root");
@@ -895,7 +991,9 @@ describe("runReplaceAnimation", () => {
       signal: new AbortController().signal,
     });
 
-    const overlay = parent.children.find((child) => child !== nextDisplayObject);
+    const overlay = parent.children.find(
+      (child) => child !== nextDisplayObject,
+    );
     const sprite = overlay.children[0];
     const maskFilter = sprite.filters[0];
     const filterManager = {

--- a/spec/parser/normalizeRenderState.test.yaml
+++ b/spec/parser/normalizeRenderState.test.yaml
@@ -204,6 +204,70 @@ out:
             easing: easeOutQuad
   audio: []
 ---
+case: Normalize update animation with persistent playback continuity
+in:
+  - id: state-2-persistent-update
+    animations:
+      - id: anim-persistent-update
+        targetId: portrait
+        type: update
+        playback:
+          continuity: persistent
+        tween:
+          scaleX:
+            keyframes:
+              - duration: 300
+                value: 1.2
+out:
+  id: state-2-persistent-update
+  elements: []
+  animations:
+    - id: anim-persistent-update
+      targetId: portrait
+      type: update
+      playback:
+        continuity: persistent
+      tween:
+        scaleX:
+          keyframes:
+            - duration: 300
+              value: 1.2
+              easing: linear
+  audio: []
+---
+case: Normalize transition animation with persistent playback continuity
+in:
+  - id: state-2-persistent-transition
+    animations:
+      - id: anim-persistent-transition
+        targetId: scene-root
+        type: transition
+        playback:
+          continuity: persistent
+        next:
+          tween:
+            alpha:
+              keyframes:
+                - duration: 300
+                  value: 1
+out:
+  id: state-2-persistent-transition
+  elements: []
+  animations:
+    - id: anim-persistent-transition
+      targetId: scene-root
+      type: transition
+      playback:
+        continuity: persistent
+      next:
+        tween:
+          alpha:
+            keyframes:
+              - duration: 300
+                value: 1
+                easing: linear
+  audio: []
+---
 case: Throw when transitions field is provided
 in:
   - id: state-3
@@ -376,6 +440,22 @@ in:
               duration: 100
               easing: easeInHexagon
 throws: "animations[0].tween.x.auto.easing must be one of:"
+---
+case: Throw when playback continuity is unsupported
+in:
+  - id: state-3c-playback
+    animations:
+      - id: anim-playback
+        targetId: text-1
+        type: update
+        playback:
+          continuity: looping
+        tween:
+          x:
+            keyframes:
+              - duration: 100
+                value: 20
+throws: "animations[0].playback.continuity must be one of: persistent."
 ---
 case: Throw when target mixes update and transition types
 in:

--- a/spec/parser/normalizeRenderState.test.yaml
+++ b/spec/parser/normalizeRenderState.test.yaml
@@ -235,6 +235,37 @@ out:
               easing: linear
   audio: []
 ---
+case: Normalize update animation with render playback continuity
+in:
+  - id: state-2-render-update
+    animations:
+      - id: anim-render-update
+        targetId: portrait
+        type: update
+        playback:
+          continuity: render
+        tween:
+          scaleX:
+            keyframes:
+              - duration: 300
+                value: 1.2
+out:
+  id: state-2-render-update
+  elements: []
+  animations:
+    - id: anim-render-update
+      targetId: portrait
+      type: update
+      playback:
+        continuity: render
+      tween:
+        scaleX:
+          keyframes:
+            - duration: 300
+              value: 1.2
+              easing: linear
+  audio: []
+---
 case: Normalize transition animation with persistent playback continuity
 in:
   - id: state-2-persistent-transition
@@ -455,7 +486,7 @@ in:
             keyframes:
               - duration: 100
                 value: 20
-throws: "animations[0].playback.continuity must be one of: persistent."
+throws: "animations[0].playback.continuity must be one of: render, persistent."
 ---
 case: Throw when target mixes update and transition types
 in:

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -13,6 +13,7 @@ import { createCompletionTracker } from "./util/completionTracker.js";
 import { normalizeRenderState } from "./util/normalizeRenderState.js";
 import { isDeepEqual } from "./util/isDeepEqual.js";
 import { createInputDomBridge } from "./util/inputDomBridge.js";
+import { buildAnimationContinuityPlan } from "./plugins/animations/planAnimations.js";
 
 /**
  * @typedef {import('./types.js').RouteGraphicsInitOptions} RouteGraphicsInitOptions
@@ -256,6 +257,12 @@ const createRouteGraphics = () => {
       return;
     }
 
+    const continuityPlan = buildAnimationContinuityPlan({
+      prevState: state,
+      nextState,
+      activeAnimations: animationBus.getContinuableAnimations(),
+    });
+
     if (renderAbortController) {
       renderAbortController.abort();
     }
@@ -267,8 +274,8 @@ const createRouteGraphics = () => {
 
     applyGlobalObjects(appInstance, state.global, nextState.global);
 
-    // Cancel all running animations synchronously
-    animationBus.cancelAll();
+    // Cancel any running animation that is not explicitly continuing.
+    animationBus.cancelAllExcept(continuityPlan.continuedAnimationIds);
 
     // Render elements (now synchronous)
     renderElements({

--- a/src/plugins/animations/animationBus.js
+++ b/src/plugins/animations/animationBus.js
@@ -132,6 +132,7 @@ const buildPropertyTimelines = (
 export const createAnimationBus = () => {
   const commandQueue = [];
   const activeAnimations = new Map();
+  const pendingAnimations = new Map();
   const listeners = new Map();
   let stateVersion = 0;
   let sampledTime = null;
@@ -170,8 +171,28 @@ export const createAnimationBus = () => {
     }
   };
 
+  const attachAnimationMetadata = (context, metadata = {}) => {
+    context.animationType = metadata.animationType ?? context.animationType;
+    context.targetId = metadata.targetId ?? context.targetId;
+    context.signature = metadata.signature ?? context.signature;
+    context.continuity = metadata.continuity ?? context.continuity ?? "render";
+    context.onContinuationUpdate =
+      metadata.onContinuationUpdate ?? context.onContinuationUpdate;
+    return context;
+  };
+
+  const toContinuableDescriptor = (context) => ({
+    id: context.id,
+    type: context.animationType ?? null,
+    targetId: context.targetId ?? null,
+    signature: context.signature ?? null,
+    continuity: context.continuity ?? "render",
+    pending: context.pending === true,
+  });
+
   const registerAnimation = (context) => {
     context.applyFrame(0);
+    pendingAnimations.delete(context.id);
     activeAnimations.set(context.id, context);
 
     const completed =
@@ -251,7 +272,7 @@ export const createAnimationBus = () => {
       isValid: () => Boolean(element) && !element.destroyed,
     };
 
-    registerAnimation(context);
+    registerAnimation(attachAnimationMetadata(context, payload));
   };
 
   const startCustomAnimation = (payload) => {
@@ -268,7 +289,7 @@ export const createAnimationBus = () => {
       isValid: payload.isValid ?? (() => true),
     };
 
-    registerAnimation(context);
+    registerAnimation(attachAnimationMetadata(context, payload));
   };
 
   const startAnimation = (payload) => {
@@ -294,6 +315,15 @@ export const createAnimationBus = () => {
         // Best-effort cancellation callback.
       }
     }
+  };
+
+  const cancelPendingAnimation = (id) => {
+    const context = pendingAnimations.get(id);
+    if (!context) return;
+
+    applyCancellation(context);
+    pendingAnimations.delete(id);
+    emit("cancelled", { id });
   };
 
   const executeCommand = (cmd) => {
@@ -333,7 +363,10 @@ export const createAnimationBus = () => {
 
   const cancelAnimation = (id) => {
     const context = activeAnimations.get(id);
-    if (!context) return;
+    if (!context) {
+      cancelPendingAnimation(id);
+      return;
+    }
 
     applyCancellation(context);
     activeAnimations.delete(id);
@@ -351,8 +384,39 @@ export const createAnimationBus = () => {
       emit("cancelled", { id });
     }
 
+    for (const [id, context] of pendingAnimations) {
+      applyCancellation(context);
+      emit("cancelled", { id });
+    }
+
     activeAnimations.clear();
+    pendingAnimations.clear();
     stateVersion++;
+  };
+
+  const cancelAllExcept = (idsToKeep = new Set()) => {
+    const keepIds =
+      idsToKeep instanceof Set ? idsToKeep : new Set(idsToKeep ?? []);
+
+    for (const [id, context] of activeAnimations) {
+      if (keepIds.has(id)) {
+        continue;
+      }
+
+      applyCancellation(context);
+      activeAnimations.delete(id);
+      emit("cancelled", { id });
+    }
+
+    for (const [id, context] of pendingAnimations) {
+      if (keepIds.has(id)) {
+        continue;
+      }
+
+      applyCancellation(context);
+      pendingAnimations.delete(id);
+      emit("cancelled", { id });
+    }
   };
 
   const tick = (deltaMS) => {
@@ -437,9 +501,85 @@ export const createAnimationBus = () => {
     listeners.get(event)?.delete(callback);
   };
 
+  const registerPending = (payload) => {
+    const context = attachAnimationMetadata(
+      {
+        id: payload.id,
+        kind: "pending",
+        pending: true,
+        applyTargetState: payload.applyTargetState ?? (() => {}),
+        onCancel: payload.onCancel,
+      },
+      payload,
+    );
+
+    pendingAnimations.set(context.id, context);
+  };
+
+  const activatePending = (id, payload) => {
+    const pendingContext = pendingAnimations.get(id);
+    if (!pendingContext) {
+      return false;
+    }
+
+    pendingAnimations.delete(id);
+    startAnimation({
+      ...payload,
+      id,
+      animationType: pendingContext.animationType,
+      targetId: pendingContext.targetId,
+      signature: pendingContext.signature,
+      continuity: pendingContext.continuity,
+      onContinuationUpdate:
+        payload.onContinuationUpdate ?? pendingContext.onContinuationUpdate,
+    });
+
+    return true;
+  };
+
+  const removePending = (id) => {
+    pendingAnimations.delete(id);
+  };
+
+  const getContinuableAnimations = () => {
+    const descriptors = new Map();
+
+    for (const [id, context] of pendingAnimations) {
+      if (context.continuity === "persistent") {
+        descriptors.set(id, toContinuableDescriptor(context));
+      }
+    }
+
+    for (const [id, context] of activeAnimations) {
+      if (context.continuity === "persistent") {
+        descriptors.set(id, toContinuableDescriptor(context));
+      }
+    }
+
+    return descriptors;
+  };
+
+  const hasContext = (id) =>
+    activeAnimations.has(id) || pendingAnimations.has(id);
+
+  const updateContinuation = (id, payload) => {
+    const context = activeAnimations.get(id) ?? pendingAnimations.get(id);
+
+    if (!context?.onContinuationUpdate) {
+      return;
+    }
+
+    try {
+      context.onContinuationUpdate(payload);
+    } catch (_error) {
+      // Continuation updates are best-effort.
+    }
+  };
+
   const getState = () => ({
     stateVersion,
     activeCount: activeAnimations.size,
+    pendingCount: pendingAnimations.size,
     animations: Array.from(activeAnimations.entries()).map(([id, ctx]) => ({
       id,
       currentTime: ctx.currentTime,
@@ -458,14 +598,21 @@ export const createAnimationBus = () => {
   return {
     dispatch,
     cancelAll,
+    cancelAllExcept,
     flush,
     tick,
     setTime,
     clearTime,
     on,
     off,
+    registerPending,
+    activatePending,
+    removePending,
+    getContinuableAnimations,
     getState,
     isAnimating,
+    hasContext,
+    updateContinuation,
     destroy,
   };
 };

--- a/src/plugins/animations/planAnimations.js
+++ b/src/plugins/animations/planAnimations.js
@@ -3,6 +3,7 @@ import {
   dispatchUpdateAnimationsNow,
 } from "./updateAnimationDispatch.js";
 import { queueDeferredUpdateAnimationStart } from "../elements/renderContext.js";
+import { isDeepEqual } from "../../util/isDeepEqual.js";
 
 export const groupAnimationsByTarget = (animations = []) => {
   if (animations instanceof Map) {
@@ -40,6 +41,116 @@ export const getTransitionAnimation = (animationsOrMap, targetId) =>
     (animation) => animation.type === "transition",
   ) ?? null;
 
+const findElementById = (elements = [], targetId) => {
+  for (const element of elements) {
+    if (element?.id === targetId) {
+      return element;
+    }
+
+    if (Array.isArray(element?.children)) {
+      const childMatch = findElementById(element.children, targetId);
+      if (childMatch) {
+        return childMatch;
+      }
+    }
+  }
+
+  return null;
+};
+
+export const getAnimationContinuitySignature = (animation = {}) => {
+  if (animation.type === "update") {
+    return JSON.stringify({
+      type: animation.type,
+      tween: animation.tween,
+      playback: animation.playback ?? null,
+    });
+  }
+
+  return JSON.stringify({
+    type: animation.type,
+    prev: animation.prev ?? null,
+    next: animation.next ?? null,
+    mask: animation.mask ?? null,
+    playback: animation.playback ?? null,
+  });
+};
+
+const canContinuePersistentUpdate = ({ prevState, nextState, animation }) => {
+  const prevTarget = findElementById(prevState?.elements, animation.targetId);
+  const nextTarget = findElementById(nextState?.elements, animation.targetId);
+
+  return (
+    prevTarget !== null &&
+    nextTarget !== null &&
+    isDeepEqual(prevTarget, nextTarget)
+  );
+};
+
+const canContinuePersistentTransition = ({ prevState, nextState, animation }) =>
+  isDeepEqual(
+    findElementById(prevState?.elements, animation.targetId),
+    findElementById(nextState?.elements, animation.targetId),
+  );
+
+export const buildAnimationContinuityPlan = ({
+  prevState,
+  nextState,
+  activeAnimations,
+}) => {
+  const continuedAnimationIds = new Set();
+  const activeById =
+    activeAnimations instanceof Map
+      ? activeAnimations
+      : new Map(activeAnimations?.map((entry) => [entry.id, entry]) ?? []);
+
+  for (const animation of nextState?.animations ?? []) {
+    if (animation?.playback?.continuity !== "persistent") {
+      continue;
+    }
+
+    const activeAnimation = activeById.get(animation.id);
+    if (!activeAnimation) {
+      continue;
+    }
+
+    if (
+      activeAnimation.type !== animation.type ||
+      activeAnimation.targetId !== animation.targetId ||
+      activeAnimation.signature !== getAnimationContinuitySignature(animation)
+    ) {
+      continue;
+    }
+
+    if (animation.type === "update") {
+      if (
+        canContinuePersistentUpdate({
+          prevState,
+          nextState,
+          animation,
+        })
+      ) {
+        continuedAnimationIds.add(animation.id);
+      }
+      continue;
+    }
+
+    if (
+      canContinuePersistentTransition({
+        prevState,
+        nextState,
+        animation,
+      })
+    ) {
+      continuedAnimationIds.add(animation.id);
+    }
+  }
+
+  return {
+    continuedAnimationIds,
+  };
+};
+
 export const dispatchUpdateAnimations = ({
   animations,
   targetId,
@@ -51,9 +162,21 @@ export const dispatchUpdateAnimations = ({
   renderContext,
 }) => {
   const relevantAnimations = getUpdateAnimations(animations, targetId);
+  const continuedAnimations = relevantAnimations.filter((animation) =>
+    typeof animationBus?.hasContext === "function"
+      ? animationBus.hasContext(animation.id)
+      : false,
+  );
+  const animationsToStart = relevantAnimations.filter(
+    (animation) => !continuedAnimations.includes(animation),
+  );
 
   if (relevantAnimations.length === 0) {
     return false;
+  }
+
+  if (animationsToStart.length === 0) {
+    return true;
   }
 
   if (renderContext?.suppressAnimations) {
@@ -63,10 +186,10 @@ export const dispatchUpdateAnimations = ({
       );
     }
 
-    applyInitialUpdateAnimationState(element, relevantAnimations);
+    applyInitialUpdateAnimationState(element, animationsToStart);
 
     queueDeferredUpdateAnimationStart(renderContext, {
-      animations: relevantAnimations,
+      animations: animationsToStart,
       animationBus,
       completionTracker,
       element,
@@ -77,7 +200,7 @@ export const dispatchUpdateAnimations = ({
   }
 
   dispatchUpdateAnimationsNow({
-    animations: relevantAnimations,
+    animations: animationsToStart,
     animationBus,
     completionTracker,
     element,

--- a/src/plugins/animations/planAnimations.js
+++ b/src/plugins/animations/planAnimations.js
@@ -4,6 +4,7 @@ import {
 } from "./updateAnimationDispatch.js";
 import { queueDeferredUpdateAnimationStart } from "../elements/renderContext.js";
 import { isDeepEqual } from "../../util/isDeepEqual.js";
+import { collectAllElementIds } from "../../util/collectElementIds.js";
 
 export const groupAnimationsByTarget = (animations = []) => {
   if (animations instanceof Map) {
@@ -41,14 +42,20 @@ export const getTransitionAnimation = (animationsOrMap, targetId) =>
     (animation) => animation.type === "transition",
   ) ?? null;
 
-const findElementById = (elements = [], targetId) => {
+const findElementMatchById = (elements = [], targetId, ancestorIds = []) => {
   for (const element of elements) {
     if (element?.id === targetId) {
-      return element;
+      return {
+        element,
+        ancestorIds,
+      };
     }
 
     if (Array.isArray(element?.children)) {
-      const childMatch = findElementById(element.children, targetId);
+      const childMatch = findElementMatchById(element.children, targetId, [
+        ...ancestorIds,
+        element.id,
+      ]);
       if (childMatch) {
         return childMatch;
       }
@@ -56,6 +63,33 @@ const findElementById = (elements = [], targetId) => {
   }
 
   return null;
+};
+
+const hasSameOwnershipPath = (prevMatch, nextMatch) =>
+  isDeepEqual(prevMatch?.ancestorIds ?? null, nextMatch?.ancestorIds ?? null);
+
+const hasSubtreeAnimationConflict = ({
+  subtreeRoot,
+  nextAnimations,
+  continuingAnimationId,
+}) => {
+  if (!subtreeRoot) {
+    return false;
+  }
+
+  const subtreeIds = collectAllElementIds(subtreeRoot);
+
+  for (const candidate of nextAnimations ?? []) {
+    if (!candidate || candidate.id === continuingAnimationId) {
+      continue;
+    }
+
+    if (subtreeIds.has(candidate.targetId)) {
+      return true;
+    }
+  }
+
+  return false;
 };
 
 export const getAnimationContinuitySignature = (animation = {}) => {
@@ -77,21 +111,56 @@ export const getAnimationContinuitySignature = (animation = {}) => {
 };
 
 const canContinuePersistentUpdate = ({ prevState, nextState, animation }) => {
-  const prevTarget = findElementById(prevState?.elements, animation.targetId);
-  const nextTarget = findElementById(nextState?.elements, animation.targetId);
+  const prevTarget = findElementMatchById(
+    prevState?.elements,
+    animation.targetId,
+  );
+  const nextTarget = findElementMatchById(
+    nextState?.elements,
+    animation.targetId,
+  );
 
   return (
     prevTarget !== null &&
     nextTarget !== null &&
-    isDeepEqual(prevTarget, nextTarget)
+    hasSameOwnershipPath(prevTarget, nextTarget) &&
+    isDeepEqual(prevTarget.element, nextTarget.element)
   );
 };
 
-const canContinuePersistentTransition = ({ prevState, nextState, animation }) =>
-  isDeepEqual(
-    findElementById(prevState?.elements, animation.targetId),
-    findElementById(nextState?.elements, animation.targetId),
+const canContinuePersistentTransition = ({
+  prevState,
+  nextState,
+  animation,
+}) => {
+  const prevTarget = findElementMatchById(
+    prevState?.elements,
+    animation.targetId,
   );
+  const nextTarget = findElementMatchById(
+    nextState?.elements,
+    animation.targetId,
+  );
+
+  if (prevTarget === null && nextTarget === null) {
+    return true;
+  }
+
+  if (
+    prevTarget === null ||
+    nextTarget === null ||
+    !hasSameOwnershipPath(prevTarget, nextTarget) ||
+    !isDeepEqual(prevTarget.element, nextTarget.element)
+  ) {
+    return false;
+  }
+
+  return !hasSubtreeAnimationConflict({
+    subtreeRoot: nextTarget.element,
+    nextAnimations: nextState?.animations,
+    continuingAnimationId: animation.id,
+  });
+};
 
 export const buildAnimationContinuityPlan = ({
   prevState,

--- a/src/plugins/animations/replace/runReplaceAnimation.js
+++ b/src/plugins/animations/replace/runReplaceAnimation.js
@@ -18,6 +18,7 @@ import {
   createRenderContext,
   flushDeferredMountOperations,
 } from "../../elements/renderContext.js";
+import { getAnimationContinuitySignature } from "../planAnimations.js";
 const DEFAULT_SUBJECT_VALUES = {
   translateX: 0,
   translateY: 0,
@@ -1302,6 +1303,12 @@ export const runReplaceAnimation = ({
   const prevSubject = prevDisplayObject
     ? createSnapshotSubject(app, prevDisplayObject)
     : null;
+  const isPersistent = animation.playback?.continuity === "persistent";
+  const continuitySignature = getAnimationContinuitySignature(animation);
+  const transitionSignalController = isPersistent
+    ? new AbortController()
+    : null;
+  const transitionSignal = transitionSignalController?.signal ?? signal;
 
   const transitionMountParent = new Container();
   const hiddenMountContext = createRenderContext({
@@ -1327,6 +1334,31 @@ export const runReplaceAnimation = ({
     completionTracker.complete(stateVersion);
     completionTracked = false;
   };
+  const nextDisplayObjectRef = { value: null };
+  const replaceOverlayRef = { value: null };
+  let finalized = false;
+  const cleanupPendingTransition = () => {
+    if (typeof animationBus?.removePending === "function") {
+      animationBus.removePending(animation.id);
+    }
+  };
+  const handleContinuationUpdate = ({ zIndex: nextZIndex } = {}) => {
+    if (
+      typeof nextZIndex === "number" &&
+      nextDisplayObjectRef.value &&
+      !nextDisplayObjectRef.value.destroyed
+    ) {
+      nextDisplayObjectRef.value.zIndex = nextZIndex;
+    }
+
+    if (
+      typeof nextZIndex === "number" &&
+      replaceOverlayRef.value?.overlay &&
+      !replaceOverlayRef.value.overlay.destroyed
+    ) {
+      replaceOverlayRef.value.overlay.zIndex = nextZIndex;
+    }
+  };
 
   const finalize = ({ flushDeferredEffects }) => {
     if (finalized) return;
@@ -1345,14 +1377,30 @@ export const runReplaceAnimation = ({
 
     clearDeferredMountOperations(hiddenMountContext);
   };
-  const nextDisplayObjectRef = { value: null };
-  const replaceOverlayRef = { value: null };
-  let finalized = false;
+
+  if (isPersistent && typeof animationBus?.registerPending === "function") {
+    animationBus.registerPending({
+      id: animation.id,
+      animationType: animation.type,
+      targetId: animation.targetId,
+      signature: continuitySignature,
+      continuity: "persistent",
+      onCancel: () => {
+        transitionSignalController?.abort();
+        clearDeferredMountOperations(hiddenMountContext);
+        transitionMountParent.destroy({ children: true });
+        destroySubjectSnapshot(prevSubject);
+        completeTransition();
+      },
+      onContinuationUpdate: handleContinuationUpdate,
+    });
+  }
 
   trackTransition();
 
   const continueWithNextDisplayObject = (nextDisplayObject) => {
-    if (signal?.aborted || parent.destroyed) {
+    if (transitionSignal?.aborted || parent.destroyed) {
+      cleanupPendingTransition();
       clearDeferredMountOperations(hiddenMountContext);
       transitionMountParent.destroy({ children: true });
       destroySubjectSnapshot(prevSubject);
@@ -1361,6 +1409,7 @@ export const runReplaceAnimation = ({
     }
 
     if (nextElement && !nextDisplayObject) {
+      cleanupPendingTransition();
       clearDeferredMountOperations(hiddenMountContext);
       completeTransition();
       throw new Error(
@@ -1402,7 +1451,7 @@ export const runReplaceAnimation = ({
         eventHandler,
         elementPlugins,
         renderContext,
-        signal,
+        signal: transitionSignal,
       });
     }
 
@@ -1422,31 +1471,47 @@ export const runReplaceAnimation = ({
     replaceOverlayRef.value = replaceOverlay;
 
     parent.addChild(replaceOverlay.overlay);
+    const animationPayload = {
+      id: animation.id,
+      driver: "custom",
+      animationType: animation.type,
+      targetId: animation.targetId,
+      signature: continuitySignature,
+      continuity: isPersistent ? "persistent" : "render",
+      onContinuationUpdate: handleContinuationUpdate,
+      duration: replaceOverlay.duration,
+      applyFrame: replaceOverlay.apply,
+      applyTargetState: () => {
+        finalize({ flushDeferredEffects: false });
+      },
+      onComplete: () => {
+        try {
+          finalize({ flushDeferredEffects: true });
+        } finally {
+          completeTransition();
+        }
+      },
+      onCancel: () => {
+        completeTransition();
+      },
+      isValid: () =>
+        Boolean(replaceOverlay.overlay) &&
+        !replaceOverlay.overlay.destroyed &&
+        (!nextDisplayObject || !nextDisplayObject.destroyed),
+    };
+
+    if (
+      isPersistent &&
+      typeof animationBus?.activatePending === "function" &&
+      animationBus.activatePending(animation.id, animationPayload)
+    ) {
+      return;
+    }
+
+    cleanupPendingTransition();
     animationBus.dispatch({
       type: "START",
-      payload: {
-        id: animation.id,
-        driver: "custom",
-        duration: replaceOverlay.duration,
-        applyFrame: replaceOverlay.apply,
-        applyTargetState: () => {
-          finalize({ flushDeferredEffects: false });
-        },
-        onComplete: () => {
-          try {
-            finalize({ flushDeferredEffects: true });
-          } finally {
-            completeTransition();
-          }
-        },
-        onCancel: () => {
-          completeTransition();
-        },
-        isValid: () =>
-          Boolean(replaceOverlay.overlay) &&
-          !replaceOverlay.overlay.destroyed &&
-          (!nextDisplayObject || !nextDisplayObject.destroyed),
-      },
+      payload: animationPayload,
     });
   };
 
@@ -1463,7 +1528,7 @@ export const runReplaceAnimation = ({
         elementPlugins,
         renderContext: hiddenMountContext,
         zIndex,
-        signal,
+        signal: transitionSignal,
       })
     : null;
 

--- a/src/plugins/animations/replace/runReplaceAnimation.js
+++ b/src/plugins/animations/replace/runReplaceAnimation.js
@@ -1316,6 +1316,7 @@ export const runReplaceAnimation = ({
   });
   const stateVersion = completionTracker.getVersion();
   let completionTracked = false;
+  let currentZIndex = zIndex;
 
   const trackTransition = () => {
     if (completionTracked) {
@@ -1343,20 +1344,21 @@ export const runReplaceAnimation = ({
     }
   };
   const handleContinuationUpdate = ({ zIndex: nextZIndex } = {}) => {
-    if (
-      typeof nextZIndex === "number" &&
-      nextDisplayObjectRef.value &&
-      !nextDisplayObjectRef.value.destroyed
-    ) {
-      nextDisplayObjectRef.value.zIndex = nextZIndex;
+    if (typeof nextZIndex !== "number") {
+      return;
+    }
+
+    currentZIndex = nextZIndex;
+
+    if (nextDisplayObjectRef.value && !nextDisplayObjectRef.value.destroyed) {
+      nextDisplayObjectRef.value.zIndex = currentZIndex;
     }
 
     if (
-      typeof nextZIndex === "number" &&
       replaceOverlayRef.value?.overlay &&
       !replaceOverlayRef.value.overlay.destroyed
     ) {
-      replaceOverlayRef.value.overlay.zIndex = nextZIndex;
+      replaceOverlayRef.value.overlay.zIndex = currentZIndex;
     }
   };
 
@@ -1456,7 +1458,7 @@ export const runReplaceAnimation = ({
     }
 
     if (nextDisplayObject) {
-      nextDisplayObject.zIndex = zIndex;
+      nextDisplayObject.zIndex = currentZIndex;
       parent.addChild(nextDisplayObject);
       nextDisplayObject.visible = false;
     }
@@ -1466,7 +1468,7 @@ export const runReplaceAnimation = ({
       animation,
       prevSubject: overlaySubjects.prevSubject,
       nextSubject: overlaySubjects.nextSubject,
-      zIndex,
+      zIndex: currentZIndex,
     });
     replaceOverlayRef.value = replaceOverlay;
 

--- a/src/plugins/animations/updateAnimationDispatch.js
+++ b/src/plugins/animations/updateAnimationDispatch.js
@@ -68,6 +68,13 @@ export const dispatchUpdateAnimationsNow = ({
   onComplete,
 }) => {
   for (const animation of animations) {
+    if (
+      typeof animationBus?.hasContext === "function" &&
+      animationBus.hasContext(animation.id)
+    ) {
+      continue;
+    }
+
     for (const [property, config] of Object.entries(animation.tween)) {
       if (
         config.auto &&
@@ -87,6 +94,16 @@ export const dispatchUpdateAnimationsNow = ({
       type: "START",
       payload: {
         id: animation.id,
+        animationType: animation.type,
+        targetId: animation.targetId,
+        continuity: animation.playback?.continuity ?? "render",
+        signature:
+          animation.signature ??
+          JSON.stringify({
+            type: animation.type,
+            tween: animation.tween,
+            playback: animation.playback ?? null,
+          }),
         element,
         properties: animation.tween,
         targetState,

--- a/src/plugins/elements/renderElements.js
+++ b/src/plugins/elements/renderElements.js
@@ -124,7 +124,15 @@ export const renderElements = ({
     const replaceAnimation = renderContext.suppressAnimations
       ? null
       : getTransitionAnimation(animationsByTarget, element.id);
+    const continuedTransition =
+      replaceAnimation &&
+      typeof animationBus?.hasContext === "function" &&
+      animationBus.hasContext(replaceAnimation.id);
     const plugin = getPlugin(element.type);
+
+    if (continuedTransition) {
+      continue;
+    }
 
     if (replaceAnimation) {
       runReplaceAnimation({
@@ -165,10 +173,21 @@ export const renderElements = ({
     const replaceAnimation = renderContext.suppressAnimations
       ? null
       : getTransitionAnimation(animationsByTarget, element.id);
+    const continuedTransition =
+      replaceAnimation &&
+      typeof animationBus?.hasContext === "function" &&
+      animationBus.hasContext(replaceAnimation.id);
     const plugin = getPlugin(element.type);
 
     // Calculate zIndex based on position in nextComputedTree
     const zIndex = nextIndexById.get(element.id) ?? -1;
+
+    if (continuedTransition) {
+      if (typeof animationBus?.updateContinuation === "function") {
+        animationBus.updateContinuation(replaceAnimation.id, { zIndex });
+      }
+      continue;
+    }
 
     if (replaceAnimation) {
       runReplaceAnimation({
@@ -215,8 +234,16 @@ export const renderElements = ({
     const replaceAnimation = renderContext.suppressAnimations
       ? null
       : getTransitionAnimation(animationsByTarget, next.id);
+    const continuedTransition =
+      replaceAnimation &&
+      typeof animationBus?.hasContext === "function" &&
+      animationBus.hasContext(replaceAnimation.id);
 
-    if (replaceAnimation) {
+    if (continuedTransition) {
+      if (typeof animationBus?.updateContinuation === "function") {
+        animationBus.updateContinuation(replaceAnimation.id, { zIndex });
+      }
+    } else if (replaceAnimation) {
       runReplaceAnimation({
         app,
         parent,

--- a/src/schemas/animations/animation.yaml
+++ b/src/schemas/animations/animation.yaml
@@ -250,7 +250,7 @@ $defs:
     properties:
       continuity:
         type: string
-        enum: [persistent]
+        enum: [render, persistent]
     additionalProperties: false
 properties:
   id:

--- a/src/schemas/animations/animation.yaml
+++ b/src/schemas/animations/animation.yaml
@@ -243,6 +243,15 @@ $defs:
         then:
           required:
             - items
+  playback:
+    type: object
+    required:
+      - continuity
+    properties:
+      continuity:
+        type: string
+        enum: [persistent]
+    additionalProperties: false
 properties:
   id:
     type: string
@@ -260,6 +269,8 @@ properties:
       payload:
         type: object
     additionalProperties: true
+  playback:
+    $ref: "#/$defs/playback"
   tween:
     $ref: "#/$defs/updateTween"
   prev:

--- a/src/util/normalizeAnimations.js
+++ b/src/util/normalizeAnimations.js
@@ -1,6 +1,7 @@
 import { SUPPORTED_EASING_NAMES } from "./animationTimeline.js";
 
 const ANIMATION_TYPES = new Set(["update", "transition"]);
+const CONTINUITY_MODES = new Set(["persistent"]);
 const UPDATE_TWEEN_PROPERTIES = new Set([
   "alpha",
   "x",
@@ -38,6 +39,20 @@ const assertNumber = (value, path) => {
   if (typeof value !== "number" || Number.isNaN(value)) {
     throw new Error(`${path} must be a number.`);
   }
+};
+
+const normalizePlayback = (playback, path) => {
+  assertPlainObject(playback, path);
+
+  if (!CONTINUITY_MODES.has(playback.continuity)) {
+    throw new Error(
+      `${path}.continuity must be one of: ${Array.from(CONTINUITY_MODES).join(", ")}.`,
+    );
+  }
+
+  return {
+    continuity: playback.continuity,
+  };
 };
 
 const normalizeAutoTween = (autoConfig, path) => {
@@ -370,6 +385,13 @@ export const normalizeAnimations = (animations = []) => {
     if (animation.complete !== undefined) {
       assertPlainObject(animation.complete, `${path}.complete`);
       normalizedAnimation.complete = animation.complete;
+    }
+
+    if (animation.playback !== undefined) {
+      normalizedAnimation.playback = normalizePlayback(
+        animation.playback,
+        `${path}.playback`,
+      );
     }
 
     assertLegacyFieldAbsent(

--- a/src/util/normalizeAnimations.js
+++ b/src/util/normalizeAnimations.js
@@ -1,7 +1,7 @@
 import { SUPPORTED_EASING_NAMES } from "./animationTimeline.js";
 
 const ANIMATION_TYPES = new Set(["update", "transition"]);
-const CONTINUITY_MODES = new Set(["persistent"]);
+const CONTINUITY_MODES = new Set(["render", "persistent"]);
 const UPDATE_TWEEN_PROPERTIES = new Set([
   "alpha",
   "x",

--- a/vt/reference/recttransition/persistent-transition-continuity-01.webp
+++ b/vt/reference/recttransition/persistent-transition-continuity-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0d67086c1a56193bfd23942c660516d1c91ea08122804e45877cd6bd05c38d2
+size 1756

--- a/vt/reference/recttransition/persistent-transition-continuity-02.webp
+++ b/vt/reference/recttransition/persistent-transition-continuity-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b48782bbf6a0fdceb59be0abfff307c0f6213eea62a8f78d5a4e1265ed610e5
+size 1922

--- a/vt/reference/recttransition/persistent-transition-continuity-03.webp
+++ b/vt/reference/recttransition/persistent-transition-continuity-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d25ee2c9c868f05dabff002e924e89d2c33acf2b903b3b8b7c62880c33a598f
+size 1932

--- a/vt/reference/recttransition/persistent-transition-continuity-04.webp
+++ b/vt/reference/recttransition/persistent-transition-continuity-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:788740ed552000b7734e9f9a1ad023a0f87e339af18fee30730020bba874d994
+size 1924

--- a/vt/reference/recttransition/persistent-update-continuity-01.webp
+++ b/vt/reference/recttransition/persistent-update-continuity-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:743dae5abec88aea45850c0941fd6906918859e7c2b9566d213cdfd40dcb0b21
+size 1830

--- a/vt/reference/recttransition/persistent-update-continuity-02.webp
+++ b/vt/reference/recttransition/persistent-update-continuity-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b381f9f3074cc6e2d8011ce1ed40f095d746c4a6a328fd718775e6338061a1b
+size 1830

--- a/vt/reference/recttransition/persistent-update-continuity-03.webp
+++ b/vt/reference/recttransition/persistent-update-continuity-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f045fe39ff090daa128f7d75fc04c770a680acb7060699635334c54299ccedfe
+size 1824

--- a/vt/reference/recttransition/persistent-update-continuity-04.webp
+++ b/vt/reference/recttransition/persistent-update-continuity-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25424bf4a2b829234d797ca6e0e3dd78c6bff4280c4f312f7e33c6dd4cd0d0e1
+size 1828

--- a/vt/reference/recttransition/persistent-update-restart-on-target-change-01.webp
+++ b/vt/reference/recttransition/persistent-update-restart-on-target-change-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f99a1d64d0ebc41254dc82970d65afcb5cfdb2e440456cdb5e439bc82ca089ae
+size 1776

--- a/vt/reference/recttransition/persistent-update-restart-on-target-change-02.webp
+++ b/vt/reference/recttransition/persistent-update-restart-on-target-change-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f6fd940046f55cc5273f8bd94fc413701e6be2007080f9efde9533927b76716
+size 1776

--- a/vt/reference/recttransition/persistent-update-restart-on-target-change-03.webp
+++ b/vt/reference/recttransition/persistent-update-restart-on-target-change-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:080bcaea8d391bbb418e95623d185225c694568eccf07f9e9810318d5e07e2cc
+size 1782

--- a/vt/reference/recttransition/persistent-update-restart-on-target-change-04.webp
+++ b/vt/reference/recttransition/persistent-update-restart-on-target-change-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c20bb1d3fd587541c3e5cc8cab212e0d6bb0387cfbc893cd5efa7358a1917ea
+size 1796

--- a/vt/specs/recttransition/persistent-transition-continuity.yaml
+++ b/vt/specs/recttransition/persistent-transition-continuity.yaml
@@ -1,0 +1,96 @@
+---
+title: Rect Persistent Transition Continuity
+description: A persistent rect transition keeps the same in-flight overlay alive across an unrelated sibling rerender.
+specs:
+  - the first state should show a partially visible entering scene rect
+  - the second render should move only the sibling foreground rect while preserving the transition progress
+  - the entering scene rect should keep advancing from the carried-over transition time after the second render
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 400
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 100
+  - action: screenshot
+---
+states:
+  - id: baseline
+    elements:
+      - id: front
+        type: rect
+        x: 900
+        y: 160
+        width: 180
+        height: 180
+        fill: "#4D4D4D"
+  - id: transition-start
+    elements:
+      - id: scene
+        type: rect
+        x: 120
+        y: 110
+        width: 860
+        height: 500
+        fill: "#FFFFFF"
+        alpha: 1
+      - id: front
+        type: rect
+        x: 900
+        y: 160
+        width: 180
+        height: 180
+        fill: "#4D4D4D"
+    animations:
+      - id: scene-fade
+        targetId: scene
+        type: transition
+        playback:
+          continuity: persistent
+        next:
+          tween:
+            alpha:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear
+  - id: transition-carried-forward
+    elements:
+      - id: scene
+        type: rect
+        x: 120
+        y: 110
+        width: 860
+        height: 500
+        fill: "#FFFFFF"
+        alpha: 1
+      - id: front
+        type: rect
+        x: 700
+        y: 160
+        width: 180
+        height: 180
+        fill: "#4D4D4D"
+    animations:
+      - id: scene-fade
+        targetId: scene
+        type: transition
+        playback:
+          continuity: persistent
+        next:
+          tween:
+            alpha:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear

--- a/vt/specs/recttransition/persistent-update-continuity.yaml
+++ b/vt/specs/recttransition/persistent-update-continuity.yaml
@@ -1,0 +1,95 @@
+---
+title: Rect Persistent Update Continuity
+description: A persistent rect update keeps its in-flight horizontal motion across an unrelated sibling rerender.
+specs:
+  - the background rect should keep its carried-over horizontal position when the second render only changes a sibling
+  - the foreground rect should move in the second state without restarting the background update
+  - the background rect should continue advancing from the carried-over time after the second render
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 400
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 100
+  - action: screenshot
+---
+states:
+  - id: baseline
+    elements:
+      - id: bg
+        type: rect
+        x: 80
+        y: 120
+        width: 320
+        height: 220
+        fill: "#FFFFFF"
+      - id: front
+        type: rect
+        x: 900
+        y: 160
+        width: 180
+        height: 180
+        fill: "#4D4D4D"
+  - id: update-start
+    elements:
+      - id: bg
+        type: rect
+        x: 520
+        y: 120
+        width: 320
+        height: 220
+        fill: "#FFFFFF"
+      - id: front
+        type: rect
+        x: 900
+        y: 160
+        width: 180
+        height: 180
+        fill: "#4D4D4D"
+    animations:
+      - id: bg-grow
+        targetId: bg
+        type: update
+        playback:
+          continuity: persistent
+        tween:
+          x:
+            auto:
+              duration: 1000
+              easing: linear
+  - id: update-carried-forward
+    elements:
+      - id: bg
+        type: rect
+        x: 520
+        y: 120
+        width: 320
+        height: 220
+        fill: "#FFFFFF"
+      - id: front
+        type: rect
+        x: 700
+        y: 160
+        width: 180
+        height: 180
+        fill: "#4D4D4D"
+    animations:
+      - id: bg-grow
+        targetId: bg
+        type: update
+        playback:
+          continuity: persistent
+        tween:
+          x:
+            auto:
+              duration: 1000
+              easing: linear

--- a/vt/specs/recttransition/persistent-update-restart-on-target-change.yaml
+++ b/vt/specs/recttransition/persistent-update-restart-on-target-change.yaml
@@ -1,0 +1,74 @@
+---
+title: Rect Persistent Update Restart On Target Change
+description: A persistent rect update restarts when the target definition changes between renders.
+specs:
+  - the first state should show an in-flight background move toward the right
+  - changing the background rect target should break continuity on the second render
+  - after the second render, the restarted animation should head toward the new leftward target instead of continuing the previous path
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 400
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 100
+  - action: screenshot
+---
+states:
+  - id: baseline
+    elements:
+      - id: bg
+        type: rect
+        x: 80
+        y: 120
+        width: 320
+        height: 220
+        fill: "#FFFFFF"
+  - id: update-start
+    elements:
+      - id: bg
+        type: rect
+        x: 520
+        y: 120
+        width: 320
+        height: 220
+        fill: "#FFFFFF"
+    animations:
+      - id: bg-grow
+        targetId: bg
+        type: update
+        playback:
+          continuity: persistent
+        tween:
+          x:
+            auto:
+              duration: 1000
+              easing: linear
+  - id: update-restarted
+    elements:
+      - id: bg
+        type: rect
+        x: 20
+        y: 120
+        width: 320
+        height: 220
+        fill: "#FFFFFF"
+    animations:
+      - id: bg-grow
+        targetId: bg
+        type: update
+        playback:
+          continuity: persistent
+        tween:
+          x:
+            auto:
+              duration: 1000
+              easing: linear


### PR DESCRIPTION
## Summary
- add `playback.continuity: persistent` support for `update` and `transition` animations
- preserve in-flight animations across unrelated renders while detaching `renderComplete` tracking after adoption
- document the interface, add Vitest coverage, add VT specs and references, and bump the package version to `1.10.0`

## Testing
- `npm test`
- `docker run --rm --user $(id -u):$(id -g) -e RTGL_VT_DEBUG=true -e RTGL_VT_CONCURRENCY=1 -v "$PWD:/workspace" docker.io/han4wluc/rtgl:playwright-v1.57.0-rtgl-v1.1.0 rtgl vt screenshot --wait-event vt:ready --concurrency 1 --item recttransition/persistent-update-continuity.yaml --item recttransition/persistent-update-restart-on-target-change.yaml --item recttransition/persistent-transition-continuity.yaml`