### PR TITLE
Add furigana placement gap support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/data/templates.yaml
+++ b/playground/data/templates.yaml
@@ -262,6 +262,8 @@
               lineHeight: 1.35
             furigana:
               text: "stable"
+              placement: top
+              gap: 2
               textStyle:
                 fontSize: 12
                 fill: "#737373"

--- a/playground/pages/docs/nodes/text-revealing.md
+++ b/playground/pages/docs/nodes/text-revealing.md
@@ -36,11 +36,29 @@ Try it in the [Playground](/playground/?template=text-revealing).
 
 ### `content[]` item shape
 
-| Field       | Type   | Required | Notes                                                |
-| ----------- | ------ | -------- | ---------------------------------------------------- |
-| `text`      | string | Yes      | Segment text.                                        |
-| `textStyle` | object | No       | Overrides root style.                                |
-| `furigana`  | object | No       | `{ text, textStyle }` rendered above parent segment. |
+| Field       | Type   | Required | Notes                                                              |
+| ----------- | ------ | -------- | ------------------------------------------------------------------ |
+| `text`      | string | Yes      | Segment text.                                                      |
+| `textStyle` | object | No       | Overrides root style.                                              |
+| `furigana`  | object | No       | `{ text, textStyle, placement, gap }` rendered beside the segment. |
+
+### `content[].furigana`
+
+| Field       | Type              | Required | Default | Notes                                                                                                                                        |
+| ----------- | ----------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `text`      | string            | Yes      | -       | Furigana/ruby text.                                                                                                                          |
+| `textStyle` | object            | No       | segment | Furigana style. Inherits from root `textStyle`, then applies the furigana override.                                                          |
+| `placement` | `top` \| `bottom` | No       | `top`   | Side of the base text where furigana is placed. The side-based name leaves room for future `left`/`right` support for vertical text layouts. |
+| `gap`       | number `>= 0`     | No       | `0`     | Additional side-relative spacing in pixels. `top` moves farther upward; `bottom` moves farther downward.                                     |
+
+```yaml
+furigana:
+  text: "かな"
+  placement: top
+  gap: 2
+  textStyle:
+    fontSize: 12
+```
 
 ### `textStyle.shadow`
 
@@ -83,6 +101,7 @@ Try it in the [Playground](/playground/?template=text-revealing).
 - `initialRevealedCharacters` is useful when an upstream engine appends to an existing line: keep the full combined `content`, set the count to the already-visible prefix length, and only the remaining suffix animates.
 - `softWipe` lays out the full text immediately and reveals it line by line with a moving soft mask. Defaults match the original soft wipe behavior: linear motion, no overlap, and a feather width clamped to the legacy range.
 - `revealEffect: none` skips animation and paints text immediately.
+- Furigana currently supports `placement: top` and `placement: bottom`. `gap` is intentionally direction-neutral so future vertical text can add `left` and `right` without renaming the field.
 - Completion contributes to global `renderComplete` tracking.
 - `complete.payload` is currently parsed but no dedicated per-node event is emitted from this plugin.
 
@@ -122,6 +141,8 @@ elements:
       - text: "漢字"
         furigana:
           text: "かんじ"
+          placement: top
+          gap: 4
           textStyle:
             fontSize: 14
             fill: "#ffd166"
@@ -171,6 +192,8 @@ elements:
           lineHeight: 1.35
         furigana:
           text: "ま"
+          placement: top
+          gap: 2
           textStyle:
             fontSize: 13
             fill: "#fff2bf"
@@ -255,6 +278,8 @@ elements:
           lineHeight: 1.35
         furigana:
           text: "そくど"
+          placement: top
+          gap: 2
           textStyle:
             fontSize: 13
             fill: "#fff2bf"

--- a/playground/static/public/playground/templates.yaml
+++ b/playground/static/public/playground/templates.yaml
@@ -262,6 +262,8 @@
               lineHeight: 1.35
             furigana:
               text: "stable"
+              placement: top
+              gap: 2
               textStyle:
                 fontSize: 12
                 fill: "#737373"

