### PR TITLE
Add text shadow styling support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/pages/docs/nodes/text-revealing.md
+++ b/playground/pages/docs/nodes/text-revealing.md
@@ -15,24 +15,24 @@ Try it in the [Playground](/playground/?template=text-revealing).
 
 ## Field Reference
 
-| Field          | Type                                 | Required            | Default        | Notes                                                                                                                           |
-| -------------- | ------------------------------------ | ------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `id`           | string                               | Yes                 | -              | Element id.                                                                                                                     |
-| `type`         | string                               | Yes                 | -              | Must be `text-revealing`.                                                                                                       |
-| `x`            | number                               | Yes (public schema) | `0` at runtime | Position before anchor transform.                                                                                               |
-| `y`            | number                               | Yes (public schema) | `0` at runtime | Position before anchor transform.                                                                                               |
-| `content`      | array                                | No                  | `[]`           | Array of rich text segments.                                                                                                    |
-| `width`        | number                               | No                  | auto           | If omitted, parser uses a 500px wrap basis for layout measurement.                                                              |
-| `anchorX`      | number                               | No                  | `0`            | Anchor offset ratio.                                                                                                            |
-| `anchorY`      | number                               | No                  | `0`            | Anchor offset ratio.                                                                                                            |
-| `alpha`        | number                               | No                  | `1`            | Opacity `0..1`.                                                                                                                 |
-| `textStyle`    | object                               | No                  | text defaults  | Base style for segments.                                                                                                        |
-| `speed`        | number                               | No                  | `50`           | Uses a curved `0..100` scale. `0..99` gets progressively faster with extra control in the upper range; `100` renders instantly. |
-| `initialRevealedCharacters` | number                  | No                  | `0`            | Leading characters to paint as already revealed before the animation starts.                                                     |
-| `revealEffect` | `typewriter` \| `softWipe` \| `none` | No                  | `typewriter`   | `softWipe` reveals pre-laid-out text with a soft left-to-right mask, one laid-out line at a time. `none` renders instantly.     |
-| `softWipe`     | object                               | No                  | see below      | Parameters used when `revealEffect: softWipe`.                                                                                  |
-| `indicator`    | object                               | No                  | -              | Revealing/complete icon config + offset.                                                                                        |
-| `complete`     | object                               | No                  | -              | Parsed and kept in computed node.                                                                                               |
+| Field                       | Type                                 | Required            | Default        | Notes                                                                                                                           |
+| --------------------------- | ------------------------------------ | ------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                        | string                               | Yes                 | -              | Element id.                                                                                                                     |
+| `type`                      | string                               | Yes                 | -              | Must be `text-revealing`.                                                                                                       |
+| `x`                         | number                               | Yes (public schema) | `0` at runtime | Position before anchor transform.                                                                                               |
+| `y`                         | number                               | Yes (public schema) | `0` at runtime | Position before anchor transform.                                                                                               |
+| `content`                   | array                                | No                  | `[]`           | Array of rich text segments.                                                                                                    |
+| `width`                     | number                               | No                  | auto           | If omitted, parser uses a 500px wrap basis for layout measurement.                                                              |
+| `anchorX`                   | number                               | No                  | `0`            | Anchor offset ratio.                                                                                                            |
+| `anchorY`                   | number                               | No                  | `0`            | Anchor offset ratio.                                                                                                            |
+| `alpha`                     | number                               | No                  | `1`            | Opacity `0..1`.                                                                                                                 |
+| `textStyle`                 | object                               | No                  | text defaults  | Base style for segments.                                                                                                        |
+| `speed`                     | number                               | No                  | `50`           | Uses a curved `0..100` scale. `0..99` gets progressively faster with extra control in the upper range; `100` renders instantly. |
+| `initialRevealedCharacters` | number                               | No                  | `0`            | Leading characters to paint as already revealed before the animation starts.                                                    |
+| `revealEffect`              | `typewriter` \| `softWipe` \| `none` | No                  | `typewriter`   | `softWipe` reveals pre-laid-out text with a soft left-to-right mask, one laid-out line at a time. `none` renders instantly.     |
+| `softWipe`                  | object                               | No                  | see below      | Parameters used when `revealEffect: softWipe`.                                                                                  |
+| `indicator`                 | object                               | No                  | -              | Revealing/complete icon config + offset.                                                                                        |
+| `complete`                  | object                               | No                  | -              | Parsed and kept in computed node.                                                                                               |
 
 ### `content[]` item shape
 
@@ -41,6 +41,18 @@ Try it in the [Playground](/playground/?template=text-revealing).
 | `text`      | string | Yes      | Segment text.                                        |
 | `textStyle` | object | No       | Overrides root style.                                |
 | `furigana`  | object | No       | `{ text, textStyle }` rendered above parent segment. |
+
+### `textStyle.shadow`
+
+`text-revealing` uses the same text shadow interface as `text`. Segment and furigana styles inherit the root `textStyle.shadow`; set `shadow: null` on a segment or furigana style to remove it.
+
+| Field     | Type   | Default |
+| --------- | ------ | ------- |
+| `color`   | string | `black` |
+| `alpha`   | number | `1`     |
+| `blur`    | number | `0`     |
+| `offsetX` | number | `2`     |
+| `offsetY` | number | `2`     |
 
 ### `indicator`
 
@@ -100,6 +112,12 @@ elements:
       fill: "#ffffff"
       fontSize: 34
       lineHeight: 1.3
+      shadow:
+        color: "#000000"
+        alpha: 0.45
+        blur: 5
+        offsetX: 0
+        offsetY: 4
     content:
       - text: "漢字"
         furigana:
@@ -107,6 +125,7 @@ elements:
           textStyle:
             fontSize: 14
             fill: "#ffd166"
