### PR TITLE
Support continuing text reveals from an initial offset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/pages/docs/nodes/text-revealing.md
+++ b/playground/pages/docs/nodes/text-revealing.md
@@ -28,6 +28,7 @@ Try it in the [Playground](/playground/?template=text-revealing).
 | `alpha`        | number                               | No                  | `1`            | Opacity `0..1`.                                                                                                                 |
 | `textStyle`    | object                               | No                  | text defaults  | Base style for segments.                                                                                                        |
 | `speed`        | number                               | No                  | `50`           | Uses a curved `0..100` scale. `0..99` gets progressively faster with extra control in the upper range; `100` renders instantly. |
+| `initialRevealedCharacters` | number                  | No                  | `0`            | Leading characters to paint as already revealed before the animation starts.                                                     |
 | `revealEffect` | `typewriter` \| `softWipe` \| `none` | No                  | `typewriter`   | `softWipe` reveals pre-laid-out text with a soft left-to-right mask, one laid-out line at a time. `none` renders instantly.     |
 | `softWipe`     | object                               | No                  | see below      | Parameters used when `revealEffect: softWipe`.                                                                                  |
 | `indicator`    | object                               | No                  | -              | Revealing/complete icon config + offset.                                                                                        |
@@ -67,6 +68,7 @@ Try it in the [Playground](/playground/?template=text-revealing).
 - Reveal runs chunk by chunk.
 - `speed` uses an exponential/log-like mapping so `50..99` covers most of the fast reveal range with finer control than a linear scale.
 - `speed: 100` skips animation entirely and paints the final text immediately, regardless of `revealEffect`.
+- `initialRevealedCharacters` is useful when an upstream engine appends to an existing line: keep the full combined `content`, set the count to the already-visible prefix length, and only the remaining suffix animates.
 - `softWipe` lays out the full text immediately and reveals it line by line with a moving soft mask. Defaults match the original soft wipe behavior: linear motion, no overlap, and a feather width clamped to the legacy range.
 - `revealEffect: none` skips animation and paints text immediately.
 - Completion contributes to global `renderComplete` tracking.