--- a/spec/parser/parseTextRevealing.furiganaPlacement.spec.js
+++ b/spec/parser/parseTextRevealing.furiganaPlacement.spec.js
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTextRevealing } from "../../src/plugins/elements/text-revealing/parseTextRevealing.js";
+
+const createState = (furigana = {}) => ({
+  id: "furigana-placement",
+  type: "text-revealing",
+  width: 300,
+  content: [
+    {
+      text: "BASE",
+      textStyle: {
+        fontFamily: "Arial",
+        fontSize: 32,
+      },
+      furigana: {
+        text: "ruby",
+        textStyle: {
+          fontFamily: "Arial",
+          fontSize: 12,
+        },
+        ...furigana,
+      },
+    },
+  ],
+});
+
+const firstPart = (parsed) => parsed.content[0].lineParts[0];
+
+describe("parseTextRevealing furigana placement", () => {
+  it("defaults to top placement with zero gap", () => {
+    const legacy = firstPart(parseTextRevealing({ state: createState() }));
+    const explicitTopNoGap = firstPart(
+      parseTextRevealing({
+        state: createState({
+          placement: "top",
+          gap: 0,
+        }),
+      }),
+    );
+
+    expect(legacy.furigana.x).toBe(explicitTopNoGap.furigana.x);
+    expect(legacy.furigana.y).toBe(explicitTopNoGap.furigana.y);
+  });
+
+  it("moves top furigana farther from the base text with a positive gap", () => {
+    const topNoGap = firstPart(
+      parseTextRevealing({
+        state: createState({
+          placement: "top",
+          gap: 0,
+        }),
+      }),
+    );
+    const topWithGap = firstPart(
+      parseTextRevealing({
+        state: createState({
+          placement: "top",
+          gap: 6,
+        }),
+      }),
+    );
+
+    expect(topWithGap.furigana.x).toBe(topNoGap.furigana.x);
+    expect(topWithGap.furigana.y).toBe(topNoGap.furigana.y - 6);
+    expect(topWithGap.furigana.y).toBeLessThan(topWithGap.y);
+  });
+
+  it("places bottom furigana below the base text with the configured gap", () => {
+    const parsed = parseTextRevealing({
+      state: createState({
+        placement: "bottom",
+        gap: 6,
+      }),
+    });
+    const part = firstPart(parsed);
+
+    expect(part.furigana.y).toBe(part.y + parsed.content[0].lineMaxHeight + 6);
+    expect(part.furigana.y).toBeGreaterThan(part.y);
+  });
+
+  it("rejects unsupported placement values until that side is implemented", () => {
+    expect(() =>
+      parseTextRevealing({
+        state: createState({
+          placement: "left",
+        }),
+      }),
+    ).toThrow(
+      "Input Error: content[0].furigana.placement must be one of top, bottom.",
+    );
+  });
+
+  it("rejects invalid gap values", () => {
+    expect(() =>
+      parseTextRevealing({
+        state: createState({
+          gap: -1,
+        }),
+      }),
+    ).toThrow(
+      "Input Error: content[0].furigana.gap must be a finite number >= 0.",
+    );
+  });
+});

--- a/src/plugins/elements/text-revealing/parseTextRevealing.js
+++ b/src/plugins/elements/text-revealing/parseTextRevealing.js
@@ -13,6 +13,64 @@ const normalizeInitialRevealedCharacters = (value) => {
   return Math.max(0, Math.floor(value));
 };
 