+            shadow: null
       - text: " mixed with English text."
 ```
 

--- a/playground/pages/docs/nodes/text.md
+++ b/playground/pages/docs/nodes/text.md
@@ -15,21 +15,21 @@ Try it in the [Playground](/playground/?template=interactive-elements).
 
 ## Field Reference
 
-| Field        | Type   | Required            | Default         | Notes                                       |
-| ------------ | ------ | ------------------- | --------------- | ------------------------------------------- |
-| `id`         | string | Yes                 | -               | Element id.                                 |
-| `type`       | string | Yes                 | -               | Must be `text`.                             |
-| `x`          | number | Yes (public schema) | `0` at runtime  | Position before anchor transform.           |
-| `y`          | number | Yes (public schema) | `0` at runtime  | Position before anchor transform.           |
-| `content`    | string | No                  | `""`            | Converted to string at parse time.          |
+| Field        | Type   | Required            | Default         | Notes                                                                    |
+| ------------ | ------ | ------------------- | --------------- | ------------------------------------------------------------------------ |
+| `id`         | string | Yes                 | -               | Element id.                                                              |
+| `type`       | string | Yes                 | -               | Must be `text`.                                                          |
+| `x`          | number | Yes (public schema) | `0` at runtime  | Position before anchor transform.                                        |
+| `y`          | number | Yes (public schema) | `0` at runtime  | Position before anchor transform.                                        |
+| `content`    | string | No                  | `""`            | Converted to string at parse time.                                       |
 | `width`      | number | No                  | auto            | Fixed layout box width. Also enables wrapping (`wordWrapWidth = width`). |
-| `anchorX`    | number | No                  | `0`             | Can be outside `0..1`.                      |
-| `anchorY`    | number | No                  | `0`             | Can be outside `0..1`.                      |
-| `alpha`      | number | No                  | `1`             | Opacity `0..1`.                             |
-| `textStyle`  | object | No                  | engine defaults | See table below.                            |
-| `hover`      | object | No                  | -               | Hover style, cursor, sound, payload.        |
-| `click`      | object | No                  | -               | Press style, sound, payload.                |
-| `rightClick` | object | No                  | -               | Right-press style, sound, payload.          |
+| `anchorX`    | number | No                  | `0`             | Can be outside `0..1`.                                                   |
+| `anchorY`    | number | No                  | `0`             | Can be outside `0..1`.                                                   |
+| `alpha`      | number | No                  | `1`             | Opacity `0..1`.                                                          |
+| `textStyle`  | object | No                  | engine defaults | See table below.                                                         |
+| `hover`      | object | No                  | -               | Hover style, cursor, sound, payload.                                     |
+| `click`      | object | No                  | -               | Press style, sound, payload.                                             |
+| `rightClick` | object | No                  | -               | Right-press style, sound, payload.                                       |
 
 ### `textStyle`
 
@@ -45,6 +45,19 @@ Try it in the [Playground](/playground/?template=interactive-elements).
 | `wordWrapWidth` | number                        | `0`           |
 | `strokeColor`   | string                        | `transparent` |
 | `strokeWidth`   | number                        | `0`           |
+| `shadow`        | object \| null                | -             |
+
+### `textStyle.shadow`
+
+`shadow` enables a single text shadow. Omit it for no shadow. Set it to `null` inside an interaction style to remove a base shadow for that state.
+
+| Field     | Type   | Default |
+| --------- | ------ | ------- |
+| `color`   | string | `black` |
+| `alpha`   | number | `1`     |
+| `blur`    | number | `0`     |
+| `offsetX` | number | `2`     |
+| `offsetY` | number | `2`     |
 
 ## Layout Notes
 
@@ -86,11 +99,20 @@ elements:
       fontSize: 42
       strokeColor: "#000000"
       strokeWidth: 4
+      shadow:
+        color: "#000000"
+        alpha: 0.45
+        blur: 6
+        offsetX: 0
+        offsetY: 4
     hover:
       cursor: pointer
       soundSrc: hover-sfx
       textStyle:
         fill: "#ffdd55"
+        shadow:
+          alpha: 0.8
+          blur: 8
       payload:
         action: menuHover
         target: start

--- a/spec/elements/textHoverLayout.spec.js
+++ b/spec/elements/textHoverLayout.spec.js
@@ -2,6 +2,7 @@ import { Container } from "pixi.js";
 import { describe, expect, it, vi } from "vitest";
 import { addText } from "../../src/plugins/elements/text/addText.js";
 import { parseText } from "../../src/plugins/elements/text/parseText.js";
+import { getTextLayoutPosition } from "../../src/plugins/elements/text/textLayout.js";
 
 const createSharedParams = () => ({
   app: {
@@ -182,6 +183,143 @@ describe("text hover layout", () => {
     });
   });
 
+  it("maps shadow to Pixi dropShadow options", () => {
+    const parent = new Container();
+    const shared = createSharedParams();
+    const element = parseText({
+      state: {
+        id: "text-shadow-style",
+        type: "text",
+        x: 20,
+        y: 30,
+        alpha: 1,
+        content: "Shadowed",
+        textStyle: {
+          fontSize: 24,
+          fontFamily: "Arial",
+          fill: "#FFFFFF",
+          shadow: {
+            color: "#112233",
+            alpha: 0.5,
+            blur: 4,
+            offsetX: 3,
+            offsetY: 4,
+          },
+        },
+      },
+    });
+
+    addText({
+      ...shared,
+      parent,
+      zIndex: 0,
+      element,
+    });
+
+    const text = parent.getChildByLabel("text-shadow-style");
+
+    expect(text.style.dropShadow).toMatchObject({
+      color: "#112233",
+      alpha: 0.5,
+      blur: 4,
+      distance: 5,
+    });
+    expect(text.style.dropShadow.angle).toBeCloseTo(Math.atan2(4, 3), 8);
+    expect(text.style.padding).toBe(9);
+  });
+
+  it("deep-merges and removes shadow in interactive textStyle states", () => {
+    const parent = new Container();
+    const shared = createSharedParams();
+    const element = parseText({
+      state: {
+        id: "text-interactive-shadow",
+        type: "text",
+        x: 20,
+        y: 30,
+        alpha: 1,
+        content: "Interactive shadow",
+        textStyle: {
+          fontSize: 24,
+          fontFamily: "Arial",
+          fill: "#A6A6A6",
+          shadow: {
+            color: "#111111",
+            alpha: 0.35,
+            blur: 3,
+            offsetX: 2,
+            offsetY: 5,
+          },
+        },
+        hover: {
+          textStyle: {
+            fill: "#FFFFFF",
+            shadow: {
+              color: "#333333",
+              alpha: 0.85,
+            },
+          },
+        },
+        click: {
+          textStyle: {
+            shadow: null,
+          },
+        },
+      },
+    });
+
+    addText({
+      ...shared,
+      parent,
+      zIndex: 0,
+      element,
+    });
+
+    const text = parent.getChildByLabel("text-interactive-shadow");
+    const baseDistance = Math.hypot(2, 5);
+    const baseAngle = Math.atan2(5, 2);
+
+    expect(text.style.dropShadow).toMatchObject({
+      color: "#111111",
+      alpha: 0.35,
+      blur: 3,
+      distance: baseDistance,
+    });
+
+    text.emit("pointerover");
+
+    expect(text.style.fill).toBe("#FFFFFF");
+    expect(text.style.dropShadow).toMatchObject({
+      color: "#333333",
+      alpha: 0.85,
+      blur: 3,
+      distance: baseDistance,
+    });
+    expect(text.style.dropShadow.angle).toBeCloseTo(baseAngle, 8);
+
+    text.emit("pointerdown");
+
+    expect(text.style.dropShadow).toBeNull();
+
+    text.emit("pointerup");
+
+    expect(text.style.dropShadow).toMatchObject({
+      color: "#333333",
+      alpha: 0.85,
+      blur: 3,
+      distance: baseDistance,
+    });
+
+    text.emit("pointerout");
+
+    expect(text.style.dropShadow).toMatchObject({
+      color: "#111111",
+      alpha: 0.35,
+      blur: 3,
+      distance: baseDistance,
+    });
+  });
+
   it("positions centered fixed-width text inside the layout box", () => {
     const parent = new Container();
     const shared = createSharedParams();
@@ -214,6 +352,50 @@ describe("text hover layout", () => {
     expect(text.y).toBe(element.y);
   });
 
+  it("positions centered fixed-width text with shadows by glyph width", () => {
+    const parent = new Container();
+    const shared = createSharedParams();
+    const element = parseText({
+      state: {
+        id: "text-fixed-center-shadow",
+        type: "text",
+        x: 40,
+        y: 60,
+        width: 260,
+        content: "Centered",
+        textStyle: {
+          fontSize: 24,
+          fontFamily: "Arial",
+          fill: "#FFFFFF",
+          align: "center",
+          shadow: {
+            color: "#737373",
+            blur: 0,
+            offsetX: 12,
+            offsetY: 0,
+          },
+        },
+      },
+    });
+
+    addText({
+      ...shared,
+      parent,
+      zIndex: 0,
+      element,
+    });
+
+    const text = parent.getChildByLabel("text-fixed-center-shadow");
+    const targetPosition = getTextLayoutPosition(element);
+
+    expect(text.width).toBeGreaterThan(element.measuredWidth);
+    expect(text.x).toBeCloseTo(targetPosition.x, 4);
+    expect(text.x).toBeCloseTo(
+      element.x + (element.width - element.measuredWidth) / 2,
+      4,
+    );
+  });
+
   it("positions right-aligned fixed-width text inside the layout box", () => {
     const parent = new Container();
     const shared = createSharedParams();
@@ -244,6 +426,50 @@ describe("text hover layout", () => {
     const text = parent.getChildByLabel("text-fixed-right");
     expect(text.x).toBeCloseTo(element.x + element.width - text.width, 4);
     expect(text.y).toBe(element.y);
+  });
+
+  it("positions right-aligned fixed-width text with shadows by glyph width", () => {
+    const parent = new Container();
+    const shared = createSharedParams();
+    const element = parseText({
+      state: {
+        id: "text-fixed-right-shadow",
+        type: "text",
+        x: 40,
+        y: 60,
+        width: 260,
+        content: "Right",
+        textStyle: {
+          fontSize: 24,
+          fontFamily: "Arial",
+          fill: "#FFFFFF",
+          align: "right",
+          shadow: {
+            color: "#737373",
+            blur: 0,
+            offsetX: 12,
+            offsetY: 0,
+          },
+        },
+      },
+    });
+
+    addText({
+      ...shared,
+      parent,
+      zIndex: 0,
+      element,
+    });
+
+    const text = parent.getChildByLabel("text-fixed-right-shadow");
+    const targetPosition = getTextLayoutPosition(element);
+
+    expect(text.width).toBeGreaterThan(element.measuredWidth);
+    expect(text.x).toBeCloseTo(targetPosition.x, 4);
+    expect(text.x).toBeCloseTo(
+      element.x + element.width - element.measuredWidth,
+      4,
+    );
   });
 
   it("keeps a fixed-width box anchor stable when hover styles change text metrics", () => {
@@ -286,7 +512,11 @@ describe("text hover layout", () => {
 
     const text = parent.getChildByLabel("text-fixed-width-hover-layout");
     const getBoxCenter = () => {
-      const offset = getHorizontalOffset(element.width, text.width, text.style.align);
+      const offset = getHorizontalOffset(
+        element.width,
+        text.width,
+        text.style.align,
+      );
       return {
         x: text.x - offset + element.width * 0.5,
         y: text.y + text.height * 0.5,
@@ -304,5 +534,62 @@ describe("text hover layout", () => {
 
     expect(getBoxCenter().x).toBeCloseTo(beforeHoverAnchor.x, 4);
     expect(getBoxCenter().y).toBeCloseTo(beforeHoverAnchor.y, 4);
+  });
+
+  it("keeps fixed-width aligned text stable when only shadow metrics change", () => {
+    const parent = new Container();
+    const shared = createSharedParams();
+    const element = parseText({
+      state: {
+        id: "text-fixed-shadow-hover-layout",
+        type: "text",
+        x: 80,
+        y: 120,
+        width: 260,
+        alpha: 1,
+        content: "Shadow hover",
+        textStyle: {
+          fontSize: 24,
+          fontFamily: "Arial",
+          fill: "#FFFFFF",
+          align: "center",
+          shadow: {
+            color: "#737373",
+            blur: 0,
+            offsetX: 4,
+            offsetY: 0,
+          },
+        },
+        hover: {
+          textStyle: {
+            shadow: {
+              offsetX: 28,
+            },
+          },
+        },
+      },
+    });
+
+    addText({
+      ...shared,
+      parent,
+      zIndex: 0,
+      element,
+    });
+
+    const text = parent.getChildByLabel("text-fixed-shadow-hover-layout");
+    const beforeHoverX = text.x;
+    const beforeHoverWidth = text.width;
+
+    text.emit("pointerover");
+
+    expect(text.style.dropShadow.distance).toBe(28);
+    expect(text.width).toBeGreaterThan(beforeHoverWidth);
+    expect(text.x).toBeCloseTo(beforeHoverX, 4);
+
+    text.emit("pointerout");
+
+    expect(text.style.dropShadow.distance).toBe(4);
+    expect(text.x).toBeCloseTo(beforeHoverX, 4);
   });
 });

--- a/spec/elements/textRevealingRuntime.initialRevealedCharacters.spec.js
+++ b/spec/elements/textRevealingRuntime.initialRevealedCharacters.spec.js
@@ -70,8 +70,9 @@ const runReveal = async ({ element, playback = "autoplay", signal } = {}) => {
 };
 
 const getSoftWipeStartAction = (animationBus) =>
-  animationBus.dispatch.mock.calls.find(([action]) => action.type === "START")
-    ?.[0];
+  animationBus.dispatch.mock.calls.find(
+    ([action]) => action.type === "START",
+  )?.[0];
 
 const getLineContainer = (container, element, lineIndex = 0) =>
   container
@@ -100,8 +101,9 @@ describe("runTextReveal initialRevealedCharacters", () => {
     });
     const initialText = getRenderedText(container);
 
-    expect(initialText.startsWith(fullText.slice(0, initialRevealedCharacters)))
-      .toBe(true);
+    expect(
+      initialText.startsWith(fullText.slice(0, initialRevealedCharacters)),
+    ).toBe(true);
     expect(initialText.length).toBeGreaterThan(initialRevealedCharacters);
     expect(initialText.length).toBeLessThan(fullText.length);
 
@@ -139,7 +141,8 @@ describe("runTextReveal initialRevealedCharacters", () => {
     const container = new Container();
     const completionTracker = createCompletionTracker();
     const animationBus = { dispatch: vi.fn() };
-    const fullText = "Prefix resumes from the live snapshot, not the old offset.";
+    const fullText =
+      "Prefix resumes from the live snapshot, not the old offset.";
     const element = createTextRevealingElement({
       content: [{ text: fullText }],
       initialRevealedCharacters: "Prefix ".length,
@@ -192,7 +195,8 @@ describe("runTextReveal initialRevealedCharacters", () => {
   });
 
   it("starts softWipe from a shifted prefix time", async () => {
-    const fullText = "Soft wipe should continue from an already visible prefix.";
+    const fullText =
+      "Soft wipe should continue from an already visible prefix.";
     const softWipe = {
       easing: "linear",
       softness: 0,
@@ -230,6 +234,42 @@ describe("runTextReveal initialRevealedCharacters", () => {
 
     baselineStart.payload.onCancel();
     shiftedStart.payload.onCancel();
+  });
+
+  it("keeps overlapped softWipe lines hidden after a completed prefix line", async () => {
+    const firstLine = "First soft wipe line";
+    const secondLine = "Second soft wipe line";
+    const element = createTextRevealingElement({
+      content: [{ text: `${firstLine}\n${secondLine}` }],
+      revealEffect: "softWipe",
+      softWipe: {
+        easing: "linear",
+        softness: 0,
+        lineOverlap: 0.5,
+      },
+      initialRevealedCharacters: firstLine.length,
+    });
+    const { container, animationBus } = await runReveal({ element });
+    const startAction = getSoftWipeStartAction(animationBus);
+
+    expect(startAction?.payload).toBeDefined();
+
+    startAction.payload.applyFrame(0);
+
+    const indicator = container.children[1];
+    const firstChunkIndicatorY =
+      element.content[0].y +
+      element.content[0].lineMaxHeight -
+      indicator.height;
+    const secondChunkIndicatorY =
+      element.content[1].y +
+      element.content[1].lineMaxHeight -
+      indicator.height;
+
+    expect(indicator.y).toBe(firstChunkIndicatorY);
+    expect(indicator.y).not.toBe(secondChunkIndicatorY);
+
+    startAction.payload.onCancel();
   });
 
   it("renders a paused-initial softWipe prefix without dispatching animation work", async () => {

--- a/spec/parser/parseTextRevealing.shadow.spec.js
+++ b/spec/parser/parseTextRevealing.shadow.spec.js
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { parseTextRevealing } from "../../src/plugins/elements/text-revealing/parseTextRevealing.js";
+
+describe("parseTextRevealing text shadow", () => {
+  it("keeps shadow offsets out of segmented text advances", () => {
+    const withoutShadow = parseTextRevealing({
+      state: {
+        id: "plain-dialogue",
+        type: "text-revealing",
+        x: 0,
+        y: 0,
+        width: 480,
+        textStyle: {
+          fontSize: 24,
+          fontFamily: "Arial",
+        },
+        content: [{ text: "A" }, { text: "B" }],
+      },
+    });
+    const withShadow = parseTextRevealing({
+      state: {
+        id: "shadowed-dialogue",
+        type: "text-revealing",
+        x: 0,
+        y: 0,
+        width: 480,
+        textStyle: {
+          fontSize: 24,
+          fontFamily: "Arial",
+          shadow: {
+            offsetX: 10,
+            offsetY: 0,
+          },
+        },
+        content: [{ text: "A" }, { text: "B" }],
+      },
+    });
+
+    expect(withShadow.content[0].lineParts[1].x).toBe(
+      withoutShadow.content[0].lineParts[1].x,
+    );
+  });
+
+  it("inherits, deep-merges, and removes shadow across segment styles", () => {
+    const parsed = parseTextRevealing({
+      state: {
+        id: "shadowed-dialogue",
+        type: "text-revealing",
+        x: 0,
+        y: 0,
+        width: 480,
+        textStyle: {
+          fontSize: 24,
+          fontFamily: "Arial",
+          fill: "#FFFFFF",
+          shadow: {
+            color: "#111111",
+            alpha: 0.4,
+            blur: 3,
+            offsetX: 2,
+            offsetY: 4,
+          },
+        },
+        content: [
+          {
+            text: "Base shadow. ",
+          },
+          {
+            text: "Merged shadow.",
+            textStyle: {
+              fill: "#D9D9D9",
+              shadow: {
+                color: "#333333",
+                alpha: 0.9,
+              },
+            },
+          },
+          {
+            text: " Ruby",
+            furigana: {
+              text: "ru",
+              textStyle: {
+                fontSize: 12,
+                shadow: null,
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const [basePart, mergedPart, rubyPart] = parsed.content[0].lineParts;
+
+    expect(basePart.textStyle.shadow).toEqual({
+      color: "#111111",
+      alpha: 0.4,
+      blur: 3,
+      offsetX: 2,
+      offsetY: 4,
+    });
+    expect(mergedPart.textStyle.shadow).toEqual({
+      color: "#333333",
+      alpha: 0.9,
+      blur: 3,
+      offsetX: 2,
+      offsetY: 4,
+    });
+    expect(rubyPart.furigana.textStyle.shadow).toBeNull();
+  });
+});

--- a/spec/util/toPixiTextStyle.spec.js
+++ b/spec/util/toPixiTextStyle.spec.js
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_TEXT_SHADOW,
+  toPixiTextStyle,
+} from "../../src/util/toPixiTextStyle.js";
+
+describe("toPixiTextStyle", () => {
+  it("maps public shadow offsets to Pixi dropShadow distance and angle", () => {
+    const style = toPixiTextStyle({
+      fill: "#ffffff",
+      shadow: {
+        color: "#112233",
+        alpha: 0.45,
+        blur: 6,
+        offsetX: 3,
+        offsetY: 4,
+      },
+    });
+
+    expect(style).not.toHaveProperty("shadow");
+    expect(style).not.toHaveProperty("dropShadowColor");
+    expect(style.dropShadow).toMatchObject({
+      color: "#112233",
+      alpha: 0.45,
+      blur: 6,
+      distance: 5,
+    });
+    expect(style.dropShadow.angle).toBeCloseTo(Math.atan2(4, 3), 8);
+    expect(style.padding).toBe(11);
+  });
+
+  it("uses visible defaults when shadow is enabled with an empty object", () => {
+    const style = toPixiTextStyle({
+      shadow: {},
+    });
+
+    expect(style.dropShadow).toMatchObject({
+      color: DEFAULT_TEXT_SHADOW.color,
+      alpha: DEFAULT_TEXT_SHADOW.alpha,
+      blur: DEFAULT_TEXT_SHADOW.blur,
+      distance: Math.hypot(
+        DEFAULT_TEXT_SHADOW.offsetX,
+        DEFAULT_TEXT_SHADOW.offsetY,
+      ),
+    });
+  });
+
+  it("maps null shadow to a disabled Pixi dropShadow", () => {
+    const style = toPixiTextStyle({
+      shadow: null,
+    });
+
+    expect(style.dropShadow).toBeNull();
+    expect(style).not.toHaveProperty("padding");
+  });
+
+  it("does not expose Pixi dropShadow as public pass-through input", () => {
+    const style = toPixiTextStyle({
+      dropShadow: {
+        color: "#ff0000",
+        distance: 100,
+      },
+    });
+
+    expect(style).not.toHaveProperty("dropShadow");
+  });
+
+  it("can omit dropShadow for text measurement styles", () => {
+    const style = toPixiTextStyle(
+      {
+        padding: 2,
+        shadow: {
+          offsetX: 8,
+          offsetY: 0,
+        },
+      },
+      { includeShadow: false },
+    );
+
+    expect(style).not.toHaveProperty("dropShadow");
+    expect(style.padding).toBe(2);
+  });
+});

--- a/src/plugins/elements/input/inputShared.js
+++ b/src/plugins/elements/input/inputShared.js
@@ -114,7 +114,8 @@ const getHorizontalOffset = (layoutWidth, measuredWidth, align) => {
   return 0;
 };
 
-const createMeasuredStyle = (style) => new TextStyle(toPixiTextStyle(style));
+const createMeasuredStyle = (style) =>
+  new TextStyle(toPixiTextStyle(style, { includeShadow: false }));
 
 const measureWidth = (text, style) =>
   CanvasTextMetrics.measureText(text, createMeasuredStyle(style)).width;

--- a/src/plugins/elements/text-revealing/parseTextRevealing.js
+++ b/src/plugins/elements/text-revealing/parseTextRevealing.js
@@ -2,6 +2,7 @@ import { CanvasTextMetrics, TextStyle } from "pixi.js";
 import { parseCommonObject } from "../util/parseCommonObject.js";
 import { DEFAULT_TEXT_STYLE } from "../../../types.js";
 import { toPixiTextStyle } from "../../../util/toPixiTextStyle.js";
+import { mergeTextStyle } from "../../../util/mergeTextStyle.js";
 import { normalizeSoftWipeConfig } from "./softWipeConfig.js";
 
 const normalizeInitialRevealedCharacters = (value) => {
@@ -165,7 +166,9 @@ const createTextChunks = (segments, wordWrapWidth) => {
 
     const measurements = CanvasTextMetrics.measureText(
       segment.text,
-      new TextStyle(toPixiTextStyle(styleWithWordWrap)),
+      new TextStyle(
+        toPixiTextStyle(styleWithWordWrap, { includeShadow: false }),
+      ),
     );
 
     // Check if text fits on current line
@@ -227,7 +230,7 @@ const createTextChunks = (segments, wordWrapWidth) => {
     const measurementsWithNoWrapping = CanvasTextMetrics.measureText(
       textPart,
       new TextStyle({
-        ...toPixiTextStyle(segment.textStyle),
+        ...toPixiTextStyle(segment.textStyle, { includeShadow: false }),
         wordWrap: false,
         breakWords: false,
       }),
@@ -254,7 +257,11 @@ const createTextChunks = (segments, wordWrapWidth) => {
 
       const furiganaMeasurements = CanvasTextMetrics.measureText(
         segment.furigana.text,
-        new TextStyle(toPixiTextStyle(segment.furigana.textStyle)),
+        new TextStyle(
+          toPixiTextStyle(segment.furigana.textStyle, {
+            includeShadow: false,
+          }),
+        ),
       );
 
       // Calculate furigana position relative to current line's max height
@@ -340,18 +347,17 @@ const createTextChunks = (segments, wordWrapWidth) => {
  * @returns {TextRevealingComputedNode}
  */
 export const parseTextRevealing = ({ state }) => {
-  const defaultTextStyle = {
-    ...DEFAULT_TEXT_STYLE,
-    wordWrap: true,
-    ...(state.textStyle || {}),
-  };
+  const defaultTextStyle = mergeTextStyle(
+    {
+      ...DEFAULT_TEXT_STYLE,
+      wordWrap: true,
+    },
+    state.textStyle,
+  );
 
   const processedContent = (state.content || []).map((item) => {
     // TODO: if breakwords is true this will crash
-    const itemTextStyle = {
-      ...defaultTextStyle,
-      ...(item.textStyle || {}),
-    };
+    const itemTextStyle = mergeTextStyle(defaultTextStyle, item.textStyle);
 
     itemTextStyle.lineHeight = Math.round(
       itemTextStyle.lineHeight * itemTextStyle.fontSize,
@@ -364,10 +370,10 @@ export const parseTextRevealing = ({ state }) => {
 
     let furigana = null;
     if (item.furigana) {
-      const furiganaTextStyle = {
-        ...defaultTextStyle,
-        ...(item.furigana.textStyle || {}),
-      };
+      const furiganaTextStyle = mergeTextStyle(
+        defaultTextStyle,
+        item.furigana.textStyle,
+      );
 
       furiganaTextStyle.lineHeight = Math.round(
         furiganaTextStyle.lineHeight * furiganaTextStyle.fontSize,
@@ -437,7 +443,6 @@ export const parseTextRevealing = ({ state }) => {
     content: chunks,
     textStyle: {
       ...defaultTextStyle,
-      ...(state.textStyle || {}),
     },
     speed: state.speed ?? 50,
     revealEffect: state.revealEffect ?? "typewriter",

--- a/src/plugins/elements/text-revealing/textRevealingRuntime.js
+++ b/src/plugins/elements/text-revealing/textRevealingRuntime.js
@@ -607,39 +607,70 @@ const getInverseSoftWipeProgress = ({ progress, easingName }) => {
   return clampedProgress;
 };
 
-const getSoftWipeInitialTime = ({
+const createSoftWipeInitialTimeline = ({
   timedLines,
-  duration,
   initialRevealedCharacters,
+  softWipe,
   easingName,
 }) => {
   let remainingCharacters = Math.max(0, Math.floor(initialRevealedCharacters));
+  let reachedRevealBoundary = remainingCharacters <= 0;
+  let nextStartTime = 0;
+  let totalDuration = 0;
 
-  if (remainingCharacters <= 0) {
-    return 0;
-  }
-
-  for (const line of timedLines) {
+  const adjustedTimedLines = timedLines.map((line) => {
     const lineCharacters = Math.max(0, line.totalCharacters ?? 0);
+    let rawInitialProgress = 0;
+    let completedByInitialReveal = false;
 
-    if (lineCharacters <= 0) {
-      continue;
+    if (!reachedRevealBoundary && remainingCharacters > 0) {
+      if (lineCharacters <= 0 || remainingCharacters >= lineCharacters) {
+        remainingCharacters -= lineCharacters;
+        rawInitialProgress = 1;
+        completedByInitialReveal = true;
+      } else {
+        const easedProgress = remainingCharacters / lineCharacters;
+
+        rawInitialProgress = getInverseSoftWipeProgress({
+          progress: easedProgress,
+          easingName,
+        });
+        remainingCharacters = 0;
+        reachedRevealBoundary = true;
+      }
     }
 
-    if (remainingCharacters <= lineCharacters) {
-      const easedProgress = remainingCharacters / lineCharacters;
-      const rawProgress = getInverseSoftWipeProgress({
-        progress: easedProgress,
-        easingName,
-      });
-
-      return clamp(line.startTime + rawProgress * line.duration, 0, duration);
+    if (completedByInitialReveal) {
+      return {
+        ...line,
+        startTime: -line.duration,
+        endTime: 0,
+      };
     }
 
-    remainingCharacters -= lineCharacters;
-  }
+    reachedRevealBoundary = true;
 
-  return duration;
+    const startTime =
+      rawInitialProgress > 0
+        ? -rawInitialProgress * line.duration
+        : Math.max(0, nextStartTime);
+    const endTime = startTime + line.duration;
+
+    totalDuration = Math.max(totalDuration, endTime);
+    nextStartTime =
+      endTime - line.duration * softWipe.lineOverlap + softWipe.lineDelay;
+
+    return {
+      ...line,
+      startTime,
+      endTime,
+    };
+  });
+
+  return {
+    timedLines: adjustedTimedLines,
+    duration: Math.max(1, Math.ceil(totalDuration)),
+  };
 };
 
 const destroySoftWipeLineMasks = (lineMasks) => {
@@ -823,28 +854,18 @@ const runSoftWipePausedInitialReveal = ({
     1,
     Math.round((totalCharacters / effectiveSpeed) * 1000),
   );
-  const { timedLines, duration } = createSoftWipeLineTimings({
+  const baseTimeline = createSoftWipeLineTimings({
     lines,
     edgeWidth,
     baseDuration,
     softWipe,
   });
-  const startTime = getSoftWipeInitialTime({
-    timedLines,
-    duration,
+  const { timedLines } = createSoftWipeInitialTimeline({
+    timedLines: baseTimeline.timedLines,
     initialRevealedCharacters: revealedCharacters,
+    softWipe,
     easingName: softWipe.easing,
   });
-
-  if (startTime >= duration) {
-    positionIndicatorAtTextEnd(
-      indicatorSprite,
-      lastTextObject,
-      indicatorOffset,
-    );
-    applyCompleteIndicator(indicatorSprite, element);
-    return;
-  }
 
   const lineMasks = createSoftWipeLineMasks({
     contentContainer,
@@ -868,7 +889,7 @@ const runSoftWipePausedInitialReveal = ({
     easing,
     indicatorSprite,
     indicatorOffset,
-    currentTime: startTime,
+    currentTime: 0,
   });
 };
 
@@ -885,11 +906,14 @@ const runSoftWipeReveal = ({
   const { lines, lastTextObject, lastChunk, totalCharacters, maxLineHeight } =
     buildFullTextContent(contentContainer, element);
 
+  const initialRevealedCharacters = getInitialRevealedCharacters(element);
+
   positionIndicatorForChunk(indicatorSprite, lastChunk, indicatorOffset);
 
   if (
     lines.length === 0 ||
     totalCharacters === 0 ||
+    initialRevealedCharacters >= totalCharacters ||
     !lines.some((line) => line.bounds.width > 0 && line.bounds.height > 0) ||
     !globalThis.document ||
     !animationBus
@@ -910,29 +934,18 @@ const runSoftWipeReveal = ({
     1,
     Math.round((totalCharacters / effectiveSpeed) * 1000),
   );
-  const { timedLines, duration } = createSoftWipeLineTimings({
+  const baseTimeline = createSoftWipeLineTimings({
     lines,
     edgeWidth,
     baseDuration,
     softWipe,
   });
-  const initialRevealedCharacters = getInitialRevealedCharacters(element);
-  const startTime = getSoftWipeInitialTime({
-    timedLines,
-    duration,
+  const { timedLines, duration } = createSoftWipeInitialTimeline({
+    timedLines: baseTimeline.timedLines,
     initialRevealedCharacters,
+    softWipe,
     easingName: softWipe.easing,
   });
-
-  if (startTime >= duration) {
-    positionIndicatorAtTextEnd(
-      indicatorSprite,
-      lastTextObject,
-      indicatorOffset,
-    );
-    applyCompleteIndicator(indicatorSprite, element);
-    return false;
-  }
 
   const stateVersion = completionTracker.getVersion();
   const animationId = `${element.id}-soft-wipe`;
@@ -998,14 +1011,13 @@ const runSoftWipeReveal = ({
 
   registerTextRevealRuntime(container, finalizeCleanup);
   completionTracker.track(stateVersion);
-  const remainingDuration = Math.max(1, Math.ceil(duration - startTime));
 
   animationBus.dispatch({
     type: "START",
     payload: {
       id: animationId,
       driver: "custom",
-      duration: remainingDuration,
+      duration,
       applyFrame: (currentTime) => {
         applySoftWipeFrame({
           timedLines,
@@ -1013,7 +1025,7 @@ const runSoftWipeReveal = ({
           easing,
           indicatorSprite,
           indicatorOffset,
-          currentTime: Math.min(duration, startTime + currentTime),
+          currentTime: Math.min(duration, currentTime),
         });
       },
       applyTargetState: () => {

--- a/src/plugins/elements/text/parseText.js
+++ b/src/plugins/elements/text/parseText.js
@@ -2,6 +2,7 @@ import { CanvasTextMetrics, TextStyle } from "pixi.js";
 import { parseCommonObject } from "../util/parseCommonObject.js";
 import { DEFAULT_TEXT_STYLE } from "../../../types.js";
 import { toPixiTextStyle } from "../../../util/toPixiTextStyle.js";
+import { mergeTextStyle } from "../../../util/mergeTextStyle.js";
 
 /**
  * @typedef {import('../../../types.js').BaseElement} BaseElement
@@ -16,10 +17,7 @@ import { toPixiTextStyle } from "../../../util/toPixiTextStyle.js";
  * @returns {TextComputedNode}
  */
 export const parseText = ({ state }) => {
-  const textStyle = {
-    ...DEFAULT_TEXT_STYLE,
-    ...state.textStyle,
-  };
+  const textStyle = mergeTextStyle(DEFAULT_TEXT_STYLE, state.textStyle);
 
   textStyle.lineHeight = Math.round(textStyle.fontSize * textStyle.lineHeight);
 
@@ -34,7 +32,7 @@ export const parseText = ({ state }) => {
 
   const { width, height } = CanvasTextMetrics.measureText(
     contentString,
-    new TextStyle(toPixiTextStyle(textStyle)),
+    new TextStyle(toPixiTextStyle(textStyle, { includeShadow: false })),
   );
 
   // Round pixel calculations

--- a/src/plugins/elements/text/textLayout.js
+++ b/src/plugins/elements/text/textLayout.js
@@ -1,5 +1,8 @@
+import { CanvasTextMetrics, TextStyle } from "pixi.js";
 import applyTextStyle from "../../../util/applyTextStyle.js";
 import { DEFAULT_TEXT_STYLE } from "../../../types.js";
+import { mergeTextStyle } from "../../../util/mergeTextStyle.js";
+import { toPixiTextStyle } from "../../../util/toPixiTextStyle.js";
 
 const TEXT_ANCHOR_RATIOS = Symbol("routeGraphicsTextAnchorRatios");
 const TEXT_LAYOUT_STATE = Symbol("routeGraphicsTextLayoutState");
@@ -18,7 +21,79 @@ const getLayoutWidth = (textElement) => {
     return layoutState.layoutWidth;
   }
 
+  if (typeof layoutState?.measuredWidth === "number") {
+    return layoutState.measuredWidth;
+  }
+
   return textElement.width;
+};
+
+const measureTextLayout = (textValue, style) => {
+  const metrics = CanvasTextMetrics.measureText(
+    String(textValue ?? ""),
+    new TextStyle(toPixiTextStyle(style, { includeShadow: false })),
+  );
+
+  return {
+    width: metrics.width,
+    height: metrics.height,
+  };
+};
+
+const usesTextShadow = (style) =>
+  style?.shadow !== undefined &&
+  style.shadow !== null &&
+  style.shadow !== false;
+
+const getRuntimeTextLayout = (textElement, style) => {
+  if (usesTextShadow(style)) {
+    return measureTextLayout(textElement.text, style);
+  }
+
+  return {
+    width: textElement.width,
+    height: textElement.height,
+  };
+};
+
+const getMeasuredWidth = (textElement) => {
+  const layoutState = textElement[TEXT_LAYOUT_STATE];
+
+  if (typeof layoutState?.measuredWidth === "number") {
+    return layoutState.measuredWidth;
+  }
+
+  return textElement.width;
+};
+
+const getMeasuredHeight = (textElement) => {
+  const layoutState = textElement[TEXT_LAYOUT_STATE];
+
+  if (typeof layoutState?.measuredHeight === "number") {
+    return layoutState.measuredHeight;
+  }
+
+  return textElement.height;
+};
+
+const setTextLayoutState = (textElement, textComputedNode, measurements) => {
+  const fixedWidth = Boolean(textComputedNode.__fixedWidth);
+  const runtimeMeasurements =
+    measurements ??
+    getRuntimeTextLayout(textElement, textComputedNode.textStyle);
+  const measuredWidth =
+    runtimeMeasurements.width ??
+    textComputedNode.measuredWidth ??
+    textComputedNode.width;
+  const measuredHeight =
+    runtimeMeasurements.height ?? textComputedNode.height ?? textElement.height;
+
+  textElement[TEXT_LAYOUT_STATE] = {
+    fixedWidth,
+    layoutWidth: fixedWidth ? textComputedNode.width : measuredWidth,
+    measuredWidth,
+    measuredHeight,
+  };
 };
 
 const getHorizontalOffset = (layoutWidth, measuredWidth, align) => {
@@ -51,11 +126,15 @@ export const getTextLayoutPosition = (textComputedNode) => {
 };
 
 export const syncTextAnchorRatios = (textElement, textComputedNode) => {
+  const measurements = getRuntimeTextLayout(
+    textElement,
+    textComputedNode.textStyle,
+  );
   const width =
     textComputedNode.__fixedWidth && typeof textComputedNode.width === "number"
       ? textComputedNode.width
-      : textElement.width || textComputedNode.width;
-  const height = textElement.height || textComputedNode.height;
+      : measurements.width;
+  const height = measurements.height;
   const anchorXRatio =
     typeof textComputedNode.__anchorXRatio === "number"
       ? textComputedNode.__anchorXRatio
@@ -69,10 +148,7 @@ export const syncTextAnchorRatios = (textElement, textComputedNode) => {
     x: anchorXRatio,
     y: anchorYRatio,
   };
-  textElement[TEXT_LAYOUT_STATE] = {
-    fixedWidth: Boolean(textComputedNode.__fixedWidth),
-    layoutWidth: textComputedNode.width,
-  };
+  setTextLayoutState(textElement, textComputedNode, measurements);
 };
 
 const getLineHeightRatio = (style) => {
@@ -90,10 +166,7 @@ const getLineHeightRatio = (style) => {
 const resolveInteractiveTextStyle = (baseStyle, overrideStyle) => {
   if (!overrideStyle) return baseStyle;
 
-  const resolvedStyle = {
-    ...baseStyle,
-    ...overrideStyle,
-  };
+  const resolvedStyle = mergeTextStyle(baseStyle, overrideStyle);
 
   if (
     overrideStyle.fontSize !== undefined ||
@@ -125,36 +198,49 @@ export const applyInteractiveTextStyle = (
 
   const currentOffsetX = getHorizontalOffset(
     layoutWidth,
-    textElement.width,
+    getMeasuredWidth(textElement),
     getTextAlign(textElement.style),
   );
   const boxPositionX = textElement.x - currentOffsetX;
   const anchorPositionX = boxPositionX + layoutWidth * anchorRatios.x;
-  const anchorPositionY = textElement.y + textElement.height * anchorRatios.y;
+  const anchorPositionY =
+    textElement.y + getMeasuredHeight(textElement) * anchorRatios.y;
 
   applyTextStyle(textElement, resolvedStyle);
 
-  const nextLayoutWidth = getLayoutWidth(textElement);
+  const nextMeasurements = getRuntimeTextLayout(textElement, resolvedStyle);
+  const fixedWidth = textElement[TEXT_LAYOUT_STATE]?.fixedWidth === true;
+  const nextLayoutWidth = fixedWidth ? layoutWidth : nextMeasurements.width;
   const nextOffsetX = getHorizontalOffset(
     nextLayoutWidth,
-    textElement.width,
-    getTextAlign(textElement.style),
+    nextMeasurements.width,
+    getTextAlign(resolvedStyle),
   );
 
   textElement.x =
     anchorPositionX - nextLayoutWidth * anchorRatios.x + nextOffsetX;
-  textElement.y = anchorPositionY - textElement.height * anchorRatios.y;
+  textElement.y = anchorPositionY - nextMeasurements.height * anchorRatios.y;
+  textElement[TEXT_LAYOUT_STATE] = {
+    ...(textElement[TEXT_LAYOUT_STATE] ?? {}),
+    layoutWidth: nextLayoutWidth,
+    measuredWidth: nextMeasurements.width,
+    measuredHeight: nextMeasurements.height,
+  };
 };
 
 export const positionTextInLayoutBox = (textElement, textComputedNode) => {
+  setTextLayoutState(textElement, textComputedNode);
+  const measuredWidth = usesTextShadow(textComputedNode.textStyle)
+    ? (textComputedNode.measuredWidth ?? getMeasuredWidth(textElement))
+    : getMeasuredWidth(textElement);
   const nextPosition = getTextLayoutPosition({
     ...textComputedNode,
-    measuredWidth: textElement.width,
+    measuredWidth,
     width:
       textComputedNode.__fixedWidth &&
       typeof textComputedNode.width === "number"
         ? textComputedNode.width
-        : textElement.width,
+        : measuredWidth,
   });
 
   textElement.x = nextPosition.x;

--- a/src/schemas/elements/text-revealing.computed.yaml
+++ b/src/schemas/elements/text-revealing.computed.yaml
@@ -3,6 +3,35 @@ title: Text Revealing Computed Node
 description: Schema for text revealing computed node after parsing
 type: object
 $def:
+  textShadow:
+    description: Optional text shadow. Null removes a base shadow in resolved segment styles.
+    oneOf:
+      - type: "null"
+      - type: object
+        properties:
+          color:
+            type: string
+            description: Shadow color
+            default: black
+          alpha:
+            type: number
+            description: Shadow opacity (0-1)
+            minimum: 0
+            maximum: 1
+            default: 1
+          blur:
+            type: number
+            description: Shadow blur radius in pixels
+            minimum: 0
+            default: 0
+          offsetX:
+            type: number
+            description: Horizontal shadow offset in pixels
+            default: 2
+          offsetY:
+            type: number
+            description: Vertical shadow offset in pixels
+            default: 2
   textStyle:
     type: object
     properties:
@@ -40,6 +69,8 @@ $def:
       strokeWidth:
         type: number
         description: Text stroke/outline width
+      shadow:
+        "$ref": "#/$def/textShadow"
   softWipe:
     type: object
     description: Parameters for the softWipe reveal effect.

--- a/src/schemas/elements/text-revealing.element.yaml
+++ b/src/schemas/elements/text-revealing.element.yaml
@@ -8,6 +8,35 @@ required:
   - x
   - y
 $def:
+  textShadow:
+    description: Optional text shadow. Use null in a segment style to remove a base shadow.
+    oneOf:
+      - type: "null"
+      - type: object
+        properties:
+          color:
+            type: string
+            description: Shadow color
+            default: black
+          alpha:
+            type: number
+            description: Shadow opacity (0-1)
+            minimum: 0
+            maximum: 1
+            default: 1
+          blur:
+            type: number
+            description: Shadow blur radius in pixels
+            minimum: 0
+            default: 0
+          offsetX:
+            type: number
+            description: Horizontal shadow offset in pixels
+            default: 2
+          offsetY:
+            type: number
+            description: Vertical shadow offset in pixels
+            default: 2
   textStyle:
     type: object
     properties:
@@ -45,6 +74,8 @@ $def:
       strokeWidth:
         type: number
         description: Text stroke/outline width
+      shadow:
+        "$ref": "#/$def/textShadow"
   softWipe:
     type: object
     description: Parameters for the softWipe reveal effect.
@@ -165,6 +196,7 @@ properties:
   softWipe:
     "$ref": "#/$def/softWipe"
   textStyle:
+    "$ref": "#/$def/textStyle"
   complete:
     type: object
     properties:

--- a/src/schemas/elements/text.computed.yaml
+++ b/src/schemas/elements/text.computed.yaml
@@ -3,6 +3,35 @@ title: Text Computed Node
 description: Schema for text computed node after parsing
 type: object
 $def:
+  textShadow:
+    description: Optional text shadow. Null removes a base shadow in resolved interaction styles.
+    oneOf:
+      - type: "null"
+      - type: object
+        properties:
+          color:
+            type: string
+            description: Shadow color
+            default: black
+          alpha:
+            type: number
+            description: Shadow opacity (0-1)
+            minimum: 0
+            maximum: 1
+            default: 1
+          blur:
+            type: number
+            description: Shadow blur radius in pixels
+            minimum: 0
+            default: 0
+          offsetX:
+            type: number
+            description: Horizontal shadow offset in pixels
+            default: 2
+          offsetY:
+            type: number
+            description: Vertical shadow offset in pixels
+            default: 2
   textStyle:
     type: object
     properties:
@@ -44,6 +73,8 @@ $def:
       strokeWidth:
         type: number
         description: Text stroke/outline width
+      shadow:
+        "$ref": "#/$def/textShadow"
 required:
   - id
   - type

--- a/src/schemas/elements/text.element.yaml
+++ b/src/schemas/elements/text.element.yaml
@@ -8,6 +8,35 @@ required:
   - x
   - y
 $def:
+  textShadow:
+    description: Optional text shadow. Use null in an interaction style to remove a base shadow.
+    oneOf:
+      - type: "null"
+      - type: object
+        properties:
+          color:
+            type: string
+            description: Shadow color
+            default: black
+          alpha:
+            type: number
+            description: Shadow opacity (0-1)
+            minimum: 0
+            maximum: 1
+            default: 1
+          blur:
+            type: number
+            description: Shadow blur radius in pixels
+            minimum: 0
+            default: 0
+          offsetX:
+            type: number
+            description: Horizontal shadow offset in pixels
+            default: 2
+          offsetY:
+            type: number
+            description: Vertical shadow offset in pixels
+            default: 2
   textStyle:
     type: object
     properties:
@@ -46,6 +75,8 @@ $def:
       strokeWidth:
         type: number
         description: Text stroke/outline width
+      shadow:
+        "$ref": "#/$def/textShadow"
 properties:
   id:
     type: string

--- a/src/types.js
+++ b/src/types.js
@@ -399,6 +399,15 @@
  */
 
 /**
+ * @typedef {Object} TextShadow
+ * @property {string} [color] - Shadow color
+ * @property {number} [alpha] - Shadow opacity from 0 to 1
+ * @property {number} [blur] - Shadow blur radius in pixels
+ * @property {number} [offsetX] - Horizontal shadow offset in pixels
+ * @property {number} [offsetY] - Vertical shadow offset in pixels
+ */
+
+/**
  * @typedef {Object} TextStyle
  * @property {string} fill - Text color
  * @property {string} fontFamily - Font family
@@ -410,6 +419,7 @@
  * @property {number} wordWrapWidth - Word wrap width
  * @property {string} [strokeColor] - Text stroke/outline color
  * @property {number} [strokeWidth] - Text stroke/outline width
+ * @property {TextShadow | null} [shadow] - Optional text shadow
  */
 
 /**
@@ -726,6 +736,7 @@ export const DEFAULT_TEXT_STYLE = {
  * @property {string} fontFamily - The font family of the text
  * @property {string} strokeColor - The stroke color of the text
  * @property {number} strokeWidth - The stroke width of the text
+ * @property {TextShadow | null} [shadow] - Optional text shadow
  */
 
 /**

--- a/src/util/applyTextStyle.js
+++ b/src/util/applyTextStyle.js
@@ -13,6 +13,9 @@ export default (element, style) => {
     strokeColor: style?.strokeColor ?? DEFAULT_TEXT_STYLE.strokeColor,
     strokeWidth: style?.strokeWidth ?? DEFAULT_TEXT_STYLE.strokeWidth,
     wordWrapWidth: style?.wordWrapWidth ?? DEFAULT_TEXT_STYLE.wordWrapWidth,
+    ...(Object.prototype.hasOwnProperty.call(style ?? {}, "shadow")
+      ? { shadow: style.shadow }
+      : {}),
   };
 
   element.style = toPixiTextStyle(appliedStyle);

--- a/src/util/getCharacterXPositionInATextObject.js
+++ b/src/util/getCharacterXPositionInATextObject.js
@@ -1,8 +1,23 @@
 import { CanvasTextMetrics } from "pixi.js";
 
+const createMeasurementStyle = (style) => {
+  if (!style?.dropShadow || typeof style.clone !== "function") {
+    return style;
+  }
+
+  const measurementStyle = style.clone();
+
+  measurementStyle.dropShadow = null;
+
+  return measurementStyle;
+};
+
 export function getCharacterXPositionInATextObject(textObj, index) {
   const subString = textObj.text.substring(0, index);
-  const metrics = CanvasTextMetrics.measureText(subString, textObj.style);
+  const metrics = CanvasTextMetrics.measureText(
+    subString,
+    createMeasurementStyle(textObj.style),
+  );
   const characterLocalX = metrics.width;
   const characterGlobalX = textObj.x + characterLocalX;
 

--- a/src/util/mergeTextStyle.js
+++ b/src/util/mergeTextStyle.js
@@ -1,0 +1,31 @@
+const isPlainObject = (value) =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+const mergeShadow = (baseShadow, overrideShadow) => {
+  if (overrideShadow === undefined) return baseShadow;
+  if (overrideShadow === null || overrideShadow === false) return null;
+
+  if (isPlainObject(overrideShadow)) {
+    return {
+      ...(isPlainObject(baseShadow) ? baseShadow : {}),
+      ...overrideShadow,
+    };
+  }
+
+  return overrideShadow;
+};
+
+export const mergeTextStyle = (baseStyle = {}, overrideStyle = {}) => {
+  if (!overrideStyle) return { ...baseStyle };
+
+  const mergedStyle = {
+    ...baseStyle,
+    ...overrideStyle,
+  };
+
+  if (Object.prototype.hasOwnProperty.call(overrideStyle, "shadow")) {
+    mergedStyle.shadow = mergeShadow(baseStyle?.shadow, overrideStyle.shadow);
+  }
+
+  return mergedStyle;
+};

--- a/src/util/toPixiTextStyle.js
+++ b/src/util/toPixiTextStyle.js
@@ -1,5 +1,13 @@
 import { DEFAULT_TEXT_STYLE } from "../types.js";
 
+export const DEFAULT_TEXT_SHADOW = {
+  color: "black",
+  alpha: 1,
+  blur: 0,
+  offsetX: 2,
+  offsetY: 2,
+};
+
 const getStrokeStyle = (style = {}) => {
   const baseStroke =
     typeof style.stroke === "object" && style.stroke !== null
@@ -15,11 +23,59 @@ const getStrokeStyle = (style = {}) => {
   };
 };
 
-export const toPixiTextStyle = (style = {}) => {
-  const { strokeColor, strokeWidth, stroke, ...rest } = style;
+const toPixiDropShadow = (shadow) => {
+  if (shadow === undefined) return undefined;
+  if (shadow === null || shadow === false) return null;
+
+  const normalizedShadow =
+    typeof shadow === "object" && shadow !== null
+      ? {
+          ...DEFAULT_TEXT_SHADOW,
+          ...shadow,
+        }
+      : DEFAULT_TEXT_SHADOW;
+  const offsetX = normalizedShadow.offsetX;
+  const offsetY = normalizedShadow.offsetY;
+  const distance = Math.hypot(offsetX, offsetY);
 
   return {
+    alpha: normalizedShadow.alpha,
+    angle: distance === 0 ? 0 : Math.atan2(offsetY, offsetX),
+    blur: normalizedShadow.blur,
+    color: normalizedShadow.color,
+    distance,
+  };
+};
+
+const getShadowPadding = (dropShadow) => {
+  if (!dropShadow) return 0;
+
+  return Math.ceil(Math.max(0, dropShadow.blur) + dropShadow.distance);
+};
+
+export const toPixiTextStyle = (style = {}, options = {}) => {
+  const includeShadow = options.includeShadow !== false;
+  const { strokeColor, strokeWidth, stroke, shadow, ...rest } = style;
+  delete rest.dropShadow;
+
+  const pixiStyle = {
     ...rest,
     stroke: getStrokeStyle({ strokeColor, strokeWidth, stroke }),
   };
+
+  if (includeShadow) {
+    const pixiDropShadow = toPixiDropShadow(shadow);
+    const shadowPadding = getShadowPadding(pixiDropShadow);
+    const padding = Math.max(rest.padding ?? 0, shadowPadding);
+
+    if (shadow !== undefined) {
+      pixiStyle.dropShadow = pixiDropShadow;
+    }
+
+    if (padding > 0) {
+      pixiStyle.padding = padding;
+    }
+  }
+
+  return pixiStyle;
 };

--- a/vt/reference/textbasic/text-shadow-01.webp
+++ b/vt/reference/textbasic/text-shadow-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6d5bbb965a440a427a8d248183e75fdd1c2192a6b77bc0aa48513e3e97eb4a2
+size 21964

--- a/vt/reference/textbasic/text-shadow-02.webp
+++ b/vt/reference/textbasic/text-shadow-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:582780edade55bc8b97b1351bde40eaf5e33270fe034acc80a3407efdb7e5909
+size 19472

--- a/vt/reference/textbasic/text-shadow-03.webp
+++ b/vt/reference/textbasic/text-shadow-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6d5bbb965a440a427a8d248183e75fdd1c2192a6b77bc0aa48513e3e97eb4a2
+size 21964

--- a/vt/reference/textrevealing/update-text-revealing-continue-from-offset-soft-wipe-03.webp
+++ b/vt/reference/textrevealing/update-text-revealing-continue-from-offset-soft-wipe-03.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3e6f5edc04ec8b932dbf22022a40b8b4f8d47a00e6801f303b97820f2a13944
-size 3582
+oid sha256:59d7d594a47ad99b1b8507229bf669164235b69244845faab7db80b14a7c9af8
+size 3618

--- a/vt/reference/textrevealing/update-text-revealing-continue-from-offset-typewriter-03.webp
+++ b/vt/reference/textrevealing/update-text-revealing-continue-from-offset-typewriter-03.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c89dfb328c3c6895c2dcc11806bf7f3946f52c5159d177b32819467b7a1ed8c2
-size 3470
+oid sha256:fa49d7df7a33d55db9b67e5c73ea768288e2e034ed9ab802441ce837feb2ff62
+size 3248

--- a/vt/reference/textrevealing/update-text-revealing-continue-from-offset-typewriter-04.webp
+++ b/vt/reference/textrevealing/update-text-revealing-continue-from-offset-typewriter-04.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7f339c933e79c6735912e2cc904c72c5653b12460e8faf34b16325445bbbcd66
-size 4038
+oid sha256:1f6bcca165b4283e1d6dd4f52f60619c157a4b2e76ebce73e0cb5307dffd280e
+size 3772

--- a/vt/specs/textbasic/text-shadow.yaml
+++ b/vt/specs/textbasic/text-shadow.yaml
@@ -1,0 +1,134 @@
+---
+title: Text Shadow
+description: Text shadow rendering is the subject of this spec, so grayscale shadows are used to verify hard offsets, soft blur, and shadow removal on update.
+specs:
+  - text should render a hard offset shadow from textStyle.shadow
+  - text should render a blurred shadow without clipping the blur edge
+  - text should render an all-direction shadow when blur is set and both offsets are zero
+  - updating textStyle.shadow to null should remove an existing shadow
+steps:
+  - action: keypress
+    key: "n"
+  - action: screenshot
+  - action: keypress
+    key: b
+  - action: screenshot
+---
+states:
+  - elements:
+      - id: hard-shadow
+        type: text
+        x: 56
+        "y": 56
+        content: Hard Shadow
+        textStyle:
+          fontFamily: Arial
+          fontSize: 56
+          fill: "#FFFFFF"
+          shadow:
+            color: "#737373"
+            alpha: 1
+            blur: 0
+            offsetX: 8
+            offsetY: 8
+      - id: soft-shadow
+        type: text
+        x: 56
+        "y": 156
+        content: Soft Shadow
+        textStyle:
+          fontFamily: Arial
+          fontSize: 56
+          fill: "#D9D9D9"
+          shadow:
+            color: "#FFFFFF"
+            alpha: 0.5
+            blur: 8
+            offsetX: 0
+            offsetY: 8
+      - id: removable-shadow
+        type: text
+        x: 56
+        "y": 256
+        content: Shadow Removed On Next State
+        textStyle:
+          fontFamily: Arial
+          fontSize: 44
+          fill: "#FFFFFF"
+          shadow:
+            color: "#737373"
+            alpha: 1
+            blur: 0
+            offsetX: 7
+            offsetY: 7
+      - id: all-direction-shadow
+        type: text
+        x: 56
+        "y": 356
+        content: All Direction Shadow
+        textStyle:
+          fontFamily: Arial
+          fontSize: 50
+          fill: "#D9D9D9"
+          shadow:
+            color: "#FFFFFF"
+            alpha: 0.45
+            blur: 10
+            offsetX: 0
+            offsetY: 0
+  - elements:
+      - id: hard-shadow
+        type: text
+        x: 56
+        "y": 56
+        content: Hard Shadow
+        textStyle:
+          fontFamily: Arial
+          fontSize: 56
+          fill: "#FFFFFF"
+          shadow:
+            color: "#A6A6A6"
+            alpha: 1
+            blur: 0
+            offsetX: -8
+            offsetY: 8
+      - id: soft-shadow
+        type: text
+        x: 56
+        "y": 156
+        content: Soft Shadow
+        textStyle:
+          fontFamily: Arial
+          fontSize: 56
+          fill: "#D9D9D9"
+          shadow:
+            color: "#FFFFFF"
+            alpha: 0.5
+            blur: 10
+            offsetX: 6
+            offsetY: 0
+      - id: removable-shadow
+        type: text
+        x: 56
+        "y": 256
+        content: Shadow Removed On Next State
+        textStyle:
+          fontFamily: Arial
+          fontSize: 44
+          fill: "#FFFFFF"
+          shadow: null
+      - id: all-direction-shadow
+        type: text
+        x: 56
+        "y": 356
+        content: All Direction Shadow
+        textStyle:
+          fontFamily: Arial
+          fontSize: 50
+          fill: "#D9D9D9"
+          shadow:
+            color: "#FFFFFF"
+            alpha: 0.45
+            blur: 10
+            offsetX: 0
+            offsetY: 0


### PR DESCRIPTION
Summary:
- Add public textStyle.shadow support for text and text-revealing, including docs, schemas, and type docs.
- Map shadow offsets to Pixi dropShadow while keeping shadows out of layout and caret measurements.
- Deep-merge inherited shadows and allow shadow: null to remove an inherited/base shadow.
- Keep the useful text-revealing soft-wipe follow-up from the local staged work so completed prefix lines do not reveal overlapped following lines at frame 0.

Tests:
- bunx prettier --check changed files
- bun run test spec/util/toPixiTextStyle.spec.js spec/parser/parseTextRevealing.shadow.spec.js spec/elements/textHoverLayout.spec.js spec/elements/textRevealingRuntime.initialRevealedCharacters.spec.js spec/elements/updateTextRevealing.spec.js
- bun run test
- pre-push hook: bunx prettier --check src; vitest run