--- a/spec/elements/textRevealingRuntime.initialRevealedCharacters.spec.js
+++ b/spec/elements/textRevealingRuntime.initialRevealedCharacters.spec.js
@@ -1,0 +1,282 @@
+import { Container } from "pixi.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseTextRevealing } from "../../src/plugins/elements/text-revealing/parseTextRevealing.js";
+import { runTextReveal } from "../../src/plugins/elements/text-revealing/textRevealingRuntime.js";
+
+const createCompletionTracker = () => ({
+  getVersion: () => 0,
+  track: vi.fn(),
+  complete: vi.fn(),
+});
+
+const getRenderedText = (container) => {
+  const textParts = [];
+  const visit = (node) => {
+    if (typeof node?.text === "string") {
+      textParts.push(node.text);
+    }
+
+    if (Array.isArray(node?.children)) {
+      node.children.forEach(visit);
+    }
+  };
+
+  visit(container);
+
+  return textParts.join("");
+};
+
+const createTextRevealingElement = (overrides = {}) =>
+  parseTextRevealing({
+    state: {
+      id: "line-1",
+      type: "text-revealing",
+      x: 0,
+      y: 0,
+      width: 600,
+      speed: 24,
+      revealEffect: "typewriter",
+      content: [{ text: "Already visible, then continue from there." }],
+      textStyle: {
+        fontSize: 20,
+        fontFamily: "Arial",
+        breakWords: false,
+      },
+      ...overrides,
+    },
+  });
+
+const runReveal = async ({ element, playback = "autoplay", signal } = {}) => {
+  const container = new Container();
+  const completionTracker = createCompletionTracker();
+  const animationBus = { dispatch: vi.fn() };
+  const reveal = runTextReveal({
+    container,
+    element,
+    completionTracker,
+    animationBus,
+    zIndex: 0,
+    signal: signal ?? new AbortController().signal,
+    playback,
+  });
+
+  return {
+    container,
+    completionTracker,
+    animationBus,
+    reveal,
+  };
+};
+
+const getSoftWipeStartAction = (animationBus) =>
+  animationBus.dispatch.mock.calls.find(([action]) => action.type === "START")
+    ?.[0];
+
+const getLineContainer = (container, element, lineIndex = 0) =>
+  container
+    .getChildByLabel(`${element.id}-content`)
+    .getChildByLabel(`${element.id}-line-${lineIndex}`);
+
+describe("runTextReveal initialRevealedCharacters", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("prefills a typewriter prefix before revealing the remaining text", async () => {
+    const fullText = "Already visible, then continue from there.";
+    const initialRevealedCharacters = "Already visible, ".length;
+    const element = createTextRevealingElement({
+      content: [{ text: fullText }],
+      initialRevealedCharacters,
+    });
+
+    const { container, completionTracker, reveal } = await runReveal({
+      element,
+    });
+    const initialText = getRenderedText(container);
+
+    expect(initialText.startsWith(fullText.slice(0, initialRevealedCharacters)))
+      .toBe(true);
+    expect(initialText.length).toBeGreaterThan(initialRevealedCharacters);
+    expect(initialText.length).toBeLessThan(fullText.length);
+
+    await vi.runAllTimersAsync();
+    await reveal;
+
+    expect(getRenderedText(container)).toBe(fullText);
+    expect(completionTracker.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders only the prefix for paused-initial typewriter playback", async () => {
+    const fullText = "Already visible, then wait for deferred autoplay.";
+    const initialRevealedCharacters = "Already visible, ".length;
+    const element = createTextRevealingElement({
+      content: [{ text: fullText }],
+      initialRevealedCharacters,
+    });
+    const { container, completionTracker, animationBus, reveal } =
+      await runReveal({
+        element,
+        playback: "paused-initial",
+      });
+
+    await reveal;
+
+    expect(getRenderedText(container)).toBe(
+      fullText.slice(0, initialRevealedCharacters),
+    );
+    expect(completionTracker.track).not.toHaveBeenCalled();
+    expect(completionTracker.complete).not.toHaveBeenCalled();
+    expect(animationBus.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("resumes typewriter progress from the runtime snapshot after an offset start", async () => {
+    const container = new Container();
+    const completionTracker = createCompletionTracker();
+    const animationBus = { dispatch: vi.fn() };
+    const fullText = "Prefix resumes from the live snapshot, not the old offset.";
+    const element = createTextRevealingElement({
+      content: [{ text: fullText }],
+      initialRevealedCharacters: "Prefix ".length,
+    });
+
+    const firstController = new AbortController();
+    const firstReveal = runTextReveal({
+      container,
+      element,
+      completionTracker,
+      animationBus,
+      zIndex: 0,
+      signal: firstController.signal,
+      playback: "autoplay",
+    });
+
+    await vi.advanceTimersByTimeAsync(220);
+
+    const partialText = getRenderedText(container);
+
+    expect(partialText.length).toBeGreaterThan(
+      element.initialRevealedCharacters,
+    );
+    expect(partialText.length).toBeLessThan(fullText.length);
+
+    firstController.abort();
+    await firstReveal;
+
+    const resumeReveal = runTextReveal({
+      container,
+      element,
+      completionTracker,
+      animationBus,
+      zIndex: 0,
+      signal: new AbortController().signal,
+      playback: "resume",
+    });
+
+    await vi.advanceTimersByTimeAsync(60);
+
+    expect(getRenderedText(container).length).toBeGreaterThan(
+      partialText.length,
+    );
+
+    await vi.runAllTimersAsync();
+    await resumeReveal;
+
+    expect(getRenderedText(container)).toBe(fullText);
+    expect(completionTracker.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts softWipe from a shifted prefix time", async () => {
+    const fullText = "Soft wipe should continue from an already visible prefix.";
+    const softWipe = {
+      easing: "linear",
+      softness: 0,
+    };
+    const baseline = await runReveal({
+      element: createTextRevealingElement({
+        content: [{ text: fullText }],
+        revealEffect: "softWipe",
+        softWipe,
+      }),
+    });
+    const shifted = await runReveal({
+      element: createTextRevealingElement({
+        content: [{ text: fullText }],
+        revealEffect: "softWipe",
+        softWipe,
+        initialRevealedCharacters: "Soft wipe should continue ".length,
+      }),
+    });
+    const baselineStart = getSoftWipeStartAction(baseline.animationBus);
+    const shiftedStart = getSoftWipeStartAction(shifted.animationBus);
+
+    expect(baselineStart?.payload).toBeDefined();
+    expect(shiftedStart?.payload).toBeDefined();
+    expect(shiftedStart.payload.duration).toBeLessThan(
+      baselineStart.payload.duration,
+    );
+
+    baselineStart.payload.applyFrame(0);
+    shiftedStart.payload.applyFrame(0);
+
+    expect(shifted.container.children[1].x).toBeGreaterThan(
+      baseline.container.children[1].x,
+    );
+
+    baselineStart.payload.onCancel();
+    shiftedStart.payload.onCancel();
+  });
+
+  it("renders a paused-initial softWipe prefix without dispatching animation work", async () => {
+    const fullText = "Soft wipe prefix is visible before deferred autoplay.";
+    const initialRevealedCharacters = "Soft wipe prefix ".length;
+    const element = createTextRevealingElement({
+      content: [{ text: fullText }],
+      revealEffect: "softWipe",
+      softWipe: {
+        easing: "linear",
+        softness: 0,
+      },
+      initialRevealedCharacters,
+    });
+    const { container, completionTracker, animationBus, reveal } =
+      await runReveal({
+        element,
+        playback: "paused-initial",
+      });
+
+    await reveal;
+
+    expect(getRenderedText(container)).toBe(fullText);
+    expect(getLineContainer(container, element).mask).toBeTruthy();
+    expect(container.children[1].x).toBeGreaterThan(12);
+    expect(completionTracker.track).not.toHaveBeenCalled();
+    expect(completionTracker.complete).not.toHaveBeenCalled();
+    expect(animationBus.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("completes softWipe immediately when the offset covers all characters", async () => {
+    const fullText = "Fully covered soft wipe.";
+    const element = createTextRevealingElement({
+      content: [{ text: fullText }],
+      revealEffect: "softWipe",
+      initialRevealedCharacters: fullText.length,
+    });
+    const { container, completionTracker, animationBus, reveal } =
+      await runReveal({
+        element,
+      });
+
+    await reveal;
+
+    expect(getRenderedText(container)).toBe(fullText);
+    expect(getSoftWipeStartAction(animationBus)).toBeUndefined();
+    expect(completionTracker.track).toHaveBeenCalledTimes(1);
+    expect(completionTracker.complete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/spec/elements/updateTextRevealing.spec.js
+++ b/spec/elements/updateTextRevealing.spec.js
@@ -161,6 +161,86 @@ describe("updateTextRevealing", () => {
     );
   });
 
+  it("restarts reveal when only the initial revealed character offset changes", async () => {
+    const parent = new Container();
+    const child = new Container();
+    child.label = "line-1";
+    parent.addChild(child);
+
+    await updateTextRevealing({
+      parent,
+      prevElement: createElement({
+        initialRevealedCharacters: 0,
+      }),
+      nextElement: createElement({
+        initialRevealedCharacters: 12,
+      }),
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      renderContext: createRenderContext(),
+      completionTracker: createCompletionTracker(),
+      zIndex: 0,
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.runTextReveal).toHaveBeenCalledTimes(1);
+    expect(mocks.runTextReveal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playback: "autoplay",
+        element: expect.objectContaining({
+          initialRevealedCharacters: 12,
+        }),
+      }),
+    );
+  });
+
+  it("preserves initial revealed character offset through deferred autoplay", async () => {
+    const parent = new Container();
+    const child = new Container();
+    child.label = "line-1";
+    parent.addChild(child);
+    const renderContext = createRenderContext({ suppressAnimations: true });
+
+    await updateTextRevealing({
+      parent,
+      prevElement: createElement(),
+      nextElement: createElement({
+        content: [
+          {
+            text: "Original text content with appended continuation",
+          },
+        ],
+        initialRevealedCharacters: "Original text content".length,
+      }),
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      renderContext,
+      completionTracker: createCompletionTracker(),
+      zIndex: 0,
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.runTextReveal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playback: "paused-initial",
+        element: expect.objectContaining({
+          initialRevealedCharacters: "Original text content".length,
+        }),
+      }),
+    );
+
+    flushDeferredMountOperations(renderContext);
+
+    expect(mocks.runTextReveal).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        playback: "autoplay",
+        element: expect.objectContaining({
+          initialRevealedCharacters: "Original text content".length,
+        }),
+      }),
+    );
+  });
+
   it("restarts reveal when softWipe parameters change", async () => {
     const parent = new Container();
     const child = new Container();

--- a/spec/parser/parseTextRevealing.initialRevealedCharacters.spec.js
+++ b/spec/parser/parseTextRevealing.initialRevealedCharacters.spec.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTextRevealing } from "../../src/plugins/elements/text-revealing/parseTextRevealing.js";
+
+const createState = (overrides = {}) => ({
+  id: "line-1",
+  type: "text-revealing",
+  x: 0,
+  y: 0,
+  content: [{ text: "Already visible then revealed." }],
+  textStyle: {
+    fontFamily: "Arial",
+    fontSize: 20,
+    breakWords: false,
+  },
+  ...overrides,
+});
+
+describe("parseTextRevealing initialRevealedCharacters", () => {
+  it("preserves a finite non-negative integer offset", () => {
+    const parsed = parseTextRevealing({
+      state: createState({
+        initialRevealedCharacters: 8.9,
+      }),
+    });
+
+    expect(parsed.initialRevealedCharacters).toBe(8);
+  });
+
+  it("normalizes unsafe supplied offsets to zero without adding the field when omitted", () => {
+    const unsafe = parseTextRevealing({
+      state: createState({
+        initialRevealedCharacters: -4,
+      }),
+    });
+    const omitted = parseTextRevealing({
+      state: createState(),
+    });
+
+    expect(unsafe.initialRevealedCharacters).toBe(0);
+    expect(omitted).not.toHaveProperty("initialRevealedCharacters");
+  });
+});

--- a/src/plugins/elements/text-revealing/parseTextRevealing.js
+++ b/src/plugins/elements/text-revealing/parseTextRevealing.js
@@ -4,6 +4,14 @@ import { DEFAULT_TEXT_STYLE } from "../../../types.js";
 import { toPixiTextStyle } from "../../../util/toPixiTextStyle.js";
 import { normalizeSoftWipeConfig } from "./softWipeConfig.js";
 
+const normalizeInitialRevealedCharacters = (value) => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor(value));
+};
+
 /**
  * @typedef {import('../../../types.js').BaseElement} BaseElement
  * @typedef {import('../../../types.js').TextRevealingComputedNode} TextRevealingComputedNode
@@ -435,6 +443,11 @@ export const parseTextRevealing = ({ state }) => {
     revealEffect: state.revealEffect ?? "typewriter",
     ...(state.softWipe !== undefined && {
       softWipe: normalizeSoftWipeConfig(state.softWipe),
+    }),
+    ...(state.initialRevealedCharacters !== undefined && {
+      initialRevealedCharacters: normalizeInitialRevealedCharacters(
+        state.initialRevealedCharacters,
+      ),
     }),
     ...(state.width !== undefined && { width: state.width }),
     ...(state.complete && { complete: state.complete }),

--- a/src/plugins/elements/text-revealing/textRevealingRuntime.js
+++ b/src/plugins/elements/text-revealing/textRevealingRuntime.js
@@ -25,6 +25,8 @@ const MIN_TEXT_REVEAL_RATE = 10;
 const MAX_TEXT_REVEAL_RATE = 120;
 const TEXT_REVEAL_RATE_CURVE = 0.9;
 
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
 const clampTextRevealSpeed = (speed = DEFAULT_TEXT_REVEAL_SPEED) => {
   if (typeof speed !== "number" || !Number.isFinite(speed)) {
     return DEFAULT_TEXT_REVEAL_SPEED;
@@ -58,6 +60,27 @@ const getEffectiveSpeed = (speed) => {
 
 const getTextRevealSnapshotMode = (element) =>
   element?.revealEffect === "softWipe" ? "softWipe" : "typewriter";
+
+const getInitialRevealedCharacters = (element) => {
+  const value = element?.initialRevealedCharacters;
+
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.floor(value));
+};
+
+const getTextRevealCharacterCount = (element) =>
+  (element?.content ?? []).reduce(
+    (chunkTotal, chunk) =>
+      chunkTotal +
+      (chunk.lineParts ?? []).reduce(
+        (partTotal, part) => partTotal + (part.text?.length ?? 0),
+        0,
+      ),
+    0,
+  );
 
 export const shouldRenderTextRevealImmediately = (element) =>
   element?.revealEffect === "none" ||
@@ -292,11 +315,124 @@ const runNoneReveal = ({ contentContainer, indicatorSprite, element }) => {
   applyCompleteIndicator(indicatorSprite, element);
 };
 
-const runPausedInitialReveal = ({ indicatorSprite, element }) => {
+const runTypewriterPrefixReveal = ({
+  contentContainer,
+  indicatorSprite,
+  element,
+  revealedCharacters,
+}) => {
   const indicatorOffset = element?.indicator?.offset ?? 12;
   const firstChunk = element.content[0] ?? null;
+  const totalCharacters = getTextRevealCharacterCount(element);
+  let remainingCharacters = Math.min(
+    revealedCharacters,
+    Math.max(0, totalCharacters),
+  );
+  let lastVisibleTextObject = null;
+  let lastVisibleChunk = null;
 
-  positionIndicatorForChunk(indicatorSprite, firstChunk, indicatorOffset);
+  if (remainingCharacters <= 0) {
+    positionIndicatorForChunk(indicatorSprite, firstChunk, indicatorOffset);
+    return;
+  }
+
+  chunkLoop: for (
+    let chunkIndex = 0;
+    chunkIndex < element.content.length;
+    chunkIndex++
+  ) {
+    const chunk = element.content[chunkIndex];
+
+    for (let partIndex = 0; partIndex < chunk.lineParts.length; partIndex++) {
+      const part = chunk.lineParts[partIndex];
+      const prefilledCharacters = Math.min(
+        part.text.length,
+        remainingCharacters,
+      );
+
+      if (prefilledCharacters <= 0) {
+        break chunkLoop;
+      }
+
+      const fullFurigana = part.furigana?.text || "";
+      const furiganaLength = fullFurigana.length;
+      const prefilledFuriganaLength =
+        part.text.length > 0
+          ? Math.round(
+              (prefilledCharacters / part.text.length) * furiganaLength,
+            )
+          : 0;
+      const { text, furiganaText } = createPartObjects(
+        part,
+        part.text.substring(0, prefilledCharacters),
+        fullFurigana.substring(0, prefilledFuriganaLength),
+      );
+
+      if (furiganaText) {
+        contentContainer.addChild(furiganaText);
+      }
+
+      contentContainer.addChild(text);
+      lastVisibleTextObject = text;
+      lastVisibleChunk = chunk;
+      remainingCharacters -= prefilledCharacters;
+
+      if (prefilledCharacters < part.text.length) {
+        break chunkLoop;
+      }
+    }
+  }
+
+  if (lastVisibleChunk) {
+    positionIndicatorForChunk(
+      indicatorSprite,
+      lastVisibleChunk,
+      indicatorOffset,
+    );
+    positionIndicatorAtTextEnd(
+      indicatorSprite,
+      lastVisibleTextObject,
+      indicatorOffset,
+    );
+  } else {
+    positionIndicatorForChunk(indicatorSprite, firstChunk, indicatorOffset);
+  }
+
+  if (revealedCharacters >= totalCharacters) {
+    applyCompleteIndicator(indicatorSprite, element);
+  }
+};
+
+const runPausedInitialReveal = ({
+  contentContainer,
+  indicatorSprite,
+  element,
+}) => {
+  const revealedCharacters = getInitialRevealedCharacters(element);
+
+  if (revealedCharacters <= 0) {
+    const indicatorOffset = element?.indicator?.offset ?? 12;
+    const firstChunk = element.content[0] ?? null;
+
+    positionIndicatorForChunk(indicatorSprite, firstChunk, indicatorOffset);
+    return;
+  }
+
+  if (element.revealEffect === "softWipe") {
+    runSoftWipePausedInitialReveal({
+      contentContainer,
+      indicatorSprite,
+      element,
+      revealedCharacters,
+    });
+  } else {
+    runTypewriterPrefixReveal({
+      contentContainer,
+      indicatorSprite,
+      element,
+      revealedCharacters,
+    });
+  }
 };
 
 const runTypewriterReveal = async ({
@@ -461,6 +597,281 @@ const getSoftWipeLineProgress = ({ currentTime, line, easing }) => {
   return easing(Math.max(0, Math.min(rawProgress, 1)));
 };
 
+const getInverseSoftWipeProgress = ({ progress, easingName }) => {
+  const clampedProgress = clamp(progress, 0, 1);
+
+  if (easingName === "easeOutCubic") {
+    return 1 - Math.cbrt(1 - clampedProgress);
+  }
+
+  return clampedProgress;
+};
+
+const getSoftWipeInitialTime = ({
+  timedLines,
+  duration,
+  initialRevealedCharacters,
+  easingName,
+}) => {
+  let remainingCharacters = Math.max(0, Math.floor(initialRevealedCharacters));
+
+  if (remainingCharacters <= 0) {
+    return 0;
+  }
+
+  for (const line of timedLines) {
+    const lineCharacters = Math.max(0, line.totalCharacters ?? 0);
+
+    if (lineCharacters <= 0) {
+      continue;
+    }
+
+    if (remainingCharacters <= lineCharacters) {
+      const easedProgress = remainingCharacters / lineCharacters;
+      const rawProgress = getInverseSoftWipeProgress({
+        progress: easedProgress,
+        easingName,
+      });
+
+      return clamp(line.startTime + rawProgress * line.duration, 0, duration);
+    }
+
+    remainingCharacters -= lineCharacters;
+  }
+
+  return duration;
+};
+
+const destroySoftWipeLineMasks = (lineMasks) => {
+  lineMasks.forEach((lineMask) => {
+    if (!lineMask) {
+      return;
+    }
+
+    if (lineMask.line.container.mask === lineMask.sprite) {
+      lineMask.line.container.mask = null;
+    }
+
+    if (lineMask.sprite.parent) {
+      lineMask.sprite.parent.removeChild(lineMask.sprite);
+    }
+
+    lineMask.sprite.destroy();
+    lineMask.texture.destroy(true);
+  });
+};
+
+const createSoftWipeLineMasks = ({
+  contentContainer,
+  timedLines,
+  edgeWidth,
+}) => {
+  const lineMasks = timedLines.map((line) => {
+    const canvas = document.createElement("canvas");
+
+    canvas.width = Math.max(1, Math.ceil(line.bounds.width + edgeWidth));
+    canvas.height = Math.max(1, Math.ceil(line.bounds.height));
+
+    const context = canvas.getContext("2d");
+
+    if (!context) {
+      return null;
+    }
+
+    const texture = getCanvasTexture(canvas);
+    const sprite = new Sprite(texture);
+
+    sprite.x = Math.floor(line.bounds.x - edgeWidth);
+    sprite.y = Math.floor(line.bounds.y);
+    line.container.mask = sprite;
+    contentContainer.addChild(sprite);
+
+    return {
+      canvas,
+      context,
+      texture,
+      sprite,
+      line,
+      edgeWidth,
+    };
+  });
+
+  if (lineMasks.some((lineMask) => lineMask === null)) {
+    destroySoftWipeLineMasks(lineMasks);
+    return null;
+  }
+
+  return lineMasks;
+};
+
+const applySoftWipeFrame = ({
+  timedLines,
+  lineMasks,
+  easing,
+  indicatorSprite,
+  indicatorOffset,
+  currentTime,
+}) => {
+  let activeLine = timedLines[0];
+  let activeLineLeadingEdgeX = activeLine.bounds.x;
+
+  for (let lineIndex = 0; lineIndex < timedLines.length; lineIndex++) {
+    const line = timedLines[lineIndex];
+    const lineMask = lineMasks[lineIndex];
+    const lineProgress = getSoftWipeLineProgress({
+      currentTime,
+      line,
+      easing,
+    });
+    const { context, canvas, texture } = lineMask;
+
+    context.clearRect(0, 0, canvas.width, canvas.height);
+
+    if (lineProgress <= 0) {
+      texture.source.update();
+      continue;
+    }
+
+    const lineY = 0;
+    const lineTravelDistance = line.bounds.width + lineMask.edgeWidth;
+    const lineStart = lineMask.edgeWidth;
+    const lineLeadingEdge = lineStart + lineProgress * lineTravelDistance;
+    const hardEnd = Math.max(lineStart, lineLeadingEdge - lineMask.edgeWidth);
+
+    if (hardEnd > lineStart) {
+      context.fillStyle = "#ffffff";
+      context.fillRect(
+        lineStart,
+        lineY,
+        Math.min(hardEnd - lineStart, line.bounds.width),
+        line.bounds.height,
+      );
+    }
+
+    const gradientStart = Math.max(
+      lineStart,
+      lineLeadingEdge - lineMask.edgeWidth,
+    );
+    const gradientEnd = Math.min(
+      lineStart + line.bounds.width,
+      lineLeadingEdge,
+    );
+
+    if (gradientEnd > gradientStart) {
+      const gradient = context.createLinearGradient(
+        gradientStart,
+        0,
+        gradientEnd,
+        0,
+      );
+
+      gradient.addColorStop(0, "rgba(255, 255, 255, 1)");
+      gradient.addColorStop(1, "rgba(255, 255, 255, 0)");
+      context.fillStyle = gradient;
+      context.fillRect(
+        gradientStart,
+        lineY,
+        gradientEnd - gradientStart,
+        line.bounds.height,
+      );
+    }
+
+    texture.source.update();
+    activeLine = line;
+    activeLineLeadingEdgeX =
+      line.bounds.x +
+      Math.min(line.bounds.width, Math.max(0, lineLeadingEdge - lineStart));
+  }
+
+  positionIndicatorForChunk(indicatorSprite, activeLine.chunk, indicatorOffset);
+  indicatorSprite.x = activeLineLeadingEdgeX + indicatorOffset;
+};
+
+const runSoftWipePausedInitialReveal = ({
+  contentContainer,
+  indicatorSprite,
+  element,
+  revealedCharacters,
+}) => {
+  const indicatorOffset = element?.indicator?.offset ?? 12;
+  const { lines, lastTextObject, lastChunk, totalCharacters, maxLineHeight } =
+    buildFullTextContent(contentContainer, element);
+
+  positionIndicatorForChunk(indicatorSprite, lastChunk, indicatorOffset);
+
+  if (
+    lines.length === 0 ||
+    totalCharacters === 0 ||
+    revealedCharacters >= totalCharacters ||
+    !lines.some((line) => line.bounds.width > 0 && line.bounds.height > 0) ||
+    !globalThis.document
+  ) {
+    positionIndicatorAtTextEnd(
+      indicatorSprite,
+      lastTextObject,
+      indicatorOffset,
+    );
+    applyCompleteIndicator(indicatorSprite, element);
+    return;
+  }
+
+  const softWipe = normalizeSoftWipeConfig(element.softWipe);
+  const easing = getSoftWipeEasing(softWipe.easing);
+  const edgeWidth = getSoftWipeEdgeWidth({ maxLineHeight, softWipe });
+  const effectiveSpeed = getEffectiveSpeed(element.speed ?? 50);
+  const baseDuration = Math.max(
+    1,
+    Math.round((totalCharacters / effectiveSpeed) * 1000),
+  );
+  const { timedLines, duration } = createSoftWipeLineTimings({
+    lines,
+    edgeWidth,
+    baseDuration,
+    softWipe,
+  });
+  const startTime = getSoftWipeInitialTime({
+    timedLines,
+    duration,
+    initialRevealedCharacters: revealedCharacters,
+    easingName: softWipe.easing,
+  });
+
+  if (startTime >= duration) {
+    positionIndicatorAtTextEnd(
+      indicatorSprite,
+      lastTextObject,
+      indicatorOffset,
+    );
+    applyCompleteIndicator(indicatorSprite, element);
+    return;
+  }
+
+  const lineMasks = createSoftWipeLineMasks({
+    contentContainer,
+    timedLines,
+    edgeWidth,
+  });
+
+  if (!lineMasks) {
+    positionIndicatorAtTextEnd(
+      indicatorSprite,
+      lastTextObject,
+      indicatorOffset,
+    );
+    applyCompleteIndicator(indicatorSprite, element);
+    return;
+  }
+
+  applySoftWipeFrame({
+    timedLines,
+    lineMasks,
+    easing,
+    indicatorSprite,
+    indicatorOffset,
+    currentTime: startTime,
+  });
+};
+
 const runSoftWipeReveal = ({
   container,
   contentContainer,
@@ -471,14 +882,8 @@ const runSoftWipeReveal = ({
 }) => {
   const indicatorOffset = element?.indicator?.offset ?? 12;
   const effectiveSpeed = getEffectiveSpeed(element.speed ?? 50);
-  const {
-    lines,
-    lastTextObject,
-    lastChunk,
-    totalCharacters,
-    maxLineHeight,
-    bounds,
-  } = buildFullTextContent(contentContainer, element);
+  const { lines, lastTextObject, lastChunk, totalCharacters, maxLineHeight } =
+    buildFullTextContent(contentContainer, element);
 
   positionIndicatorForChunk(indicatorSprite, lastChunk, indicatorOffset);
 
@@ -511,56 +916,33 @@ const runSoftWipeReveal = ({
     baseDuration,
     softWipe,
   });
+  const initialRevealedCharacters = getInitialRevealedCharacters(element);
+  const startTime = getSoftWipeInitialTime({
+    timedLines,
+    duration,
+    initialRevealedCharacters,
+    easingName: softWipe.easing,
+  });
+
+  if (startTime >= duration) {
+    positionIndicatorAtTextEnd(
+      indicatorSprite,
+      lastTextObject,
+      indicatorOffset,
+    );
+    applyCompleteIndicator(indicatorSprite, element);
+    return false;
+  }
 
   const stateVersion = completionTracker.getVersion();
   const animationId = `${element.id}-soft-wipe`;
-  const lineMasks = timedLines.map((line) => {
-    const canvas = document.createElement("canvas");
-
-    canvas.width = Math.max(1, Math.ceil(line.bounds.width + edgeWidth));
-    canvas.height = Math.max(1, Math.ceil(line.bounds.height));
-
-    const context = canvas.getContext("2d");
-
-    if (!context) {
-      return null;
-    }
-
-    const texture = getCanvasTexture(canvas);
-    const sprite = new Sprite(texture);
-
-    sprite.x = Math.floor(line.bounds.x - edgeWidth);
-    sprite.y = Math.floor(line.bounds.y);
-    line.container.mask = sprite;
-    contentContainer.addChild(sprite);
-
-    return {
-      canvas,
-      context,
-      texture,
-      sprite,
-      line,
-    };
+  const lineMasks = createSoftWipeLineMasks({
+    contentContainer,
+    timedLines,
+    edgeWidth,
   });
 
-  if (lineMasks.some((lineMask) => lineMask === null)) {
-    lineMasks.forEach((lineMask) => {
-      if (!lineMask) {
-        return;
-      }
-
-      if (lineMask.line.container.mask === lineMask.sprite) {
-        lineMask.line.container.mask = null;
-      }
-
-      if (lineMask.sprite.parent) {
-        lineMask.sprite.parent.removeChild(lineMask.sprite);
-      }
-
-      lineMask.sprite.destroy();
-      lineMask.texture.destroy(true);
-    });
-
+  if (!lineMasks) {
     positionIndicatorAtTextEnd(
       indicatorSprite,
       lastTextObject,
@@ -616,94 +998,23 @@ const runSoftWipeReveal = ({
 
   registerTextRevealRuntime(container, finalizeCleanup);
   completionTracker.track(stateVersion);
+  const remainingDuration = Math.max(1, Math.ceil(duration - startTime));
 
   animationBus.dispatch({
     type: "START",
     payload: {
       id: animationId,
       driver: "custom",
-      duration,
+      duration: remainingDuration,
       applyFrame: (currentTime) => {
-        let activeLine = timedLines[0];
-        let activeLineLeadingEdgeX = activeLine.bounds.x;
-
-        for (let lineIndex = 0; lineIndex < timedLines.length; lineIndex++) {
-          const line = timedLines[lineIndex];
-          const lineMask = lineMasks[lineIndex];
-          const lineProgress = getSoftWipeLineProgress({
-            currentTime,
-            line,
-            easing,
-          });
-          const { context, canvas, texture } = lineMask;
-
-          context.clearRect(0, 0, canvas.width, canvas.height);
-
-          if (lineProgress <= 0) {
-            texture.source.update();
-            continue;
-          }
-
-          const lineY = 0;
-          const lineTravelDistance = line.bounds.width + edgeWidth;
-          const lineStart = edgeWidth;
-          const lineLeadingEdge = lineStart + lineProgress * lineTravelDistance;
-          const hardEnd = Math.max(lineStart, lineLeadingEdge - edgeWidth);
-
-          if (hardEnd > lineStart) {
-            context.fillStyle = "#ffffff";
-            context.fillRect(
-              lineStart,
-              lineY,
-              Math.min(hardEnd - lineStart, line.bounds.width),
-              line.bounds.height,
-            );
-          }
-
-          const gradientStart = Math.max(
-            lineStart,
-            lineLeadingEdge - edgeWidth,
-          );
-          const gradientEnd = Math.min(
-            lineStart + line.bounds.width,
-            lineLeadingEdge,
-          );
-
-          if (gradientEnd > gradientStart) {
-            const gradient = context.createLinearGradient(
-              gradientStart,
-              0,
-              gradientEnd,
-              0,
-            );
-
-            gradient.addColorStop(0, "rgba(255, 255, 255, 1)");
-            gradient.addColorStop(1, "rgba(255, 255, 255, 0)");
-            context.fillStyle = gradient;
-            context.fillRect(
-              gradientStart,
-              lineY,
-              gradientEnd - gradientStart,
-              line.bounds.height,
-            );
-          }
-
-          texture.source.update();
-          activeLine = line;
-          activeLineLeadingEdgeX =
-            line.bounds.x +
-            Math.min(
-              line.bounds.width,
-              Math.max(0, lineLeadingEdge - lineStart),
-            );
-        }
-
-        positionIndicatorForChunk(
+        applySoftWipeFrame({
+          timedLines,
+          lineMasks,
+          easing,
           indicatorSprite,
-          activeLine.chunk,
           indicatorOffset,
-        );
-        indicatorSprite.x = activeLineLeadingEdgeX + indicatorOffset;
+          currentTime: Math.min(duration, startTime + currentTime),
+        });
       },
       applyTargetState: () => {
         finalize(false);
@@ -743,6 +1054,7 @@ export const runTextReveal = async ({
   const renderImmediately = shouldRenderTextRevealImmediately(element);
   const resumableSnapshot =
     playback === "resume" ? getResumableTypewriterSnapshot(container) : null;
+  const initialRevealedCharacters = getInitialRevealedCharacters(element);
 
   if (playback === "resume" && !resumableSnapshot) {
     return;
@@ -762,7 +1074,7 @@ export const runTextReveal = async ({
       if (!renderImmediately) {
         setTextRevealSnapshot(container, {
           mode: getTextRevealSnapshotMode(element),
-          revealedCharacters: 0,
+          revealedCharacters: initialRevealedCharacters,
           completed: false,
         });
       }
@@ -774,7 +1086,7 @@ export const runTextReveal = async ({
         });
         runNoneReveal({ contentContainer, indicatorSprite, element });
       } else {
-        runPausedInitialReveal({ indicatorSprite, element });
+        runPausedInitialReveal({ contentContainer, indicatorSprite, element });
       }
       return;
     }
@@ -793,6 +1105,7 @@ export const runTextReveal = async ({
     } else if (element.revealEffect === "softWipe") {
       setTextRevealSnapshot(container, {
         mode: "softWipe",
+        revealedCharacters: initialRevealedCharacters,
         completed: false,
       });
 
@@ -813,9 +1126,11 @@ export const runTextReveal = async ({
       }
     } else {
       completionTracker.track(stateVersion);
+      const startAtCharacter =
+        resumableSnapshot?.revealedCharacters ?? initialRevealedCharacters;
       const nextSnapshot = setTextRevealSnapshot(container, {
         mode: "typewriter",
-        revealedCharacters: resumableSnapshot?.revealedCharacters ?? 0,
+        revealedCharacters: startAtCharacter,
         completed: false,
       });
 
@@ -824,7 +1139,7 @@ export const runTextReveal = async ({
         indicatorSprite,
         element,
         signal,
-        startAtCharacter: resumableSnapshot?.revealedCharacters ?? 0,
+        startAtCharacter,
         snapshot: nextSnapshot,
       });
     }

--- a/src/plugins/elements/text-revealing/updateTextRevealing.js
+++ b/src/plugins/elements/text-revealing/updateTextRevealing.js
@@ -15,6 +15,7 @@ const getRevealIdentity = (element = {}) =>
         ? normalizeSoftWipeConfig(element.softWipe)
         : null,
     speed: element.speed ?? 50,
+    initialRevealedCharacters: element.initialRevealedCharacters ?? 0,
     width: element.width ?? null,
     indicator: element.indicator ?? null,
     x: element.x ?? null,

--- a/src/schemas/elements/text-revealing.computed.yaml
+++ b/src/schemas/elements/text-revealing.computed.yaml
@@ -178,6 +178,11 @@ properties:
     type: number
     description: Animation speed on a curved 0-100 scale; 100 renders instantly
     default: 50
+  initialRevealedCharacters:
+    type: number
+    minimum: 0
+    description: Number of leading text characters rendered as already revealed before the reveal animation starts.
+    default: 0
   revealEffect:
     type: string
     enum: [typewriter,softWipe,none]

--- a/src/schemas/elements/text-revealing.element.yaml
+++ b/src/schemas/elements/text-revealing.element.yaml
@@ -152,6 +152,11 @@ properties:
     type: number
     description: Animation speed on a curved 0-100 scale; 100 renders instantly
     default: 50
+  initialRevealedCharacters:
+    type: number
+    minimum: 0
+    description: Number of leading text characters to render as already revealed before the reveal animation starts.
+    default: 0
   revealEffect:
     type: string
     enum: [typewriter,softWipe,none]

--- a/src/types.js
+++ b/src/types.js
@@ -466,6 +466,7 @@
  * @property {number} alpha - Opacity/transparency (0-1)
  * @property {Object} textStyle - Default text style
  * @property {number} [speed=50] - Animation speed on a curved 0-100 scale; 100 renders instantly
+ * @property {number} [initialRevealedCharacters=0] - Number of leading text characters rendered as already revealed before the reveal animation starts
  * @property {Object} complete - Complete event
  * @property {Object} [indicator] - Settings for the text continuation indicator
  * @property {Object} [indicator.revealing] - Settings for the revealing state indicator

--- a/vt/reference/textrevealing/update-text-revealing-continue-from-offset-soft-wipe-01.webp
+++ b/vt/reference/textrevealing/update-text-revealing-continue-from-offset-soft-wipe-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e24c0ffea9b53a69f7d6a86d62da8fa2054e4c3753ef77ca133a6d410c2fb57f
+size 3154

--- a/vt/reference/textrevealing/update-text-revealing-continue-from-offset-soft-wipe-02.webp
+++ b/vt/reference/textrevealing/update-text-revealing-continue-from-offset-soft-wipe-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e24c0ffea9b53a69f7d6a86d62da8fa2054e4c3753ef77ca133a6d410c2fb57f
+size 3154

--- a/vt/reference/textrevealing/update-text-revealing-continue-from-offset-soft-wipe-03.webp
+++ b/vt/reference/textrevealing/update-text-revealing-continue-from-offset-soft-wipe-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3e6f5edc04ec8b932dbf22022a40b8b4f8d47a00e6801f303b97820f2a13944
+size 3582

--- a/vt/reference/textrevealing/update-text-revealing-continue-from-offset-soft-wipe-04.webp
+++ b/vt/reference/textrevealing/update-text-revealing-continue-from-offset-soft-wipe-04.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:30eb20e22dfb04ba7a326f86519cdd21f5ca5d359ffbc3c55b4184b61bd098dd
-size 6900
+oid sha256:5d98542b757cf0387451c85d0cccaf1554a1ab7e5fb072e4c9717f92a783a6dc
+size 5304

--- a/vt/reference/textrevealing/update-text-revealing-continue-from-offset-soft-wipe-04.webp
+++ b/vt/reference/textrevealing/update-text-revealing-continue-from-offset-soft-wipe-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30eb20e22dfb04ba7a326f86519cdd21f5ca5d359ffbc3c55b4184b61bd098dd
+size 6900

--- a/vt/reference/textrevealing/update-text-revealing-continue-from-offset-typewriter-01.webp
+++ b/vt/reference/textrevealing/update-text-revealing-continue-from-offset-typewriter-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b527885b643f53db2e9c96dabafa714d5745a461cb42e6a93b31ac4a4744158
+size 3052

--- a/vt/reference/textrevealing/update-text-revealing-continue-from-offset-typewriter-02.webp
+++ b/vt/reference/textrevealing/update-text-revealing-continue-from-offset-typewriter-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b527885b643f53db2e9c96dabafa714d5745a461cb42e6a93b31ac4a4744158
+size 3052

--- a/vt/reference/textrevealing/update-text-revealing-continue-from-offset-typewriter-03.webp
+++ b/vt/reference/textrevealing/update-text-revealing-continue-from-offset-typewriter-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c89dfb328c3c6895c2dcc11806bf7f3946f52c5159d177b32819467b7a1ed8c2
+size 3470

--- a/vt/reference/textrevealing/update-text-revealing-continue-from-offset-typewriter-04.webp
+++ b/vt/reference/textrevealing/update-text-revealing-continue-from-offset-typewriter-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f339c933e79c6735912e2cc904c72c5653b12460e8faf34b16325445bbbcd66
+size 4038

--- a/vt/specs/textrevealing/update-text-revealing-continue-from-offset-soft-wipe.yaml
+++ b/vt/specs/textrevealing/update-text-revealing-continue-from-offset-soft-wipe.yaml
@@ -1,0 +1,66 @@
+---
+title: Update Text Revealing Continue From Offset Soft Wipe
+description: |
+  Same text-revealing element id can append content and start softWipe from the
+  already-visible prefix rather than wiping the whole line again.
+specs:
+  - first state renders the completed prefix
+  - second state starts with the prefix already revealed through the softWipe mask
+  - softWipe continues across the appended suffix
+steps:
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 1
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 900
+  - action: screenshot
+---
+states:
+  - id: soft-wipe-prefix-complete
+    elements:
+      - id: text-revealing-continue-soft-wipe
+        type: text-revealing
+        content:
+          - text: "Held prefix: "
+            textStyle:
+              fontSize: 30
+              fill: "#FFFFFF"
+              fontFamily: Arial
+        x: 70
+        y: 130
+        width: 980
+        alpha: 1
+        speed: 100
+        revealEffect: softWipe
+  - id: soft-wipe-continue-from-prefix
+    elements:
+      - id: text-revealing-continue-soft-wipe
+        type: text-revealing
+        content:
+          - text: "Held prefix: "
+            textStyle:
+              fontSize: 30
+              fill: "#FFFFFF"
+              fontFamily: Arial
+          - text: "continuing soft wipe text from the same dialogue line."
+            textStyle:
+              fontSize: 30
+              fill: "#8BD3FF"
+              fontFamily: Arial
+        x: 70
+        y: 130
+        width: 980
+        alpha: 1
+        speed: 18
+        initialRevealedCharacters: 13
+        revealEffect: softWipe
+        softWipe:
+          easing: linear
+          softness: 0.75

--- a/vt/specs/textrevealing/update-text-revealing-continue-from-offset-typewriter.yaml
+++ b/vt/specs/textrevealing/update-text-revealing-continue-from-offset-typewriter.yaml
@@ -1,0 +1,63 @@
+---
+title: Update Text Revealing Continue From Offset Typewriter
+description: |
+  Same text-revealing element id can append content and reveal only the new suffix
+  when initialRevealedCharacters marks the already-visible prefix.
+specs:
+  - first state renders the completed prefix
+  - second state keeps the prefix visible immediately after the content update
+  - typewriter reveal continues into the appended suffix instead of restarting at the beginning
+steps:
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 1
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 560
+  - action: screenshot
+---
+states:
+  - id: typewriter-prefix-complete
+    elements:
+      - id: text-revealing-continue
+        type: text-revealing
+        content:
+          - text: "Held prefix: "
+            textStyle:
+              fontSize: 30
+              fill: "#FFFFFF"
+              fontFamily: Arial
+        x: 70
+        y: 80
+        width: 980
+        alpha: 1
+        speed: 100
+        revealEffect: typewriter
+  - id: typewriter-continue-from-prefix
+    elements:
+      - id: text-revealing-continue
+        type: text-revealing
+        content:
+          - text: "Held prefix: "
+            textStyle:
+              fontSize: 30
+              fill: "#FFFFFF"
+              fontFamily: Arial
+          - text: "continuing typewriter text from the same dialogue line."
+            textStyle:
+              fontSize: 30
+              fill: "#FFD166"
+              fontFamily: Arial
+        x: 70
+        y: 80
+        width: 980
+        alpha: 1
+        speed: 16
+        initialRevealedCharacters: 13
+        revealEffect: typewriter


### PR DESCRIPTION
## Summary
- add the text-revealing `initialRevealedCharacters` contract across parser, schemas, types, and docs
- start typewriter reveals from the visible prefix while preserving runtime resume snapshots
- start softWipe reveals from a shifted prefix time, including paused/deferred initial frames
- add unit coverage plus VT specs and references for typewriter and softWipe continuation
- bump package version to 1.12.3

## Tests
- `node_modules/.bin/vitest run` (59 files, 374 tests)
- `node_modules/.bin/vitest run spec/parser/parseTextRevealing.initialRevealedCharacters.spec.js spec/elements/textRevealingRuntime.initialRevealedCharacters.spec.js spec/elements/updateTextRevealing.spec.js` (16 tests)
- `bun run build`
- `rtgl vt screenshot --wait-event vt:ready --item textrevealing/update-text-revealing-continue-from-offset-typewriter.yaml --item textrevealing/update-text-revealing-continue-from-offset-soft-wipe.yaml`
- `rtgl vt report --item textrevealing/update-text-revealing-continue-from-offset-typewriter.yaml --item textrevealing/update-text-revealing-continue-from-offset-soft-wipe.yaml` (8 selected screenshots, 0 mismatches)