+const DEFAULT_FURIGANA_PLACEMENT = "top";
+const LEGACY_TOP_FURIGANA_OFFSET = 2;
+const FURIGANA_PLACEMENTS = ["top", "bottom"];
+const FURIGANA_PLACEMENT_SET = new Set(FURIGANA_PLACEMENTS);
+
+const normalizeFuriganaPlacement = (placement, path) => {
+  if (placement === undefined) {
+    return DEFAULT_FURIGANA_PLACEMENT;
+  }
+
+  if (FURIGANA_PLACEMENT_SET.has(placement)) {
+    return placement;
+  }
+
+  throw new Error(
+    `Input Error: ${path}.placement must be one of ${FURIGANA_PLACEMENTS.join(
+      ", ",
+    )}.`,
+  );
+};
+
+const normalizeFuriganaGap = (gap, path) => {
+  if (gap === undefined) {
+    return 0;
+  }
+
+  if (typeof gap === "number" && Number.isFinite(gap) && gap >= 0) {
+    return gap;
+  }
+
+  throw new Error(`Input Error: ${path}.gap must be a finite number >= 0.`);
+};
+
+const getFuriganaPosition = ({
+  placement,
+  gap,
+  x,
+  y,
+  partWidth,
+  partHeight,
+  furiganaWidth,
+  furiganaHeight,
+}) => {
+  const furiganaX = Math.round(x + (partWidth - furiganaWidth) / 2);
+
+  if (placement === "bottom") {
+    return {
+      x: furiganaX,
+      y: y + partHeight + gap,
+    };
+  }
+
+  return {
+    x: furiganaX,
+    y: y - furiganaHeight + LEGACY_TOP_FURIGANA_OFFSET - gap,
+  };
+};
+
 /**
  * @typedef {import('../../../types.js').BaseElement} BaseElement
  * @typedef {import('../../../types.js').TextRevealingComputedNode} TextRevealingComputedNode
@@ -264,14 +322,22 @@ const createTextChunks = (segments, wordWrapWidth) => {
         ),
       );
 
-      // Calculate furigana position relative to current line's max height
-      const furiganaYOffset = -furiganaMeasurements.height + y + 2;
+      const furiganaPosition = getFuriganaPosition({
+        placement: segment.furigana.placement,
+        gap: segment.furigana.gap,
+        x,
+        y,
+        partWidth,
+        partHeight: measurementsWithNoWrapping.height,
+        furiganaWidth: furiganaMeasurements.width,
+        furiganaHeight: furiganaMeasurements.height,
+      });
 
       const furiganaPart = {
         text: segment.furigana.text,
         textStyle: segment.furigana.textStyle,
-        x: Math.round(x + (partWidth - furiganaMeasurements.width) / 2),
-        y: furiganaYOffset,
+        x: furiganaPosition.x,
+        y: furiganaPosition.y,
       };
 
       newTextPart.furigana = furiganaPart;
@@ -355,7 +421,7 @@ export const parseTextRevealing = ({ state }) => {
     state.textStyle,
   );
 
-  const processedContent = (state.content || []).map((item) => {
+  const processedContent = (state.content || []).map((item, itemIndex) => {
     // TODO: if breakwords is true this will crash
     const itemTextStyle = mergeTextStyle(defaultTextStyle, item.textStyle);
 
@@ -387,6 +453,14 @@ export const parseTextRevealing = ({ state }) => {
       furigana = {
         text: String(item.furigana.text),
         textStyle: furiganaTextStyle,
+        placement: normalizeFuriganaPlacement(
+          item.furigana.placement,
+          `content[${itemIndex}].furigana`,
+        ),
+        gap: normalizeFuriganaGap(
+          item.furigana.gap,
+          `content[${itemIndex}].furigana`,
+        ),
       };
     }
 

--- a/src/schemas/elements/text-revealing.computed.yaml
+++ b/src/schemas/elements/text-revealing.computed.yaml
@@ -135,10 +135,10 @@ properties:
                 "$ref": "#/$def/textStyle"
               x:
                 type: number
-                description: Horizontal position (centered above parent)
+                description: Horizontal position
               y:
                 type: number
-                description: Vertical position (negative, above parent text)
+                description: Vertical position
               furigana:
                 type: object
                 properties:
@@ -148,10 +148,10 @@ properties:
                     "$ref": "#/$def/textStyle"
                   x:
                     type: number
-                    description: Horizontal position (centered above parent)
+                    description: Horizontal position relative to the parent text part
                   y:
                     type: number
-                    description: Vertical position (negative, above parent text)
+                    description: Vertical position relative to the parent text part
         lineMaxHeight:
           type: number
           description: Maximum height of text in this line

--- a/src/schemas/elements/text-revealing.element.yaml
+++ b/src/schemas/elements/text-revealing.element.yaml
@@ -128,6 +128,16 @@ properties:
               type: string
             textStyle:
               "$ref": "#/$def/textStyle"
+            placement:
+              type: string
+              enum: [top, bottom]
+              default: top
+              description: Side of the base text where furigana is placed. Currently supports top and bottom; the side-based name leaves room for future left/right support without changing the spacing API.
+            gap:
+              type: number
+              minimum: 0
+              default: 0
+              description: Additional distance in pixels between the furigana and base text along the placement axis. Positive values move furigana farther from the base text.
   width:
     type: number
     description: Width constraint for text wrapping. When set, enables word wrap.

--- a/src/types.js
+++ b/src/types.js
@@ -512,8 +512,8 @@
  * @typedef {Object} FuriganaPart
  * @property {string} text - Furigana text
  * @property {Object} textStyle - Furigana text style
- * @property {number} x - Horizontal position (centered above parent)
- * @property {number} y - Vertical position (negative, above parent text)
+ * @property {number} x - Horizontal position relative to the parent text part
+ * @property {number} y - Vertical position relative to the parent text part
  */
 
 /**

--- a/vt/reference/textrevealing/furigana-placement-gap-01.webp
+++ b/vt/reference/textrevealing/furigana-placement-gap-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce8102c0e596dfce695a6ea11957ae77f1bd424e859d1de24f360239e327fd33
+size 7972

--- a/vt/reference/textrevealing/furigana-placement-gap-02.webp
+++ b/vt/reference/textrevealing/furigana-placement-gap-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce8102c0e596dfce695a6ea11957ae77f1bd424e859d1de24f360239e327fd33
+size 7972

--- a/vt/specs/textrevealing/furigana-placement-gap.yaml
+++ b/vt/specs/textrevealing/furigana-placement-gap.yaml
@@ -1,0 +1,121 @@
+---
+title: Text Revealing Furigana Placement and Gap
+description: Visual coverage for text-revealing furigana top and bottom placement with side-relative gap.
+specs:
+  - omitted placement should keep the default top furigana layout
+  - top placement with gap should move furigana farther above the base text
+  - bottom placement with gap should render furigana below the base text
+steps:
+  - action: screenshot
+---
+states:
+  - elements:
+      - id: default-top-label
+        type: text
+        content: default top
+        x: 80
+        "y": 58
+        textStyle:
+          fontSize: 16
+          fill: "#A6A6A6"
+          fontFamily: Arial
+      - id: top-gap-label
+        type: text
+        content: top gap 10
+        x: 300
+        "y": 58
+        textStyle:
+          fontSize: 16
+          fill: "#A6A6A6"
+          fontFamily: Arial
+      - id: bottom-gap-label
+        type: text
+        content: bottom gap 10
+        x: 520
+        "y": 58
+        textStyle:
+          fontSize: 16
+          fill: "#A6A6A6"
+          fontFamily: Arial
+      - id: default-top-rule
+        type: rect
+        x: 80
+        "y": 126
+        width: 150
+        height: 2
+        fill: "#737373"
+      - id: top-gap-rule
+        type: rect
+        x: 300
+        "y": 126
+        width: 150
+        height: 2
+        fill: "#737373"
+      - id: bottom-gap-rule
+        type: rect
+        x: 520
+        "y": 126
+        width: 150
+        height: 2
+        fill: "#737373"
+      - id: furigana-default-top
+        type: text-revealing
+        x: 80
+        "y": 126
+        width: 160
+        revealEffect: none
+        content:
+          - text: BASE
+            textStyle:
+              fontSize: 42
+              fill: "#FFFFFF"
+              fontFamily: Arial
+              lineHeight: 1.25
+            furigana:
+              text: TOP
+              textStyle:
+                fontSize: 14
+                fill: "#D9D9D9"
+                fontFamily: Arial
+      - id: furigana-top-gap
+        type: text-revealing
+        x: 300
+        "y": 126
+        width: 160
+        revealEffect: none
+        content:
+          - text: BASE
+            textStyle:
+              fontSize: 42
+              fill: "#FFFFFF"
+              fontFamily: Arial
+              lineHeight: 1.25
+            furigana:
+              text: TOP GAP
+              placement: top
+              gap: 10
+              textStyle:
+                fontSize: 14
+                fill: "#D9D9D9"
+                fontFamily: Arial
+      - id: furigana-bottom-gap
+        type: text-revealing
+        x: 520
+        "y": 126
+        width: 160
+        revealEffect: none
+        content:
+          - text: BASE
+            textStyle:
+              fontSize: 42
+              fill: "#FFFFFF"
+              fontFamily: Arial
+              lineHeight: 1.25
+            furigana:
+              text: BOTTOM GAP
+              placement: bottom
+              gap: 10
+              textStyle:
+                fontSize: 14
+                fill: "#D9D9D9"
+                fontFamily: Arial


### PR DESCRIPTION
## Summary
- add `furigana.placement` and direction-neutral `furigana.gap` for text-revealing content
- support `top` and `bottom` placement with parser validation, keeping `left`/`right` reserved for future vertical text support
- document the full furigana interface and update playground examples
- add parser unit tests and targeted VT coverage for default top, top gap, and bottom gap
- bump package version to `1.14.1`

## Verification
- `bunx prettier --check package.json src/plugins/elements/text-revealing/parseTextRevealing.js src/schemas/elements/text-revealing.element.yaml src/schemas/elements/text-revealing.computed.yaml src/types.js spec/parser/parseTextRevealing.furiganaPlacement.spec.js playground/pages/docs/nodes/text-revealing.md playground/data/templates.yaml playground/static/public/playground/templates.yaml vt/specs/textrevealing/furigana-placement-gap.yaml`
- `bunx vitest run spec/parser/parseTextRevealing.furiganaPlacement.spec.js spec/parser/parseTextRevealing.shadow.spec.js spec/parser/parseTextRevealing.test.yaml spec/parser/parseTextRevealing.wrapRegression.spec.js`
- `rtgl vt screenshot --item textrevealing/furigana-placement-gap.yaml`
- `rtgl vt report --item textrevealing/furigana-placement-gap.yaml`: 2 images, 0 mismatches
- pre-push: `bunx prettier --check src && vitest run`
