### PR TITLE
Implement channel-based audio graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ For complete usage details, go to:
 - [Events & Render Complete](http://route-graphics.routevn.com/docs/guides/events-render-complete/)
 - [Custom Plugins](http://route-graphics.routevn.com/docs/guides/custom-plugins/)
 
+Design notes:
+
+- [Audio Effects](./docs/audio-effects.md)
+
 ## Render CLI
 
 This repo includes a CLI that renders RouteGraphics YAML into PNG or MP4 output by:

--- a/docs/audio-effects.md
+++ b/docs/audio-effects.md
@@ -2,12 +2,11 @@
 
 Last updated: 2026-04-30
 
-This document defines the intended channel-based audio interface for
-Route Graphics render state.
+This document defines the channel-based audio interface for Route Graphics
+render state.
 
-It is a design and interface document. The current runtime still accepts flat
-Route Graphics `sound` audio nodes. The channel and `audioEffects` model below
-is the planned public contract for the next audio graph implementation.
+It documents the current channel-based audio graph implementation. The runtime
+also still accepts flat Route Graphics `sound` audio nodes for compatibility.
 
 ## Goals
 
@@ -30,7 +29,7 @@ is the planned public contract for the next audio graph implementation.
 
 ## Render-State Shape
 
-Route Graphics should accept two audio-facing top-level arrays:
+Route Graphics accepts two audio-facing top-level arrays:
 
 ```yaml
 audio: []
@@ -66,23 +65,9 @@ audioEffects:
         enter: { from: 0, duration: 1000, easing: linear }
         exit: { to: 0, duration: 1000, easing: linear }
         update: { duration: 300, easing: linear }
-
-  - id: music-lowpass
-    type: audioFilter
-    targetId: music
-    filterType: lowpass
-    frequency: 12000
-    q: 1
-
-  - id: music-lowpass-sweep
-    type: audioTransition
-    targetId: music-lowpass
-    properties:
-      frequency:
-        update: { duration: 500, easing: linear }
 ```
 
-For compatibility, flat `sound` nodes should remain valid:
+For compatibility, flat `sound` nodes remain valid:
 
 ```yaml
 audio:
@@ -118,14 +103,14 @@ children: []
 
 Fields:
 
-| Field | Type | Default | Description |
-| --- | --- | --- | --- |
-| `id` | string | required | Stable globally unique channel ID |
-| `type` | `audio-channel` | required | Node type |
-| `volume` | number | `100` | Local channel volume, `0` to `100` |
-| `muted` | boolean | `false` | Forces this channel's effective output to zero |
-| `pan` | number | `0` | Stereo pan, `-1` left to `1` right |
-| `children` | sound[] | `[]` | Sound nodes owned by this channel |
+| Field      | Type            | Default  | Description                                    |
+| ---------- | --------------- | -------- | ---------------------------------------------- |
+| `id`       | string          | required | Stable globally unique channel ID              |
+| `type`     | `audio-channel` | required | Node type                                      |
+| `volume`   | number          | `100`    | Local channel volume, `0` to `100`             |
+| `muted`    | boolean         | `false`  | Forces this channel's effective output to zero |
+| `pan`      | number          | `0`      | Stereo pan, `-1` left to `1` right             |
+| `children` | sound[]         | `[]`     | Sound nodes owned by this channel              |
 
 First implementation rule:
 
@@ -152,26 +137,25 @@ endAt: null
 
 Fields:
 
-| Field | Type | Default | Description |
-| --- | --- | --- | --- |
-| `id` | string | required | Globally unique playback identity |
-| `type` | `sound` | required | Node type |
-| `src` | string | required | Audio asset alias or source URL |
-| `volume` | number | `100` | Local sound volume, `0` to `100` |
-| `muted` | boolean | `false` | Forces this sound's effective output to zero |
-| `pan` | number | `0` | Stereo pan, `-1` left to `1` right |
-| `loop` | boolean | `false` | Loop playback |
-| `startDelayMs` | number | `0` | Delay in milliseconds before playback starts |
-| `playbackRate` | number | `1` | Playback speed multiplier |
-| `startAt` | number | `0` | Start offset in seconds |
-| `endAt` | number/null | `null` | Optional end time in seconds |
+| Field          | Type        | Default  | Description                                  |
+| -------------- | ----------- | -------- | -------------------------------------------- |
+| `id`           | string      | required | Globally unique playback identity            |
+| `type`         | `sound`     | required | Node type                                    |
+| `src`          | string      | required | Audio asset alias or source URL              |
+| `volume`       | number      | `100`    | Local sound volume, `0` to `100`             |
+| `muted`        | boolean     | `false`  | Forces this sound's effective output to zero |
+| `pan`          | number      | `0`      | Stereo pan, `-1` left to `1` right           |
+| `loop`         | boolean     | `false`  | Loop playback                                |
+| `startDelayMs` | number      | `0`      | Delay in milliseconds before playback starts |
+| `playbackRate` | number      | `1`      | Playback speed multiplier                    |
+| `startAt`      | number      | `0`      | Start offset in seconds                      |
+| `endAt`        | number/null | `null`   | Optional end time in seconds                 |
 
 `startAt` and `endAt` are intended for partial playback. If `endAt` is present,
 duration is `endAt - startAt`.
 
-Legacy Route Graphics `sound.delay` may be accepted as a migration alias, but
-new render state should use `startDelayMs`. This avoids confusion with the
-future `delay` audio filter.
+The channel audio graph uses `startDelayMs` only. `sound.delay` is not part of
+this interface, which avoids confusion with the future `delay` audio filter.
 
 ### Sound Identity and Replay
 
@@ -214,10 +198,9 @@ not "play it again".
 `audioEffects` is a typed effect list. It contains automation and processing
 nodes that target audio node IDs or other effect IDs.
 
-Supported effect item types:
+First implementation effect item types:
 
 - `audioTransition`
-- `audioFilter`
 
 Effects are render-state entries, not resources.
 
@@ -230,8 +213,6 @@ Route Graphics should reject invalid audio render state instead of guessing:
 - nested `audio-channel` nodes in the first implementation
 - `audioTransition.targetId` that cannot be resolved in the state used for its
   lifecycle
-- `audioFilter.targetId` that does not resolve to an `audio-channel` or `sound`
-  in the first implementation
 - transition phases missing required `duration` or `easing`
 - transition phases that use an unsupported easing name
 - unknown audio node, effect, filter, or automated property types
@@ -256,34 +237,33 @@ audioEffects:
 
 Fields:
 
-| Field | Type | Default | Description |
-| --- | --- | --- | --- |
-| `id` | string | required | Stable effect ID |
-| `type` | `audioTransition` | required | Effect type |
-| `targetId` | string | required | Audio node or effect ID to automate |
-| `properties` | object | required | Property automation map |
+| Field        | Type              | Default  | Description                         |
+| ------------ | ----------------- | -------- | ----------------------------------- |
+| `id`         | string            | required | Stable effect ID                    |
+| `type`       | `audioTransition` | required | Effect type                         |
+| `targetId`   | string            | required | Audio node or effect ID to automate |
+| `properties` | object            | required | Property automation map             |
 
-`targetId` may reference:
+First implementation `targetId` may reference:
 
 - an `audio-channel`
 - a `sound`
-- an `audioFilter`
 
 Transition phases:
 
-| Phase | When it applies | Transition source |
-| --- | --- | --- |
-| `enter` | Target appears in the next render state | next `audioEffects` |
-| `exit` | Target disappears from the next render state | previous `audioEffects` |
-| `update` | Target remains but the property value changes | next `audioEffects` |
+| Phase    | When it applies                               | Transition source       |
+| -------- | --------------------------------------------- | ----------------------- |
+| `enter`  | Target appears in the next render state       | next `audioEffects`     |
+| `exit`   | Target disappears from the next render state  | previous `audioEffects` |
+| `update` | Target remains but the property value changes | next `audioEffects`     |
 
 Transition phase fields:
 
-| Phase | Required fields | Value rule |
-| --- | --- | --- |
-| `enter` | `from`, `duration`, `easing` | Starts at `from`; ends at the target's declared value |
-| `exit` | `to`, `duration`, `easing` | Starts at the current value; ends at `to` |
-| `update` | `duration`, `easing` | Starts at the current value; ends at the next declared value |
+| Phase    | Required fields              | Value rule                                                   |
+| -------- | ---------------------------- | ------------------------------------------------------------ |
+| `enter`  | `from`, `duration`, `easing` | Starts at `from`; ends at the target's declared value        |
+| `exit`   | `to`, `duration`, `easing`   | Starts at the current value; ends at `to`                    |
+| `update` | `duration`, `easing`         | Starts at the current value; ends at the next declared value |
 
 `duration` is in milliseconds. `easing` is required and must not be defaulted
 silently. The first implementation only needs to support `linear`.
@@ -319,10 +299,10 @@ audioEffects:
         update: { duration: 500, easing: linear }
 ```
 
-## Audio Filters
+## Planned Audio Filters
 
-An `audioFilter` is a Web Audio processing effect. In the first implementation,
-it targets an audio node.
+An `audioFilter` is a planned Web Audio processing effect. It will target an
+audio node when implemented.
 
 ```yaml
 audioEffects:
@@ -336,13 +316,13 @@ audioEffects:
 
 Fields:
 
-| Field | Type | Default | Description |
-| --- | --- | --- | --- |
-| `id` | string | required | Stable filter effect ID |
-| `type` | `audioFilter` | required | Effect type |
-| `targetId` | string | required | Audio node ID to process |
-| `filterType` | string | required | Web Audio filter kind |
-| `enabled` | boolean | `true` | Disabled filters are bypassed |
+| Field        | Type          | Default  | Description                   |
+| ------------ | ------------- | -------- | ----------------------------- |
+| `id`         | string        | required | Stable filter effect ID       |
+| `type`       | `audioFilter` | required | Effect type                   |
+| `targetId`   | string        | required | Audio node ID to process      |
+| `filterType` | string        | required | Web Audio filter kind         |
+| `enabled`    | boolean       | `true`   | Disabled filters are bypassed |
 
 Filter-specific fields depend on `filterType`.
 
@@ -360,19 +340,19 @@ should not be part of the first filter implementation.
 
 ### Planned Filter Types
 
-| `filterType` | Web Audio node | Common fields |
-| --- | --- | --- |
-| `lowpass` | `BiquadFilterNode` | `frequency`, `q` |
-| `highpass` | `BiquadFilterNode` | `frequency`, `q` |
-| `bandpass` | `BiquadFilterNode` | `frequency`, `q` |
-| `notch` | `BiquadFilterNode` | `frequency`, `q` |
-| `lowshelf` | `BiquadFilterNode` | `frequency`, `gain` |
-| `highshelf` | `BiquadFilterNode` | `frequency`, `gain` |
-| `peaking` | `BiquadFilterNode` | `frequency`, `q`, `gain` |
-| `allpass` | `BiquadFilterNode` | `frequency`, `q` |
-| `delay` | `DelayNode` plus feedback gain | `delayTime`, `feedback`, `wet` |
-| `compressor` | `DynamicsCompressorNode` | `threshold`, `knee`, `ratio`, `attack`, `release` |
-| `reverb` | `ConvolverNode` | `impulseSrc`, `wet` |
+| `filterType` | Web Audio node                 | Common fields                                     |
+| ------------ | ------------------------------ | ------------------------------------------------- |
+| `lowpass`    | `BiquadFilterNode`             | `frequency`, `q`                                  |
+| `highpass`   | `BiquadFilterNode`             | `frequency`, `q`                                  |
+| `bandpass`   | `BiquadFilterNode`             | `frequency`, `q`                                  |
+| `notch`      | `BiquadFilterNode`             | `frequency`, `q`                                  |
+| `lowshelf`   | `BiquadFilterNode`             | `frequency`, `gain`                               |
+| `highshelf`  | `BiquadFilterNode`             | `frequency`, `gain`                               |
+| `peaking`    | `BiquadFilterNode`             | `frequency`, `q`, `gain`                          |
+| `allpass`    | `BiquadFilterNode`             | `frequency`, `q`                                  |
+| `delay`      | `DelayNode` plus feedback gain | `delayTime`, `feedback`, `wet`                    |
+| `compressor` | `DynamicsCompressorNode`       | `threshold`, `knee`, `ratio`, `attack`, `release` |
+| `reverb`     | `ConvolverNode`                | `impulseSrc`, `wet`                               |
 
 Filters are not required for the first implementation. The interface should be
 designed now so filters can be added without changing the audio tree shape.
@@ -547,13 +527,19 @@ For removed nodes with an exit transition, cleanup happens after the ramp:
 source.stop(now + seconds);
 ```
 
-## Suggested Implementation Stages
+## Implementation Status
 
-1. Add Route Graphics schemas for `audio-channel`, extended `sound`, and
-   `audioEffects`.
-2. Normalize flat `sound` nodes into an implicit root channel.
-3. Refactor Route Graphics `AudioStage` into an audio graph manager with channel
-   gain nodes and internal playback instance IDs.
-4. Implement `audioTransition` for `volume` on channels and sounds.
-5. Add `audioFilter`, pan transitions, and playback-rate transitions in separate
-   patches.
+Implemented:
+
+- schemas for `audio-channel`, extended `sound`, and `audioTransition`
+- flat `sound` normalization through an implicit root channel
+- channel gain nodes and internal playback instance IDs
+- `audioTransition` for `volume` on channels and sounds
+- same-ID, different-source replacement with overlapping internal instances
+- removal of the legacy `sound.delay` interface in favor of `startDelayMs`
+
+Planned separately:
+
+- `audioFilter`
+- transition automation for `pan`
+- transition automation for `playbackRate`

--- a/docs/audio-effects.md
+++ b/docs/audio-effects.md
@@ -19,8 +19,6 @@ is the planned public contract for the next audio graph implementation.
 - support mixer-style channel volume without a separate mixer concept
 - support smooth volume fades and crossfades
 - preserve compatibility with existing flat `sound` render state
-- support higher-level consumers that normalize authored `bgm`, `sfx`, and
-  `voice` actions into channel render state
 - leave room for pan, playback-rate automation, and Web Audio filters
 
 ## Non-Goals
@@ -196,20 +194,20 @@ Use generated playback-instance IDs for one-shot sounds that should replay, even
 when they use the same audio asset as a previous one-shot:
 
 ```yaml
-id: voice-${lineId}-${playbackIndex}
+id: one-shot-${eventId}-${playbackIndex}
 type: sound
-src: voices/current-scene/alice_001.ogg
+src: ui-confirm
 loop: false
 ```
 
-The playback-instance component can come from a line ID, event ID, sequence
-number, or consumer-level playback token. If the same line can be entered more
-than once and should replay voice, the generated ID must include a visit or
-playback counter, not only the static line ID.
+The playback-instance component can come from an event ID, sequence number, or
+consumer-level playback token. If the same event can be submitted more than once
+and should replay audio, the generated ID must include a visit or playback
+counter, not only a static event ID.
 
-Avoid fixed one-shot IDs such as `line-voice` or `click`. With a declarative
-diff model, repeating the same fixed ID and `src` means "keep this existing
-sound", not "play it again".
+Avoid fixed one-shot IDs such as `click` or `confirm`. With a declarative diff
+model, repeating the same fixed ID and `src` means "keep this existing sound",
+not "play it again".
 
 ## Audio Effects
 
@@ -549,93 +547,6 @@ For removed nodes with an exit transition, cleanup happens after the ramp:
 source.stop(now + seconds);
 ```
 
-## Consumer Mapping
-
-Higher-level consumers such as Route Engine can keep domain-specific authored
-actions and normalize them into channel render state.
-
-### `bgm`
-
-```yaml
-bgm:
-  resourceId: theme
-```
-
-Normalizes to:
-
-```yaml
-audio:
-  - id: music
-    type: audio-channel
-    volume: ${runtime.musicVolume}
-    muted: ${runtime.muteAll}
-    children:
-      - id: bgm
-        type: sound
-        src: theme-file
-        loop: true
-```
-
-### `sfx`
-
-```yaml
-sfx:
-  items:
-    - id: door
-      resourceId: door-close
-      volume: 80
-```
-
-Normalizes to:
-
-```yaml
-audio:
-  - id: sfx
-    type: audio-channel
-    volume: ${runtime.soundVolume}
-    muted: ${runtime.muteAll}
-    children:
-      - id: sfx-${lineId}-${item.id}-${playbackIndex}
-        type: sound
-        src: door-close-file
-        volume: 80
-```
-
-Replayable one-shot SFX should use generated playback-instance IDs. Stable SFX
-IDs are only appropriate for sounds that should persist across render states,
-such as a looping ambient effect.
-
-### `voice`
-
-```yaml
-voice:
-  resourceId: alice_001
-```
-
-Normalizes to:
-
-```yaml
-audio:
-  - id: voice
-    type: audio-channel
-    volume: ${runtime.soundVolume}
-    muted: ${runtime.muteAll}
-    children:
-      - id: voice-${lineId}-${playbackIndex}
-        type: sound
-        src: voices/current-scene/alice_001.ogg
-        loop: false
-```
-
-The generated voice sound ID must identify the playback instance, not only the
-voice asset. Two consecutive lines may use the same `voice.resourceId`; they
-still need distinct generated `sound.id` values so the renderer sees a removed
-old sound and an added new sound.
-
-Future voice-specific controls, such as per-character voice mute, should affect
-the `voice` channel or the generated voice sound volume. They should not require
-channel declarations in `resources`.
-
 ## Suggested Implementation Stages
 
 1. Add Route Graphics schemas for `audio-channel`, extended `sound`, and
@@ -644,8 +555,5 @@ channel declarations in `resources`.
 3. Refactor Route Graphics `AudioStage` into an audio graph manager with channel
    gain nodes and internal playback instance IDs.
 4. Implement `audioTransition` for `volume` on channels and sounds.
-5. Update Route Engine render-state construction to emit channels for `bgm`,
-   `sfx`, and `voice`.
-6. Add Route Engine generic `audio` authoring once renderer support is stable.
-7. Add `audioFilter`, pan transitions, and playback-rate transitions in separate
+5. Add `audioFilter`, pan transitions, and playback-rate transitions in separate
    patches.

--- a/docs/audio-effects.md
+++ b/docs/audio-effects.md
@@ -136,7 +136,7 @@ First implementation rule:
 
 ### Sounds
 
-A `sound` is a playable source. It resolves to one Web Audio source instance.
+A `sound` is a playable source. It represents one logical playback instance.
 
 ```yaml
 id: bgm
@@ -156,7 +156,7 @@ Fields:
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `id` | string | required | Stable globally unique sound ID |
+| `id` | string | required | Globally unique playback identity |
 | `type` | `sound` | required | Node type |
 | `src` | string | required | Audio asset alias or source URL |
 | `volume` | number | `100` | Local sound volume, `0` to `100` |
@@ -174,6 +174,42 @@ duration is `endAt - startAt`.
 Legacy Route Graphics `sound.delay` may be accepted as a migration alias, but
 new render state should use `startDelayMs`. This avoids confusion with the
 future `delay` audio filter.
+
+### Sound Identity and Replay
+
+Route Graphics treats `sound.id` as the playback identity.
+
+If a `sound` remains present with the same `id` and same `src`, it is a
+continuing playback instance. It should not restart just because the same render
+state is submitted again.
+
+Use stable IDs for persistent sounds:
+
+```yaml
+id: bgm
+type: sound
+src: theme
+loop: true
+```
+
+Use generated playback-instance IDs for one-shot sounds that should replay, even
+when they use the same audio asset as a previous one-shot:
+
+```yaml
+id: voice-${lineId}-${playbackIndex}
+type: sound
+src: voices/current-scene/alice_001.ogg
+loop: false
+```
+
+The playback-instance component can come from a line ID, event ID, sequence
+number, or consumer-level playback token. If the same line can be entered more
+than once and should replay voice, the generated ID must include a visit or
+playback counter, not only the static line ID.
+
+Avoid fixed one-shot IDs such as `line-voice` or `click`. With a declarative
+diff model, repeating the same fixed ID and `src` means "keep this existing
+sound", not "play it again".
 
 ## Audio Effects
 
@@ -429,6 +465,9 @@ Route Graphics should keep audio declarative.
 
 No explicit `op: play` or `op: stop` is needed in Route Graphics render state.
 
+Same `sound.id` and same `sound.src` means continuation. It does not replay.
+Consumers must use a new playback-instance ID when replaying a one-shot sound.
+
 ### Same ID, Different Source
 
 If a `sound` keeps the same `id` but changes `src`, treat it as replacement:
@@ -556,11 +595,15 @@ audio:
     volume: ${runtime.soundVolume}
     muted: ${runtime.muteAll}
     children:
-      - id: door
+      - id: sfx-${lineId}-${item.id}-${playbackIndex}
         type: sound
         src: door-close-file
         volume: 80
 ```
+
+Replayable one-shot SFX should use generated playback-instance IDs. Stable SFX
+IDs are only appropriate for sounds that should persist across render states,
+such as a looping ambient effect.
 
 ### `voice`
 
@@ -578,11 +621,16 @@ audio:
     volume: ${runtime.soundVolume}
     muted: ${runtime.muteAll}
     children:
-      - id: line-voice
+      - id: voice-${lineId}-${playbackIndex}
         type: sound
         src: voices/current-scene/alice_001.ogg
         loop: false
 ```
+
+The generated voice sound ID must identify the playback instance, not only the
+voice asset. Two consecutive lines may use the same `voice.resourceId`; they
+still need distinct generated `sound.id` values so the renderer sees a removed
+old sound and an added new sound.
 
 Future voice-specific controls, such as per-character voice mute, should affect
 the `voice` channel or the generated voice sound volume. They should not require

--- a/docs/audio-effects.md
+++ b/docs/audio-effects.md
@@ -1,0 +1,603 @@
+# Audio Channel Design
+
+Last updated: 2026-04-30
+
+This document defines the intended channel-based audio interface for
+Route Graphics render state.
+
+It is a design and interface document. The current runtime still accepts flat
+Route Graphics `sound` audio nodes. The channel and `audioEffects` model below
+is the planned public contract for the next audio graph implementation.
+
+## Goals
+
+- model audio with the same declarative state/effect split used by Route
+  Graphics visual nodes and animations
+- keep channels out of `resources`
+- keep audio nodes focused on current audio state
+- put automation and filters in a separate `audioEffects` array
+- support mixer-style channel volume without a separate mixer concept
+- support smooth volume fades and crossfades
+- preserve compatibility with existing flat `sound` render state
+- support higher-level consumers that normalize authored `bgm`, `sfx`, and
+  `voice` actions into channel render state
+- leave room for pan, playback-rate automation, and Web Audio filters
+
+## Non-Goals
+
+- no nested audio channels in the first implementation
+- no command-style `play` / `stop` operation model in Route Graphics
+- no required channel declarations in project resources
+- no first implementation dependency on reverb, delay, or EQ filters
+
+## Render-State Shape
+
+Route Graphics should accept two audio-facing top-level arrays:
+
+```yaml
+audio: []
+audioEffects: []
+```
+
+`audio` defines the desired audio graph state. `audioEffects` defines typed
+effects that target audio node IDs.
+
+All `audio` node IDs and `audioEffects` IDs share one render-state namespace.
+IDs must be globally unique within a rendered frame. This keeps `targetId`
+resolution unambiguous and avoids channel-scoped lookup rules.
+
+```yaml
+audio:
+  - id: music
+    type: audio-channel
+    volume: 80
+    muted: false
+    children:
+      - id: bgm
+        type: sound
+        src: theme
+        loop: true
+        volume: 100
+
+audioEffects:
+  - id: music-volume
+    type: audioTransition
+    targetId: music
+    properties:
+      volume:
+        enter: { from: 0, duration: 1000, easing: linear }
+        exit: { to: 0, duration: 1000, easing: linear }
+        update: { duration: 300, easing: linear }
+
+  - id: music-lowpass
+    type: audioFilter
+    targetId: music
+    filterType: lowpass
+    frequency: 12000
+    q: 1
+
+  - id: music-lowpass-sweep
+    type: audioTransition
+    targetId: music-lowpass
+    properties:
+      frequency:
+        update: { duration: 500, easing: linear }
+```
+
+For compatibility, flat `sound` nodes should remain valid:
+
+```yaml
+audio:
+  - id: click
+    type: sound
+    src: click
+```
+
+Flat sounds are treated as children of an implicit root channel.
+
+## Audio Nodes
+
+The first implementation has two audio node types:
+
+- `audio-channel`
+- `sound`
+
+Effects are not audio nodes. They live in `audioEffects`.
+
+### Audio Channels
+
+An `audio-channel` is a bus/container. It does not play a file. It controls its
+child sounds.
+
+```yaml
+id: music
+type: audio-channel
+volume: 80
+muted: false
+pan: 0
+children: []
+```
+
+Fields:
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `id` | string | required | Stable globally unique channel ID |
+| `type` | `audio-channel` | required | Node type |
+| `volume` | number | `100` | Local channel volume, `0` to `100` |
+| `muted` | boolean | `false` | Forces this channel's effective output to zero |
+| `pan` | number | `0` | Stereo pan, `-1` left to `1` right |
+| `children` | sound[] | `[]` | Sound nodes owned by this channel |
+
+First implementation rule:
+
+- `audio-channel.children` may contain `sound` nodes only.
+- nested `audio-channel` nodes are invalid until explicitly supported.
+
+### Sounds
+
+A `sound` is a playable source. It resolves to one Web Audio source instance.
+
+```yaml
+id: bgm
+type: sound
+src: theme
+volume: 100
+muted: false
+pan: 0
+loop: true
+startDelayMs: 0
+playbackRate: 1
+startAt: 0
+endAt: null
+```
+
+Fields:
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `id` | string | required | Stable globally unique sound ID |
+| `type` | `sound` | required | Node type |
+| `src` | string | required | Audio asset alias or source URL |
+| `volume` | number | `100` | Local sound volume, `0` to `100` |
+| `muted` | boolean | `false` | Forces this sound's effective output to zero |
+| `pan` | number | `0` | Stereo pan, `-1` left to `1` right |
+| `loop` | boolean | `false` | Loop playback |
+| `startDelayMs` | number | `0` | Delay in milliseconds before playback starts |
+| `playbackRate` | number | `1` | Playback speed multiplier |
+| `startAt` | number | `0` | Start offset in seconds |
+| `endAt` | number/null | `null` | Optional end time in seconds |
+
+`startAt` and `endAt` are intended for partial playback. If `endAt` is present,
+duration is `endAt - startAt`.
+
+Legacy Route Graphics `sound.delay` may be accepted as a migration alias, but
+new render state should use `startDelayMs`. This avoids confusion with the
+future `delay` audio filter.
+
+## Audio Effects
+
+`audioEffects` is a typed effect list. It contains automation and processing
+nodes that target audio node IDs or other effect IDs.
+
+Supported effect item types:
+
+- `audioTransition`
+- `audioFilter`
+
+Effects are render-state entries, not resources.
+
+### Validation Rules
+
+Route Graphics should reject invalid audio render state instead of guessing:
+
+- duplicate IDs across `audio` nodes and `audioEffects`
+- `audio-channel.children` entries whose type is not `sound`
+- nested `audio-channel` nodes in the first implementation
+- `audioTransition.targetId` that cannot be resolved in the state used for its
+  lifecycle
+- `audioFilter.targetId` that does not resolve to an `audio-channel` or `sound`
+  in the first implementation
+- transition phases missing required `duration` or `easing`
+- transition phases that use an unsupported easing name
+- unknown audio node, effect, filter, or automated property types
+
+## Audio Transitions
+
+An `audioTransition` automates property changes on a target.
+
+```yaml
+audioEffects:
+  - id: music-transitions
+    type: audioTransition
+    targetId: music
+    properties:
+      volume:
+        enter: { from: 0, duration: 1000, easing: linear }
+        exit: { to: 0, duration: 1000, easing: linear }
+        update: { duration: 300, easing: linear }
+      pan:
+        update: { duration: 200, easing: linear }
+```
+
+Fields:
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `id` | string | required | Stable effect ID |
+| `type` | `audioTransition` | required | Effect type |
+| `targetId` | string | required | Audio node or effect ID to automate |
+| `properties` | object | required | Property automation map |
+
+`targetId` may reference:
+
+- an `audio-channel`
+- a `sound`
+- an `audioFilter`
+
+Transition phases:
+
+| Phase | When it applies | Transition source |
+| --- | --- | --- |
+| `enter` | Target appears in the next render state | next `audioEffects` |
+| `exit` | Target disappears from the next render state | previous `audioEffects` |
+| `update` | Target remains but the property value changes | next `audioEffects` |
+
+Transition phase fields:
+
+| Phase | Required fields | Value rule |
+| --- | --- | --- |
+| `enter` | `from`, `duration`, `easing` | Starts at `from`; ends at the target's declared value |
+| `exit` | `to`, `duration`, `easing` | Starts at the current value; ends at `to` |
+| `update` | `duration`, `easing` | Starts at the current value; ends at the next declared value |
+
+`duration` is in milliseconds. `easing` is required and must not be defaulted
+silently. The first implementation only needs to support `linear`.
+
+Using the previous state's `audioEffects` for `exit` lets a removed sound or
+filter fade out without keeping a dead target in the next render state.
+
+First implementation target:
+
+```yaml
+audioEffects:
+  - id: music-volume
+    type: audioTransition
+    targetId: music
+    properties:
+      volume:
+        enter: { from: 0, duration: 1000, easing: linear }
+        exit: { to: 0, duration: 1000, easing: linear }
+        update: { duration: 300, easing: linear }
+```
+
+Future transition targets:
+
+```yaml
+audioEffects:
+  - id: bgm-transitions
+    type: audioTransition
+    targetId: bgm
+    properties:
+      pan:
+        update: { duration: 200, easing: linear }
+      playbackRate:
+        update: { duration: 500, easing: linear }
+```
+
+## Audio Filters
+
+An `audioFilter` is a Web Audio processing effect. In the first implementation,
+it targets an audio node.
+
+```yaml
+audioEffects:
+  - id: music-lowpass
+    type: audioFilter
+    targetId: music
+    filterType: lowpass
+    frequency: 900
+    q: 1
+```
+
+Fields:
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `id` | string | required | Stable filter effect ID |
+| `type` | `audioFilter` | required | Effect type |
+| `targetId` | string | required | Audio node ID to process |
+| `filterType` | string | required | Web Audio filter kind |
+| `enabled` | boolean | `true` | Disabled filters are bypassed |
+
+Filter-specific fields depend on `filterType`.
+
+`targetId` may reference:
+
+- an `audio-channel`
+- a `sound`
+
+When multiple filters target the same node, they are applied in `audioEffects`
+order.
+
+Future versions may allow an `audioFilter` to target another `audioFilter`.
+That requires graph validation, topological ordering, and cycle rejection. It
+should not be part of the first filter implementation.
+
+### Planned Filter Types
+
+| `filterType` | Web Audio node | Common fields |
+| --- | --- | --- |
+| `lowpass` | `BiquadFilterNode` | `frequency`, `q` |
+| `highpass` | `BiquadFilterNode` | `frequency`, `q` |
+| `bandpass` | `BiquadFilterNode` | `frequency`, `q` |
+| `notch` | `BiquadFilterNode` | `frequency`, `q` |
+| `lowshelf` | `BiquadFilterNode` | `frequency`, `gain` |
+| `highshelf` | `BiquadFilterNode` | `frequency`, `gain` |
+| `peaking` | `BiquadFilterNode` | `frequency`, `q`, `gain` |
+| `allpass` | `BiquadFilterNode` | `frequency`, `q` |
+| `delay` | `DelayNode` plus feedback gain | `delayTime`, `feedback`, `wet` |
+| `compressor` | `DynamicsCompressorNode` | `threshold`, `knee`, `ratio`, `attack`, `release` |
+| `reverb` | `ConvolverNode` | `impulseSrc`, `wet` |
+
+Filters are not required for the first implementation. The interface should be
+designed now so filters can be added without changing the audio tree shape.
+
+### Filter Lifecycle
+
+`enabled` is an immediate bypass flag. It should not be treated as a fade.
+
+Smooth filter enter and exit need one of these explicit strategies:
+
+- transition filter parameters toward or away from neutral values
+- use a filter-provided `wet` parameter when the filter supports wet/dry mixing
+
+For example, a lowpass filter can be made less audible by transitioning
+`frequency` back toward a high neutral value before the filter is removed.
+Removing a filter without such a transition may change the sound immediately.
+
+### Filter Automation
+
+Filter parameters are automated by targeting the filter effect ID with an
+`audioTransition`.
+
+```yaml
+audioEffects:
+  - id: music-lowpass
+    type: audioFilter
+    targetId: music
+    filterType: lowpass
+    frequency: 12000
+    q: 1
+
+  - id: music-lowpass-transition
+    type: audioTransition
+    targetId: music-lowpass
+    properties:
+      frequency:
+        update: { duration: 600, easing: linear }
+      q:
+        update: { duration: 300, easing: linear }
+```
+
+No dotted paths are needed.
+
+## Volume
+
+Channel volume and sound volume stack multiplicatively.
+
+```yaml
+audio:
+  - id: music
+    type: audio-channel
+    volume: 50
+    children:
+      - id: bgm
+        type: sound
+        src: theme
+        volume: 50
+```
+
+Effective volume:
+
+```text
+channel 50% * sound 50% = 25%
+```
+
+In Web Audio terms:
+
+```js
+effectiveGain = (channel.volume / 100) * (sound.volume / 100);
+```
+
+This matches normal mixer behavior: source gain is scaled by track/channel gain.
+
+If both channel and sound volumes transition at the same time, both ramps apply.
+Authors should use channel transitions for group fades and sound transitions for
+individual sound fades.
+
+## Add, Update, Remove
+
+Route Graphics should keep audio declarative.
+
+- Added audio node or effect: create it and apply `enter` transition if a
+  matching `audioTransition` exists in the next `audioEffects`.
+- Updated audio node or effect: update changed properties and apply `update`
+  transition if a matching `audioTransition` exists in the next `audioEffects`.
+- Removed audio node or effect: keep the internal node alive until `exit`
+  transition from the previous `audioEffects` completes, then stop and clean up.
+
+No explicit `op: play` or `op: stop` is needed in Route Graphics render state.
+
+### Same ID, Different Source
+
+If a `sound` keeps the same `id` but changes `src`, treat it as replacement:
+
+1. old source uses its `exit` transition
+2. new source uses its `enter` transition
+3. both internal playback instances may coexist during the crossfade
+
+Example:
+
+```yaml
+# previous
+audio:
+  - id: music
+    type: audio-channel
+    children:
+      - id: bgm
+        type: sound
+        src: track-a
+
+audioEffects:
+  - id: bgm-volume
+    type: audioTransition
+    targetId: bgm
+    properties:
+      volume:
+        exit: { to: 0, duration: 1000, easing: linear }
+
+# next
+audio:
+  - id: music
+    type: audio-channel
+    children:
+      - id: bgm
+        type: sound
+        src: track-b
+
+audioEffects:
+  - id: bgm-volume
+    type: audioTransition
+    targetId: bgm
+    properties:
+      volume:
+        enter: { from: 0, duration: 1000, easing: linear }
+```
+
+The public ID remains `bgm`, but the audio stage needs separate internal
+playback instance IDs so the outgoing and incoming sources can overlap safely.
+
+## Web Audio Mapping
+
+The intended internal graph for one channel and one child sound is:
+
+```text
+AudioBufferSourceNode
+  -> sound GainNode
+  -> sound StereoPannerNode
+  -> sound-targeted filters
+  -> channel GainNode
+  -> channel StereoPannerNode
+  -> channel-targeted filters
+  -> AudioContext.destination
+```
+
+Volume and transition scheduling use Web Audio `AudioParam` automation:
+
+```js
+const now = audioContext.currentTime;
+const seconds = duration / 1000;
+
+gain.gain.cancelScheduledValues(now);
+gain.gain.setValueAtTime(currentValue, now);
+gain.gain.linearRampToValueAtTime(targetValue, now + seconds);
+```
+
+For removed nodes with an exit transition, cleanup happens after the ramp:
+
+```js
+source.stop(now + seconds);
+```
+
+## Consumer Mapping
+
+Higher-level consumers such as Route Engine can keep domain-specific authored
+actions and normalize them into channel render state.
+
+### `bgm`
+
+```yaml
+bgm:
+  resourceId: theme
+```
+
+Normalizes to:
+
+```yaml
+audio:
+  - id: music
+    type: audio-channel
+    volume: ${runtime.musicVolume}
+    muted: ${runtime.muteAll}
+    children:
+      - id: bgm
+        type: sound
+        src: theme-file
+        loop: true
+```
+
+### `sfx`
+
+```yaml
+sfx:
+  items:
+    - id: door
+      resourceId: door-close
+      volume: 80
+```
+
+Normalizes to:
+
+```yaml
+audio:
+  - id: sfx
+    type: audio-channel
+    volume: ${runtime.soundVolume}
+    muted: ${runtime.muteAll}
+    children:
+      - id: door
+        type: sound
+        src: door-close-file
+        volume: 80
+```
+
+### `voice`
+
+```yaml
+voice:
+  resourceId: alice_001
+```
+
+Normalizes to:
+
+```yaml
+audio:
+  - id: voice
+    type: audio-channel
+    volume: ${runtime.soundVolume}
+    muted: ${runtime.muteAll}
+    children:
+      - id: line-voice
+        type: sound
+        src: voices/current-scene/alice_001.ogg
+        loop: false
+```
+
+Future voice-specific controls, such as per-character voice mute, should affect
+the `voice` channel or the generated voice sound volume. They should not require
+channel declarations in `resources`.
+
+## Suggested Implementation Stages
+
+1. Add Route Graphics schemas for `audio-channel`, extended `sound`, and
+   `audioEffects`.
+2. Normalize flat `sound` nodes into an implicit root channel.
+3. Refactor Route Graphics `AudioStage` into an audio graph manager with channel
+   gain nodes and internal playback instance IDs.
+4. Implement `audioTransition` for `volume` on channels and sounds.
+5. Update Route Engine render-state construction to emit channels for `bgm`,
+   `sfx`, and `voice`.
+6. Add Route Engine generic `audio` authoring once renderer support is stable.
+7. Add `audioFilter`, pan transitions, and playback-rate transitions in separate
+   patches.

--- a/playground/pages/docs/nodes/sound.md
+++ b/playground/pages/docs/nodes/sound.md
@@ -15,19 +15,19 @@ Try it in the [Playground](/playground/?template=sound-demo).
 
 ## Field Reference
 
-| Field    | Type    | Required | Default | Notes                                               |
-| -------- | ------- | -------- | ------- | --------------------------------------------------- |
-| `id`     | string  | Yes      | -       | Audio id.                                           |
-| `type`   | string  | Yes      | -       | Must be `sound`.                                    |
-| `src`    | string  | Yes      | -       | Audio source alias/URL.                             |
-| `volume` | number  | No       | `80`    | Runtime maps to `volume / 100`.                      |
-| `loop`   | boolean | No       | `false` | Loop playback.                                      |
-| `delay`  | number  | No       | `0`     | Delay in ms before adding to audio stage.           |
+| Field          | Type    | Required | Default | Notes                               |
+| -------------- | ------- | -------- | ------- | ----------------------------------- |
+| `id`           | string  | Yes      | -       | Audio id.                           |
+| `type`         | string  | Yes      | -       | Must be `sound`.                    |
+| `src`          | string  | Yes      | -       | Audio source alias/URL.             |
+| `volume`       | number  | No       | `100`   | Runtime maps to `volume / 100`.     |
+| `loop`         | boolean | No       | `false` | Loop playback.                      |
+| `startDelayMs` | number  | No       | `0`     | Delay in ms before playback starts. |
 
 ## Behavior Notes
 
 - Delayed sounds are scheduled and can be canceled by updates/deletes with the same `id`.
-- Updating a sound with delay reschedules from scratch.
+- Updating a pending delayed sound with `startDelayMs` reschedules from scratch.
 - If a pending delayed sound is updated to immediate playback, the pending timer is canceled and sound is added immediately.
 
 ## Example: Minimal SFX
@@ -57,6 +57,6 @@ audio:
   - id: stage-announce
     type: sound
     src: sfx-announce
-    delay: 1200
+    startDelayMs: 1200
     volume: 90
 ```

--- a/rettangoli.config.yaml
+++ b/rettangoli.config.yaml
@@ -76,6 +76,12 @@ vt:
         - title: "Render Complete Events"
           files: "rendercompleteevent"
           description: "Tests for renderComplete event firing"
+    - title: "Audio Group"
+      type: "groupLabel"
+      items:
+        - title: "Audio Manual Fixtures"
+          files: "audio"
+          description: "Manual audio fixtures for channels, transitions, and playback options"
     - title: "Slider Group"
       type: "groupLabel"
       items:

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -1,0 +1,371 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const createAudioParam = (initialValue = 0) => {
+  const param = {
+    value: initialValue,
+    cancelScheduledValues: vi.fn(),
+    setValueAtTime: vi.fn((value) => {
+      param.value = value;
+      return param;
+    }),
+    linearRampToValueAtTime: vi.fn((value) => {
+      param.value = value;
+      return param;
+    }),
+  };
+  return param;
+};
+
+const createAudioContextMock = () => {
+  const context = {
+    currentTime: 10,
+    destination: { label: "destination" },
+    gainNodes: [],
+    pannerNodes: [],
+    sources: [],
+    createGain: vi.fn(() => {
+      const node = {
+        type: "gain",
+        gain: createAudioParam(1),
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      };
+      context.gainNodes.push(node);
+      return node;
+    }),
+    createStereoPanner: vi.fn(() => {
+      const node = {
+        type: "panner",
+        pan: createAudioParam(0),
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      };
+      context.pannerNodes.push(node);
+      return node;
+    }),
+    createBufferSource: vi.fn(() => {
+      const node = {
+        type: "source",
+        buffer: null,
+        loop: false,
+        playbackRate: createAudioParam(1),
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        start: vi.fn(),
+        stop: vi.fn(),
+      };
+      context.sources.push(node);
+      return node;
+    }),
+  };
+
+  return context;
+};
+
+const setupAudioStage = async ({ assetMap = new Map() } = {}) => {
+  vi.resetModules();
+  const context = createAudioContextMock();
+  const AudioContextMock = vi.fn(function AudioContextMock() {
+    return context;
+  });
+  window.AudioContext = AudioContextMock;
+  window.webkitAudioContext = undefined;
+
+  const getAsset = vi.fn((src) => assetMap.get(src) ?? { src });
+  vi.doMock("../../src/AudioAsset.js", () => ({
+    AudioAsset: {
+      getAsset,
+    },
+  }));
+
+  const { createAudioStage } = await import("../../src/AudioStage.js");
+  const stage = createAudioStage();
+
+  return {
+    stage,
+    context,
+    getAsset,
+  };
+};
+
+const findSound = (stage, id) =>
+  [...stage._inspect().sounds.values()].find((sound) => sound.id === id);
+
+const findCurrentSound = (stage, id) => {
+  const inspect = stage._inspect();
+  const key = inspect.currentSoundKeyById.get(id);
+  return inspect.sounds.get(key);
+};
+
+describe("AudioStage graph rendering", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("renders channels, child sounds, and flat sounds through the graph", async () => {
+    const { stage, context, getAsset } = await setupAudioStage();
+
+    stage.renderGraph({
+      nextAudio: [
+        {
+          id: "music",
+          type: "audio-channel",
+          volume: 50,
+          children: [
+            {
+              id: "bgm",
+              type: "sound",
+              src: "theme",
+              volume: 40,
+              loop: true,
+            },
+          ],
+        },
+        {
+          id: "click",
+          type: "sound",
+          src: "click-sfx",
+        },
+      ],
+    });
+
+    const music = stage._inspect().channels.get("music");
+    const bgm = findSound(stage, "bgm");
+    const click = findSound(stage, "click");
+
+    expect(music.gainNode.gain.value).toBe(0.5);
+    expect(bgm.gainNode.gain.value).toBe(0.4);
+    expect(click.gainNode.gain.value).toBe(1);
+    expect(getAsset).toHaveBeenCalledWith("theme");
+    expect(getAsset).toHaveBeenCalledWith("click-sfx");
+    expect(context.sources).toHaveLength(2);
+    expect(context.sources[0].loop).toBe(true);
+    expect(context.sources[0].start).toHaveBeenCalledWith(0, 0);
+  });
+
+  it("applies enter, update, and exit volume transitions", async () => {
+    const { stage, context } = await setupAudioStage();
+    const firstAudio = [
+      {
+        id: "music",
+        type: "audio-channel",
+        volume: 80,
+        children: [{ id: "bgm", type: "sound", src: "theme" }],
+      },
+    ];
+
+    stage.renderGraph({
+      nextAudio: firstAudio,
+      nextAudioEffects: [
+        {
+          id: "music-enter",
+          type: "audioTransition",
+          targetId: "music",
+          properties: {
+            volume: {
+              enter: { from: 0, duration: 1000, easing: "linear" },
+            },
+          },
+        },
+      ],
+    });
+
+    const music = stage._inspect().channels.get("music");
+    expect(music.gainNode.gain.setValueAtTime).toHaveBeenCalledWith(0, 10);
+    expect(music.gainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      0.8,
+      11,
+    );
+
+    const secondAudio = [
+      {
+        id: "music",
+        type: "audio-channel",
+        volume: 30,
+        children: [{ id: "bgm", type: "sound", src: "theme" }],
+      },
+    ];
+
+    stage.renderGraph({
+      prevAudio: firstAudio,
+      nextAudio: secondAudio,
+      nextAudioEffects: [
+        {
+          id: "music-update",
+          type: "audioTransition",
+          targetId: "music",
+          properties: {
+            volume: {
+              update: { duration: 500, easing: "linear" },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(music.gainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      0.3,
+      10.5,
+    );
+
+    const bgmSource = context.sources[0];
+    stage.renderGraph({
+      prevAudio: secondAudio,
+      nextAudio: [],
+      prevAudioEffects: [
+        {
+          id: "music-exit",
+          type: "audioTransition",
+          targetId: "music",
+          properties: {
+            volume: {
+              exit: { to: 0, duration: 1000, easing: "linear" },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(music.gainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      0,
+      11,
+    );
+    expect(bgmSource.stop).toHaveBeenCalledWith(11);
+  });
+
+  it("replaces same-id sounds with different sources using overlapping instances", async () => {
+    const { stage, context } = await setupAudioStage();
+    const firstAudio = [{ id: "bgm", type: "sound", src: "track-a" }];
+    const secondAudio = [{ id: "bgm", type: "sound", src: "track-b" }];
+
+    stage.renderGraph({ nextAudio: firstAudio });
+    const firstSource = context.sources[0];
+
+    stage.renderGraph({
+      prevAudio: firstAudio,
+      nextAudio: secondAudio,
+      prevAudioEffects: [
+        {
+          id: "bgm-exit",
+          type: "audioTransition",
+          targetId: "bgm",
+          properties: {
+            volume: {
+              exit: { to: 0, duration: 1000, easing: "linear" },
+            },
+          },
+        },
+      ],
+      nextAudioEffects: [
+        {
+          id: "bgm-enter",
+          type: "audioTransition",
+          targetId: "bgm",
+          properties: {
+            volume: {
+              enter: { from: 0, duration: 1000, easing: "linear" },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(context.sources).toHaveLength(2);
+    expect(firstSource.stop).toHaveBeenCalledWith(11);
+    expect(findCurrentSound(stage, "bgm").src).toBe("track-b");
+  });
+
+  it("reconnects continuing sounds when they move between channels", async () => {
+    const { stage } = await setupAudioStage();
+    const firstAudio = [
+      {
+        id: "music-a",
+        type: "audio-channel",
+        children: [{ id: "bgm", type: "sound", src: "track" }],
+      },
+      {
+        id: "music-b",
+        type: "audio-channel",
+        children: [],
+      },
+    ];
+    const secondAudio = [
+      {
+        id: "music-a",
+        type: "audio-channel",
+        children: [],
+      },
+      {
+        id: "music-b",
+        type: "audio-channel",
+        children: [{ id: "bgm", type: "sound", src: "track" }],
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: firstAudio });
+    const bgm = findCurrentSound(stage, "bgm");
+    const firstChannel = stage._inspect().channels.get("music-a");
+    const secondChannel = stage._inspect().channels.get("music-b");
+
+    expect(bgm.pannerNode.connect).toHaveBeenCalledWith(firstChannel.gainNode);
+
+    stage.renderGraph({ prevAudio: firstAudio, nextAudio: secondAudio });
+
+    expect(bgm.pannerNode.disconnect).toHaveBeenCalled();
+    expect(bgm.pannerNode.connect).toHaveBeenCalledWith(secondChannel.gainNode);
+    expect(findCurrentSound(stage, "bgm")).toBe(bgm);
+  });
+
+  it("cancels pending startDelayMs playback when a sound is removed", async () => {
+    const { stage, getAsset } = await setupAudioStage();
+    const delayedAudio = [
+      {
+        id: "sfx",
+        type: "sound",
+        src: "click",
+        startDelayMs: 100,
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: delayedAudio });
+    expect(getAsset).not.toHaveBeenCalled();
+
+    stage.renderGraph({
+      prevAudio: delayedAudio,
+      nextAudio: [],
+    });
+
+    vi.advanceTimersByTime(100);
+
+    expect(getAsset).not.toHaveBeenCalled();
+    expect(findSound(stage, "sfx")).toBeUndefined();
+  });
+
+  it("validates effects when renderGraph is called directly", async () => {
+    const { stage } = await setupAudioStage();
+
+    expect(() =>
+      stage.renderGraph({
+        nextAudio: [{ id: "bgm", type: "sound", src: "track" }],
+        nextAudioEffects: [
+          {
+            id: "bad",
+            type: "audioTransition",
+            targetId: "missing",
+            properties: {
+              volume: {
+                update: { duration: 100, easing: "linear" },
+              },
+            },
+          },
+        ],
+      }),
+    ).toThrow('targetId "missing" does not resolve');
+  });
+});

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -50,6 +50,8 @@ const createAudioContextMock = () => {
         type: "source",
         buffer: null,
         loop: false,
+        loopStart: 0,
+        loopEnd: 0,
         playbackRate: createAudioParam(1),
         connect: vi.fn(),
         disconnect: vi.fn(),
@@ -252,6 +254,129 @@ describe("AudioStage graph rendering", () => {
     expect(bgmSource.stop).toHaveBeenCalledWith(11);
   });
 
+  it("does not cancel unchanged channel or sound volume ramps", async () => {
+    const { stage } = await setupAudioStage();
+    const audio = [
+      {
+        id: "music",
+        type: "audio-channel",
+        volume: 80,
+        children: [{ id: "bgm", type: "sound", src: "theme", volume: 60 }],
+      },
+    ];
+
+    stage.renderGraph({
+      nextAudio: audio,
+      nextAudioEffects: [
+        {
+          id: "music-enter",
+          type: "audioTransition",
+          targetId: "music",
+          properties: {
+            volume: {
+              enter: { from: 0, duration: 1000, easing: "linear" },
+            },
+          },
+        },
+        {
+          id: "bgm-enter",
+          type: "audioTransition",
+          targetId: "bgm",
+          properties: {
+            volume: {
+              enter: { from: 0, duration: 1000, easing: "linear" },
+            },
+          },
+        },
+      ],
+    });
+
+    const music = stage._inspect().channels.get("music");
+    const bgm = findCurrentSound(stage, "bgm");
+    music.gainNode.gain.cancelScheduledValues.mockClear();
+    music.gainNode.gain.setValueAtTime.mockClear();
+    bgm.gainNode.gain.cancelScheduledValues.mockClear();
+    bgm.gainNode.gain.setValueAtTime.mockClear();
+
+    stage.renderGraph({
+      prevAudio: audio,
+      nextAudio: audio,
+    });
+
+    expect(music.gainNode.gain.cancelScheduledValues).not.toHaveBeenCalled();
+    expect(music.gainNode.gain.setValueAtTime).not.toHaveBeenCalled();
+    expect(bgm.gainNode.gain.cancelScheduledValues).not.toHaveBeenCalled();
+    expect(bgm.gainNode.gain.setValueAtTime).not.toHaveBeenCalled();
+  });
+
+  it("uses a fresh channel bus when re-adding a channel that is still exiting", async () => {
+    const { stage, context } = await setupAudioStage();
+    const firstAudio = [
+      {
+        id: "music",
+        type: "audio-channel",
+        volume: 80,
+        children: [{ id: "bgm", type: "sound", src: "track-a" }],
+      },
+    ];
+    const nextAudio = [
+      {
+        id: "music",
+        type: "audio-channel",
+        volume: 80,
+        children: [{ id: "bgm", type: "sound", src: "track-b" }],
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: firstAudio });
+    const exitingChannel = stage._inspect().channels.get("music");
+    const firstSource = context.sources[0];
+
+    stage.renderGraph({
+      prevAudio: firstAudio,
+      nextAudio: [],
+      prevAudioEffects: [
+        {
+          id: "music-exit",
+          type: "audioTransition",
+          targetId: "music",
+          properties: {
+            volume: {
+              exit: { to: 0, duration: 1000, easing: "linear" },
+            },
+          },
+        },
+      ],
+    });
+
+    stage.renderGraph({
+      prevAudio: [],
+      nextAudio,
+      nextAudioEffects: [
+        {
+          id: "music-enter",
+          type: "audioTransition",
+          targetId: "music",
+          properties: {
+            volume: {
+              enter: { from: 0, duration: 1000, easing: "linear" },
+            },
+          },
+        },
+      ],
+    });
+
+    const activeChannel = stage._inspect().channels.get("music");
+    expect(activeChannel).not.toBe(exitingChannel);
+    expect(context.sources).toHaveLength(2);
+    expect(firstSource.stop).toHaveBeenCalledWith(11);
+
+    vi.advanceTimersByTime(1000);
+
+    expect(stage._inspect().channels.get("music")).toBe(activeChannel);
+    expect(findCurrentSound(stage, "bgm").src).toBe("track-b");
+  });
+
   it("replaces same-id sounds with different sources using overlapping instances", async () => {
     const { stage, context } = await setupAudioStage();
     const firstAudio = [{ id: "bgm", type: "sound", src: "track-a" }];
@@ -358,6 +483,68 @@ describe("AudioStage graph rendering", () => {
 
     expect(getAsset).not.toHaveBeenCalled();
     expect(findSound(stage, "sfx")).toBeUndefined();
+  });
+
+  it("reschedules pending startDelayMs playback when the delay changes", async () => {
+    const { stage, getAsset } = await setupAudioStage();
+    const firstAudio = [
+      {
+        id: "sfx",
+        type: "sound",
+        src: "click",
+        startDelayMs: 100,
+      },
+    ];
+    const secondAudio = [
+      {
+        id: "sfx",
+        type: "sound",
+        src: "click",
+        startDelayMs: 300,
+      },
+    ];
+    const immediateAudio = [
+      {
+        id: "sfx",
+        type: "sound",
+        src: "click",
+        startDelayMs: 0,
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: firstAudio });
+    vi.advanceTimersByTime(50);
+
+    stage.renderGraph({ prevAudio: firstAudio, nextAudio: secondAudio });
+    vi.advanceTimersByTime(50);
+    expect(getAsset).not.toHaveBeenCalled();
+
+    stage.renderGraph({ prevAudio: secondAudio, nextAudio: immediateAudio });
+    expect(getAsset).toHaveBeenCalledWith("click");
+  });
+
+  it("loops bounded sound segments instead of starting them with a duration", async () => {
+    const { stage, context } = await setupAudioStage();
+
+    stage.renderGraph({
+      nextAudio: [
+        {
+          id: "loop",
+          type: "sound",
+          src: "track",
+          loop: true,
+          startAt: 1,
+          endAt: 4,
+        },
+      ],
+    });
+
+    const source = context.sources[0];
+    expect(source.loop).toBe(true);
+    expect(source.loopStart).toBe(1);
+    expect(source.loopEnd).toBe(4);
+    expect(source.start).toHaveBeenCalledWith(0, 1);
+    expect(source.start.mock.calls[0]).toHaveLength(2);
   });
 
   it("validates effects when renderGraph is called directly", async () => {

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -164,6 +164,34 @@ describe("AudioStage graph rendering", () => {
     expect(context.resume).toHaveBeenCalled();
   });
 
+  it("resumes a suspended audio context before scheduling delayed playback", async () => {
+    const { stage, context, getAsset } = await setupAudioStage();
+    context.state = "suspended";
+    context.resume.mockImplementation(() => {
+      context.state = "running";
+      return Promise.resolve();
+    });
+
+    stage.renderGraph({
+      nextAudio: [
+        {
+          id: "sfx",
+          type: "sound",
+          src: "click",
+          startDelayMs: 100,
+        },
+      ],
+    });
+
+    expect(context.resume).toHaveBeenCalledTimes(1);
+    expect(getAsset).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+
+    expect(context.resume).toHaveBeenCalledTimes(1);
+    expect(getAsset).toHaveBeenCalledWith("click");
+  });
+
   it("applies enter, update, and exit volume transitions", async () => {
     const { stage, context } = await setupAudioStage();
     const firstAudio = [

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -19,10 +19,12 @@ const createAudioParam = (initialValue = 0) => {
 const createAudioContextMock = () => {
   const context = {
     currentTime: 10,
+    state: "running",
     destination: { label: "destination" },
     gainNodes: [],
     pannerNodes: [],
     sources: [],
+    resume: vi.fn(() => Promise.resolve()),
     createGain: vi.fn(() => {
       const node = {
         type: "gain",
@@ -147,6 +149,17 @@ describe("AudioStage graph rendering", () => {
     expect(context.sources).toHaveLength(2);
     expect(context.sources[0].loop).toBe(true);
     expect(context.sources[0].start).toHaveBeenCalledWith(0, 0);
+  });
+
+  it("resumes a suspended audio context before playback starts", async () => {
+    const { stage, context } = await setupAudioStage();
+    context.state = "suspended";
+
+    stage.renderGraph({
+      nextAudio: [{ id: "sfx", type: "sound", src: "click" }],
+    });
+
+    expect(context.resume).toHaveBeenCalled();
   });
 
   it("applies enter, update, and exit volume transitions", async () => {

--- a/spec/audio/renderAudio.spec.js
+++ b/spec/audio/renderAudio.spec.js
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderAudio } from "../../src/plugins/audio/renderAudio.js";
+
+describe("renderAudio", () => {
+  it("uses AudioStage graph rendering when available", () => {
+    const app = {
+      audioStage: {
+        renderGraph: vi.fn(),
+      },
+    };
+    const nextAudioTree = [
+      {
+        id: "music",
+        type: "audio-channel",
+        children: [{ id: "bgm", type: "sound", src: "theme" }],
+      },
+    ];
+    const nextAudioEffects = [
+      {
+        id: "music-fade",
+        type: "audioTransition",
+        targetId: "music",
+        properties: {
+          volume: {
+            enter: { from: 0, duration: 100, easing: "linear" },
+          },
+        },
+      },
+    ];
+
+    renderAudio({
+      app,
+      prevAudioTree: [],
+      nextAudioTree,
+      prevAudioEffects: [],
+      nextAudioEffects,
+      audioPlugins: [],
+    });
+
+    expect(app.audioStage.renderGraph).toHaveBeenCalledWith({
+      prevAudio: [],
+      nextAudio: nextAudioTree,
+      prevAudioEffects: [],
+      nextAudioEffects,
+    });
+  });
+
+  it("validates audio state before rendering", () => {
+    const app = {
+      audioStage: {
+        renderGraph: vi.fn(),
+      },
+    };
+
+    expect(() =>
+      renderAudio({
+        app,
+        prevAudioTree: [],
+        nextAudioTree: [{ id: "sfx", type: "sound", src: "click", delay: 1 }],
+        audioPlugins: [],
+      }),
+    ).toThrow("delay is not supported");
+
+    expect(app.audioStage.renderGraph).not.toHaveBeenCalled();
+  });
+});

--- a/spec/audio/renderAudio.spec.js
+++ b/spec/audio/renderAudio.spec.js
@@ -45,6 +45,52 @@ describe("renderAudio", () => {
     });
   });
 
+  it("dispatches custom audio plugin nodes alongside graph audio", () => {
+    const app = {
+      audioStage: {
+        renderGraph: vi.fn(),
+      },
+    };
+    const customPlugin = {
+      type: "custom-audio",
+      add: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const prevCustom = {
+      id: "custom",
+      type: "custom-audio",
+      src: "custom-a",
+      customValue: 1,
+    };
+    const nextCustom = {
+      id: "custom",
+      type: "custom-audio",
+      src: "custom-a",
+      customValue: 2,
+    };
+    const graphSound = { id: "sfx", type: "sound", src: "click" };
+
+    renderAudio({
+      app,
+      prevAudioTree: [prevCustom],
+      nextAudioTree: [nextCustom, graphSound],
+      audioPlugins: [customPlugin],
+    });
+
+    expect(app.audioStage.renderGraph).toHaveBeenCalledWith({
+      prevAudio: [],
+      nextAudio: [graphSound],
+      prevAudioEffects: [],
+      nextAudioEffects: [],
+    });
+    expect(customPlugin.update).toHaveBeenCalledWith({
+      app,
+      prevElement: prevCustom,
+      nextElement: nextCustom,
+    });
+  });
+
   it("validates audio state before rendering", () => {
     const app = {
       audioStage: {

--- a/spec/audio/updateSound.spec.js
+++ b/spec/audio/updateSound.spec.js
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { addSound, clearPendingSounds } from "../../src/plugins/audio/sound/addSound.js";
+import {
+  addSound,
+  clearPendingSounds,
+} from "../../src/plugins/audio/sound/addSound.js";
 import { updateSound } from "../../src/plugins/audio/sound/updateSound.js";
 
 const createMockApp = () => {
@@ -36,12 +39,17 @@ describe("updateSound", () => {
 
     updateSound({
       app,
-      prevElement: { id: "bgm", type: "sound", src: "old.mp3", delay: 0 },
+      prevElement: {
+        id: "bgm",
+        type: "sound",
+        src: "old.mp3",
+        startDelayMs: 0,
+      },
       nextElement: {
         id: "bgm",
         type: "sound",
         src: "next.mp3",
-        delay: 100,
+        startDelayMs: 100,
         loop: true,
         volume: 50,
       },
@@ -62,21 +70,26 @@ describe("updateSound", () => {
     });
   });
 
-  it("promotes pending delayed sound to immediate playback when delay becomes zero", () => {
+  it("promotes pending delayed sound to immediate playback when startDelayMs becomes zero", () => {
     const app = createMockApp();
     addSound({
       app,
-      element: { id: "sfx", type: "sound", src: "old.mp3", delay: 100 },
+      element: { id: "sfx", type: "sound", src: "old.mp3", startDelayMs: 100 },
     });
 
     updateSound({
       app,
-      prevElement: { id: "sfx", type: "sound", src: "old.mp3", delay: 100 },
+      prevElement: {
+        id: "sfx",
+        type: "sound",
+        src: "old.mp3",
+        startDelayMs: 100,
+      },
       nextElement: {
         id: "sfx",
         type: "sound",
         src: "new.mp3",
-        delay: 0,
+        startDelayMs: 0,
         loop: false,
         volume: 90,
       },
@@ -99,12 +112,17 @@ describe("updateSound", () => {
 
     updateSound({
       app,
-      prevElement: { id: "amb", type: "sound", src: "amb.mp3", delay: 0 },
+      prevElement: {
+        id: "amb",
+        type: "sound",
+        src: "amb.mp3",
+        startDelayMs: 0,
+      },
       nextElement: {
         id: "amb",
         type: "sound",
         src: "amb-2.mp3",
-        delay: 0,
+        startDelayMs: 0,
         loop: true,
         volume: 60,
       },

--- a/spec/parser/normalizeRenderState.test.yaml
+++ b/spec/parser/normalizeRenderState.test.yaml
@@ -14,6 +14,7 @@ out:
   elements: []
   animations: []
   audio: []
+  audioEffects: []
 ---
 case: Preserve provided arrays
 in:
@@ -33,6 +34,7 @@ in:
     audio:
       - id: sound-1
         type: sound
+        src: sfx-1
 out:
   id: state-2
   elements:
@@ -51,6 +53,8 @@ out:
   audio:
     - id: sound-1
       type: sound
+      src: sfx-1
+  audioEffects: []
 ---
 case: Normalize transition animation with mask defaults
 in:
@@ -79,6 +83,7 @@ out:
               value: 1
               easing: linear
   audio: []
+  audioEffects: []
 ---
 case: Normalize transition animation with prev tween
 in:
@@ -110,6 +115,7 @@ out:
                 value: 0
                 easing: linear
   audio: []
+  audioEffects: []
 ---
 case: Normalize transition animation with next tween
 in:
@@ -142,6 +148,7 @@ out:
                 value: 0
                 easing: easeInCubic
   audio: []
+  audioEffects: []
 ---
 case: Preserve advanced easing names
 in:
@@ -170,6 +177,7 @@ out:
               value: 20
               easing: easeInCubic
   audio: []
+  audioEffects: []
 ---
 case: Normalize update auto tween shorthand
 in:
@@ -203,6 +211,7 @@ out:
             duration: 220
             easing: easeOutQuad
   audio: []
+  audioEffects: []
 ---
 case: Normalize update blur tween
 in:
@@ -240,6 +249,7 @@ out:
             duration: 220
             easing: easeOutQuad
   audio: []
+  audioEffects: []
 ---
 case: Normalize update animation with persistent playback continuity
 in:
@@ -271,6 +281,7 @@ out:
               value: 1.2
               easing: linear
   audio: []
+  audioEffects: []
 ---
 case: Normalize update animation with render playback continuity
 in:
@@ -302,6 +313,7 @@ out:
               value: 1.2
               easing: linear
   audio: []
+  audioEffects: []
 ---
 case: Normalize transition animation with persistent playback continuity
 in:
@@ -335,6 +347,7 @@ out:
                 value: 1
                 easing: linear
   audio: []
+  audioEffects: []
 ---
 case: Throw when transitions field is provided
 in:

--- a/spec/util/normalizeAudio.spec.js
+++ b/spec/util/normalizeAudio.spec.js
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import {
+  flattenAudioNodes,
+  normalizeAudioRenderState,
+} from "../../src/util/normalizeAudio.js";
+
+describe("normalizeAudioRenderState", () => {
+  it("flattens channels and flat sounds", () => {
+    const result = flattenAudioNodes([
+      {
+        id: "music",
+        type: "audio-channel",
+        volume: 80,
+        children: [
+          {
+            id: "bgm",
+            type: "sound",
+            src: "theme",
+            volume: 50,
+          },
+        ],
+      },
+      {
+        id: "click",
+        type: "sound",
+        src: "click-sfx",
+      },
+    ]);
+
+    expect(result.channels).toEqual([
+      {
+        id: "music",
+        type: "audio-channel",
+        volume: 80,
+        muted: false,
+        pan: 0,
+      },
+    ]);
+    expect(result.sounds).toEqual([
+      {
+        id: "bgm",
+        type: "sound",
+        src: "theme",
+        volume: 50,
+        muted: false,
+        pan: 0,
+        loop: false,
+        startDelayMs: 0,
+        playbackRate: 1,
+        startAt: 0,
+        endAt: null,
+        channelId: "music",
+      },
+      {
+        id: "click",
+        type: "sound",
+        src: "click-sfx",
+        volume: 100,
+        muted: false,
+        pan: 0,
+        loop: false,
+        startDelayMs: 0,
+        playbackRate: 1,
+        startAt: 0,
+        endAt: null,
+        channelId: null,
+      },
+    ]);
+  });
+
+  it("rejects duplicate IDs across nodes and effects", () => {
+    expect(() =>
+      normalizeAudioRenderState({
+        audio: [{ id: "music", type: "audio-channel" }],
+        audioEffects: [
+          {
+            id: "music",
+            type: "audioTransition",
+            targetId: "music",
+            properties: {
+              volume: {
+                update: { duration: 100, easing: "linear" },
+              },
+            },
+          },
+        ],
+      }),
+    ).toThrow('duplicate audio render-state id "music"');
+  });
+
+  it("rejects nested channels and non-sound channel children", () => {
+    expect(() =>
+      normalizeAudioRenderState({
+        audio: [
+          {
+            id: "music",
+            type: "audio-channel",
+            children: [{ id: "nested", type: "audio-channel" }],
+          },
+        ],
+      }),
+    ).toThrow("nested audio-channel nodes are not supported");
+
+    expect(() =>
+      normalizeAudioRenderState({
+        audio: [
+          {
+            id: "music",
+            type: "audio-channel",
+            children: [{ id: "effect", type: "audioFilter" }],
+          },
+        ],
+      }),
+    ).toThrow('audio[0].children[0].type must be "sound"');
+  });
+
+  it("rejects removed legacy sound.delay", () => {
+    expect(() =>
+      normalizeAudioRenderState({
+        audio: [
+          {
+            id: "sfx",
+            type: "sound",
+            src: "click",
+            delay: 100,
+          },
+        ],
+      }),
+    ).toThrow("audio[0].delay is not supported");
+  });
+
+  it("validates volume transitions strictly", () => {
+    const audio = [{ id: "music", type: "audio-channel" }];
+
+    expect(() =>
+      normalizeAudioRenderState({
+        audio,
+        audioEffects: [
+          {
+            id: "fade",
+            type: "audioTransition",
+            targetId: "missing",
+            properties: {
+              volume: {
+                update: { duration: 100, easing: "linear" },
+              },
+            },
+          },
+        ],
+      }),
+    ).toThrow('targetId "missing" does not resolve');
+
+    expect(() =>
+      normalizeAudioRenderState({
+        audio,
+        audioEffects: [
+          {
+            id: "fade",
+            type: "audioTransition",
+            targetId: "music",
+            properties: {
+              volume: {
+                update: { duration: 100 },
+              },
+            },
+          },
+        ],
+      }),
+    ).toThrow("audioEffects[0].properties.volume.update.easing is required");
+
+    expect(() =>
+      normalizeAudioRenderState({
+        audio,
+        audioEffects: [
+          {
+            id: "fade",
+            type: "audioTransition",
+            targetId: "music",
+            properties: {
+              pan: {
+                update: { duration: 100, easing: "linear" },
+              },
+            },
+          },
+        ],
+      }),
+    ).toThrow('unsupported audio transition property "pan"');
+
+    expect(() =>
+      normalizeAudioRenderState({
+        audio,
+        audioEffects: [
+          {
+            id: "fade",
+            type: "audioTransition",
+            targetId: "music",
+            properties: {
+              volume: {
+                enter: { from: 0, to: 50, duration: 100, easing: "linear" },
+              },
+            },
+          },
+        ],
+      }),
+    ).toThrow('unsupported audio transition field "to"');
+  });
+});

--- a/spec/util/normalizeAudio.spec.js
+++ b/spec/util/normalizeAudio.spec.js
@@ -88,6 +88,32 @@ describe("normalizeAudioRenderState", () => {
     ).toThrow('duplicate audio render-state id "music"');
   });
 
+  it("preserves top-level custom audio plugin nodes", () => {
+    const result = normalizeAudioRenderState({
+      audio: [
+        { id: "custom-1", type: "custom-audio", customValue: 1 },
+        { id: "sfx", type: "sound", src: "click" },
+      ],
+    });
+
+    expect(result.audio).toEqual([
+      { id: "custom-1", type: "custom-audio", customValue: 1 },
+      { id: "sfx", type: "sound", src: "click" },
+    ]);
+    expect(result.sounds).toHaveLength(1);
+  });
+
+  it("still rejects duplicate custom audio plugin node IDs", () => {
+    expect(() =>
+      normalizeAudioRenderState({
+        audio: [
+          { id: "custom-1", type: "custom-audio" },
+          { id: "custom-1", type: "sound", src: "click" },
+        ],
+      }),
+    ).toThrow('duplicate audio render-state id "custom-1"');
+  });
+
   it("rejects nested channels and non-sound channel children", () => {
     expect(() =>
       normalizeAudioRenderState({

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -1,9 +1,287 @@
 import { AudioAsset } from "./AudioAsset.js";
+import { normalizeVolume } from "./util/normalizeVolume.js";
+import { normalizeAudioRenderState } from "./util/normalizeAudio.js";
 
-const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+const ROOT_CHANNEL_ID = "__route_graphics_audio_root__";
+const DIRECT_CHANNEL_ID = "__route_graphics_audio_direct__";
+
+let audioContext;
+
+const getAudioContext = () => {
+  if (audioContext) return audioContext;
+
+  const AudioContextCtor =
+    globalThis.window?.AudioContext ?? globalThis.window?.webkitAudioContext;
+
+  if (!AudioContextCtor) {
+    throw new Error("AudioContext is not available in this environment.");
+  }
+
+  audioContext = new AudioContextCtor();
+  return audioContext;
+};
+
+const connect = (from, to) => {
+  if (from && to && typeof from.connect === "function") {
+    from.connect(to);
+  }
+};
+
+const disconnect = (node) => {
+  if (node && typeof node.disconnect === "function") {
+    node.disconnect();
+  }
+};
+
+const getParamValue = (param, fallback = 0) =>
+  typeof param?.value === "number" ? param.value : fallback;
+
+const setParamNow = (param, value, context = getAudioContext()) => {
+  if (!param) return;
+  if (typeof param.cancelScheduledValues === "function") {
+    param.cancelScheduledValues(context.currentTime);
+  }
+  if (typeof param.setValueAtTime === "function") {
+    param.setValueAtTime(value, context.currentTime);
+  } else {
+    param.value = value;
+  }
+};
+
+const rampParam = (param, value, durationMs, context = getAudioContext()) => {
+  if (!param) return;
+
+  const now = context.currentTime;
+  const seconds = durationMs / 1000;
+  const currentValue = getParamValue(param);
+
+  if (typeof param.cancelScheduledValues === "function") {
+    param.cancelScheduledValues(now);
+  }
+  if (typeof param.setValueAtTime === "function") {
+    param.setValueAtTime(currentValue, now);
+  } else {
+    param.value = currentValue;
+  }
+
+  if (seconds > 0 && typeof param.linearRampToValueAtTime === "function") {
+    param.linearRampToValueAtTime(value, now + seconds);
+  } else if (typeof param.setValueAtTime === "function") {
+    param.setValueAtTime(value, now + seconds);
+  } else {
+    param.value = value;
+  }
+};
+
+const createGainNode = (value = 1) => {
+  const context = getAudioContext();
+  const node = context.createGain();
+  setParamNow(node.gain, value, context);
+  return node;
+};
+
+const createPannerNode = (pan = 0) => {
+  const context = getAudioContext();
+  if (typeof context.createStereoPanner !== "function") {
+    return null;
+  }
+
+  const node = context.createStereoPanner();
+  setParamNow(node.pan, pan, context);
+  return node;
+};
+
+const getVolumeValue = ({ volume, muted }) =>
+  muted ? 0 : normalizeVolume(volume, 100);
+
+const getTransitionPhase = (effects = [], targetId, property, phase) => {
+  const transition = effects.find(
+    (effect) =>
+      effect.type === "audioTransition" && effect.targetId === targetId,
+  );
+
+  return transition?.properties?.[property]?.[phase] ?? null;
+};
+
+const getTransitionDuration = (transition) =>
+  typeof transition?.duration === "number" ? transition.duration : 0;
+
+const applyVolume = ({ gainNode, targetValue, transition }) => {
+  if (!transition) {
+    setParamNow(gainNode.gain, targetValue);
+    return 0;
+  }
+
+  const initialValue =
+    transition.from !== undefined
+      ? normalizeVolume(transition.from, 100)
+      : undefined;
+  const finalValue =
+    transition.to !== undefined
+      ? normalizeVolume(transition.to, 100)
+      : targetValue;
+
+  if (initialValue !== undefined) {
+    setParamNow(gainNode.gain, initialValue);
+  }
+  rampParam(gainNode.gain, finalValue, transition.duration);
+
+  return transition.duration;
+};
+
+const createChannelInstance = (channel, outputNode) => {
+  const gainNode = createGainNode(getVolumeValue(channel));
+  const pannerNode = createPannerNode(channel.pan ?? 0);
+
+  connect(gainNode, pannerNode ?? outputNode);
+  if (pannerNode) connect(pannerNode, outputNode);
+
+  return {
+    id: channel.id,
+    gainNode,
+    pannerNode,
+    volume: channel.volume ?? 100,
+    muted: channel.muted ?? false,
+    pan: channel.pan ?? 0,
+    outputNode,
+    cleanupTimeoutId: null,
+  };
+};
+
+const createSoundInstance = ({ sound, channelNode, internalId }) => {
+  const gainNode = createGainNode(getVolumeValue(sound));
+  const pannerNode = createPannerNode(sound.pan ?? 0);
+
+  connect(gainNode, pannerNode ?? channelNode);
+  if (pannerNode) connect(pannerNode, channelNode);
+
+  return {
+    internalId,
+    id: sound.id,
+    src: sound.src,
+    url: sound.src,
+    loop: sound.loop ?? false,
+    volume: sound.volume ?? 100,
+    muted: sound.muted ?? false,
+    pan: sound.pan ?? 0,
+    startDelayMs: sound.startDelayMs ?? 0,
+    playbackRate: sound.playbackRate ?? 1,
+    startAt: sound.startAt ?? 0,
+    endAt: sound.endAt ?? null,
+    channelId: sound.channelId ?? null,
+    gainNode,
+    pannerNode,
+    source: null,
+    pendingTimeoutId: null,
+    cleanupTimeoutId: null,
+  };
+};
+
+const createSourceForSound = (sound) => {
+  const context = getAudioContext();
+  const audioBuffer = AudioAsset.getAsset(sound.src);
+  if (!audioBuffer) {
+    console.warn("AudioStage: asset not found", sound.src);
+    return null;
+  }
+
+  const source = context.createBufferSource();
+  source.buffer = audioBuffer;
+  source.loop = sound.loop ?? false;
+
+  if (source.playbackRate) {
+    setParamNow(source.playbackRate, sound.playbackRate ?? 1, context);
+  }
+
+  connect(source, sound.gainNode);
+
+  const offset = sound.startAt ?? 0;
+  const duration =
+    sound.endAt !== null && sound.endAt !== undefined
+      ? Math.max(sound.endAt - offset, 0)
+      : undefined;
+
+  if (duration !== undefined) {
+    source.start(0, offset, duration);
+  } else {
+    source.start(0, offset);
+  }
+
+  return source;
+};
+
+const playSound = (sound) => {
+  if (sound.pendingTimeoutId !== null) {
+    clearTimeout(sound.pendingTimeoutId);
+    sound.pendingTimeoutId = null;
+  }
+
+  const start = () => {
+    sound.pendingTimeoutId = null;
+    sound.source = createSourceForSound(sound);
+  };
+
+  if (sound.startDelayMs > 0) {
+    sound.pendingTimeoutId = setTimeout(start, sound.startDelayMs);
+    return;
+  }
+
+  start();
+};
+
+const stopSource = (sound, delayMs = 0) => {
+  if (sound.pendingTimeoutId !== null) {
+    clearTimeout(sound.pendingTimeoutId);
+    sound.pendingTimeoutId = null;
+  }
+
+  if (!sound.source) return;
+
+  const context = getAudioContext();
+  try {
+    sound.source.stop(context.currentTime + delayMs / 1000);
+  } catch {
+    // Stopping an already-stopped source is harmless for cleanup.
+  }
+};
+
+const cleanupSound = (sound) => {
+  if (sound.pendingTimeoutId !== null) {
+    clearTimeout(sound.pendingTimeoutId);
+    sound.pendingTimeoutId = null;
+  }
+  if (sound.cleanupTimeoutId !== null) {
+    clearTimeout(sound.cleanupTimeoutId);
+    sound.cleanupTimeoutId = null;
+  }
+
+  stopSource(sound);
+  disconnect(sound.source);
+  disconnect(sound.gainNode);
+  disconnect(sound.pannerNode);
+};
+
+const cleanupChannel = (channel) => {
+  if (channel.cleanupTimeoutId !== null) {
+    clearTimeout(channel.cleanupTimeoutId);
+    channel.cleanupTimeoutId = null;
+  }
+  disconnect(channel.gainNode);
+  disconnect(channel.pannerNode);
+};
+
+const schedule = (callback, delayMs) => {
+  if (delayMs <= 0) {
+    callback();
+    return null;
+  }
+  return setTimeout(callback, delayMs);
+};
 
 /**
- * Creates an audio player instance
+ * Creates an audio player instance.
+ * Kept as a small compatibility wrapper for direct tests/integrations.
+ *
  * @param {string} id
  * @param {Object} options
  * @param {string} options.url
@@ -12,163 +290,482 @@ const audioContext = new (window.AudioContext || window.webkitAudioContext)();
  * @returns {Object} Audio player instance
  */
 export const createAudioPlayer = (id, options) => {
-  let audioSource;
-  const gainNode = audioContext.createGain();
-  gainNode.gain.value = options.volume ?? 1.0;
-  gainNode.connect(audioContext.destination);
-
-  let state = {
+  const sound = {
     id,
-    url: options.url,
-    loop: options.loop || false,
-    volume: options.volume ?? 1.0,
+    src: options.url,
+    loop: options.loop ?? false,
+    volume: (options.volume ?? 1) * 100,
   };
+  const channel = createChannelInstance(
+    { id: `${id}:channel`, volume: 100, muted: false, pan: 0 },
+    getAudioContext().destination,
+  );
+  const instance = createSoundInstance({
+    sound,
+    channelNode: channel.gainNode,
+    internalId: id,
+  });
 
-  const play = () => {
-    const audioBuffer = AudioAsset.getAsset(state.url);
-    if (!audioBuffer) {
-      console.warn("AudioPlayer.play: Asset not found", state.url);
-      return;
-    }
-    audioSource = audioContext.createBufferSource();
-    audioSource.buffer = audioBuffer;
-    audioSource.loop = state.loop;
-    gainNode.gain.setValueAtTime(state.volume, audioContext.currentTime);
-    audioSource.connect(gainNode);
-    audioSource.start(0);
-  };
-
-  const stop = () => {
-    if (audioSource) {
-      audioSource.stop();
-      audioSource.disconnect();
-      gainNode.disconnect();
-      gainNode.connect(audioContext.destination);
-    }
-  };
-
+  const play = () => playSound(instance);
+  const stop = () => cleanupSound(instance);
   const update = (newState) => {
-    state = { ...state, ...newState };
-  };
-
-  const getId = () => state.id;
-  const getUrl = () => state.url;
-  const getLoop = () => state.loop;
-  const getVolume = () => state.volume;
-  const setUrl = (url) => {
-    state.url = url;
-  };
-  const setLoop = (loop) => {
-    state.loop = loop;
-  };
-  const setVolume = (volume) => {
-    state.volume = volume;
-    gainNode.gain.value = volume;
+    instance.src = newState.url ?? instance.src;
+    instance.url = instance.src;
+    instance.loop = newState.loop ?? instance.loop;
+    if (newState.volume !== undefined) {
+      instance.volume = newState.volume * 100;
+      setParamNow(instance.gainNode.gain, newState.volume);
+    }
   };
 
   return {
     play,
     stop,
     update,
-    getId,
-    getUrl,
-    getLoop,
-    getVolume,
-    setUrl,
-    setLoop,
-    setVolume,
+    getId: () => instance.id,
+    getUrl: () => instance.url,
+    getLoop: () => instance.loop,
+    getVolume: () => normalizeVolume(instance.volume, 100),
+    setUrl: (url) => {
+      instance.src = url;
+      instance.url = url;
+    },
+    setLoop: (loop) => {
+      instance.loop = loop;
+      if (instance.source) instance.source.loop = loop;
+    },
+    setVolume: (volume) => {
+      instance.volume = volume * 100;
+      setParamNow(instance.gainNode.gain, volume);
+    },
     get id() {
-      return state.id;
+      return instance.id;
     },
     get url() {
-      return state.url;
+      return instance.url;
     },
     get loop() {
-      return state.loop;
+      return instance.loop;
     },
     get volume() {
-      return state.volume;
+      return normalizeVolume(instance.volume, 100);
     },
-    gainNode,
+    gainNode: instance.gainNode,
   };
 };
 
 /**
- * @typedef {Object} AudioElement
- * @property {string} id - The ID of the audio element
- * @property {string} url - The URL of the audio file
- * @property {boolean} [loop=false] - Whether the audio should loop
- * @property {number} [volume=1.0] - Volume between 0 and 1
- */
-
-/**
- * Creates an audio stage instance
+ * Creates an audio stage instance.
+ *
  * @returns {Object} Audio stage instance
  */
 export const createAudioStage = () => {
-  let audioPlayers = [];
-  let stageAudios = [];
+  const channels = new Map();
+  const sounds = new Map();
+  const currentSoundKeyById = new Map();
+  const directAudios = new Map();
+  let soundGeneration = 0;
 
-  const add = (element) => {
-    stageAudios.push(element);
+  const ensureRootChannel = (id) => {
+    const existing = channels.get(id);
+    if (existing) return existing;
+
+    const channel = createChannelInstance(
+      { id, volume: 100, muted: false, pan: 0 },
+      getAudioContext().destination,
+    );
+    channels.set(id, channel);
+    return channel;
   };
 
-  const remove = (id) => {
-    stageAudios = stageAudios.filter((audio) => audio.id !== id);
+  const ensureChannel = (channel, effects, phase) => {
+    const existing = channels.get(channel.id);
+    const transition = getTransitionPhase(effects, channel.id, "volume", phase);
+
+    if (existing) {
+      if (existing.cleanupTimeoutId !== null) {
+        clearTimeout(existing.cleanupTimeoutId);
+        existing.cleanupTimeoutId = null;
+      }
+
+      existing.volume = channel.volume;
+      existing.muted = channel.muted;
+      existing.pan = channel.pan;
+      applyVolume({
+        gainNode: existing.gainNode,
+        targetValue: getVolumeValue(channel),
+        transition,
+      });
+      if (existing.pannerNode?.pan) {
+        setParamNow(existing.pannerNode.pan, channel.pan ?? 0);
+      }
+      return existing;
+    }
+
+    const created = createChannelInstance(
+      channel,
+      getAudioContext().destination,
+    );
+    channels.set(channel.id, created);
+    applyVolume({
+      gainNode: created.gainNode,
+      targetValue: getVolumeValue(channel),
+      transition,
+    });
+    return created;
   };
 
-  const getById = (id) => {
-    return stageAudios.find((audio) => audio.id === id);
+  const getParentChannelForSound = (sound) => {
+    const parentChannel =
+      sound.channelId !== null
+        ? channels.get(sound.channelId)
+        : ensureRootChannel(ROOT_CHANNEL_ID);
+
+    if (!parentChannel) {
+      throw new Error(
+        `Input error: sound "${sound.id}" references missing channel.`,
+      );
+    }
+
+    return parentChannel;
   };
 
-  const tick = () => {
-    for (const audio of stageAudios) {
-      const audioPlayer = audioPlayers.find((player) => player.id === audio.id);
+  const connectSoundToChannel = (instance, channelNode) => {
+    disconnect(instance.gainNode);
+    disconnect(instance.pannerNode);
+    connect(instance.gainNode, instance.pannerNode ?? channelNode);
+    if (instance.pannerNode) connect(instance.pannerNode, channelNode);
+  };
 
-      // add
-      if (!audioPlayer) {
-        const player = createAudioPlayer(audio.id, {
-          url: audio.url,
-          loop: audio.loop,
-          volume: audio.volume ?? 1.0,
-        });
-        audioPlayers.push(player);
-        player.play();
+  const removeChannel = (channel, effects) => {
+    if (
+      !channel ||
+      channel.id === ROOT_CHANNEL_ID ||
+      channel.id === DIRECT_CHANNEL_ID
+    ) {
+      return 0;
+    }
+
+    const transition = getTransitionPhase(
+      effects,
+      channel.id,
+      "volume",
+      "exit",
+    );
+    const duration = applyVolume({
+      gainNode: channel.gainNode,
+      targetValue: getVolumeValue(channel),
+      transition,
+    });
+
+    return duration;
+  };
+
+  const addSoundInstance = ({ sound, effects, phase, internalId }) => {
+    const parentChannel = getParentChannelForSound(sound);
+
+    const instance = createSoundInstance({
+      sound,
+      channelNode: parentChannel.gainNode,
+      internalId,
+    });
+    sounds.set(internalId, instance);
+    currentSoundKeyById.set(sound.id, internalId);
+
+    const transition = getTransitionPhase(effects, sound.id, "volume", phase);
+    applyVolume({
+      gainNode: instance.gainNode,
+      targetValue: getVolumeValue(sound),
+      transition,
+    });
+    playSound(instance);
+    return instance;
+  };
+
+  const removeSoundInstance = (instance, effects, inheritedDuration = 0) => {
+    if (!instance) return 0;
+
+    const transition = getTransitionPhase(
+      effects,
+      instance.id,
+      "volume",
+      "exit",
+    );
+    const ownDuration = applyVolume({
+      gainNode: instance.gainNode,
+      targetValue: getVolumeValue(instance),
+      transition,
+    });
+    const duration = Math.max(ownDuration, inheritedDuration);
+
+    stopSource(instance, duration);
+    instance.cleanupTimeoutId = schedule(() => {
+      cleanupSound(instance);
+      sounds.delete(instance.internalId);
+    }, duration);
+
+    return duration;
+  };
+
+  const updateSoundInstance = ({ instance, sound, effects }) => {
+    if (instance.channelId !== sound.channelId) {
+      const parentChannel = getParentChannelForSound(sound);
+      connectSoundToChannel(instance, parentChannel.gainNode);
+    }
+
+    instance.loop = sound.loop;
+    instance.volume = sound.volume;
+    instance.muted = sound.muted;
+    instance.pan = sound.pan;
+    instance.startDelayMs = sound.startDelayMs;
+    instance.playbackRate = sound.playbackRate;
+    instance.startAt = sound.startAt;
+    instance.endAt = sound.endAt;
+    instance.channelId = sound.channelId;
+
+    if (instance.source) {
+      instance.source.loop = sound.loop;
+      if (instance.source.playbackRate) {
+        setParamNow(instance.source.playbackRate, sound.playbackRate);
+      }
+    }
+
+    if (instance.pannerNode?.pan) {
+      setParamNow(instance.pannerNode.pan, sound.pan);
+    }
+
+    const transition = getTransitionPhase(
+      effects,
+      sound.id,
+      "volume",
+      "update",
+    );
+    applyVolume({
+      gainNode: instance.gainNode,
+      targetValue: getVolumeValue(sound),
+      transition,
+    });
+  };
+
+  const renderGraph = ({
+    prevAudio = [],
+    nextAudio = [],
+    prevAudioEffects = [],
+    nextAudioEffects = [],
+  } = {}) => {
+    const prev = normalizeAudioRenderState({
+      audio: prevAudio,
+      audioEffects: prevAudioEffects,
+    });
+    const next = normalizeAudioRenderState({
+      audio: nextAudio,
+      audioEffects: nextAudioEffects,
+    });
+
+    const prevChannelById = new Map(
+      prev.channels.map((channel) => [channel.id, channel]),
+    );
+    const nextChannelById = new Map(
+      next.channels.map((channel) => [channel.id, channel]),
+    );
+    const prevSoundById = new Map(
+      prev.sounds.map((sound) => [sound.id, sound]),
+    );
+    const nextSoundById = new Map(
+      next.sounds.map((sound) => [sound.id, sound]),
+    );
+
+    ensureRootChannel(ROOT_CHANNEL_ID);
+
+    const removedChannels = new Map();
+    const channelCleanupDurations = new Map();
+
+    for (const [id, prevChannel] of prevChannelById) {
+      if (!nextChannelById.has(id)) {
+        const duration = removeChannel(channels.get(id), prevAudioEffects);
+        removedChannels.set(id, channels.get(id));
+        channelCleanupDurations.set(id, duration);
+      }
+    }
+
+    for (const [id, nextChannel] of nextChannelById) {
+      ensureChannel(
+        nextChannel,
+        nextAudioEffects,
+        prevChannelById.has(id) ? "update" : "enter",
+      );
+    }
+
+    for (const [id, prevSound] of prevSoundById) {
+      const nextSound = nextSoundById.get(id);
+      const currentKey = currentSoundKeyById.get(id);
+      const instance = currentKey ? sounds.get(currentKey) : null;
+      const inheritedDuration = prevSound.channelId
+        ? (channelCleanupDurations.get(prevSound.channelId) ?? 0)
+        : 0;
+
+      if (!nextSound) {
+        const duration = removeSoundInstance(
+          instance,
+          prevAudioEffects,
+          inheritedDuration,
+        );
+        if (prevSound.channelId) {
+          channelCleanupDurations.set(
+            prevSound.channelId,
+            Math.max(
+              channelCleanupDurations.get(prevSound.channelId) ?? 0,
+              duration,
+            ),
+          );
+        }
+        currentSoundKeyById.delete(id);
         continue;
       }
 
-      // check if need update
-      if (audioPlayer.url !== audio.url || audioPlayer.loop !== audio.loop) {
-        audioPlayer.stop();
-        audioPlayer.setUrl(audio.url);
-        audioPlayer.setLoop(audio.loop ?? false);
-        audioPlayer.play();
-      }
-
-      if (audioPlayer.getVolume() !== (audio.volume ?? 1.0)) {
-        audioPlayer.setVolume(audio.volume ?? 1.0);
+      if (prevSound.src !== nextSound.src) {
+        const duration = removeSoundInstance(
+          instance,
+          prevAudioEffects,
+          inheritedDuration,
+        );
+        if (prevSound.channelId) {
+          channelCleanupDurations.set(
+            prevSound.channelId,
+            Math.max(
+              channelCleanupDurations.get(prevSound.channelId) ?? 0,
+              duration,
+            ),
+          );
+        }
+        addSoundInstance({
+          sound: nextSound,
+          effects: nextAudioEffects,
+          phase: "enter",
+          internalId: `render:${id}:${++soundGeneration}`,
+        });
       }
     }
 
-    // to be removed
-    const toRemoveAudioPlayerIds = [];
-    for (const player of audioPlayers) {
-      if (!stageAudios.find((audio) => audio.id === player.id)) {
-        player.stop();
-        toRemoveAudioPlayerIds.push(player.id);
+    for (const [id, nextSound] of nextSoundById) {
+      if (!prevSoundById.has(id)) {
+        addSoundInstance({
+          sound: nextSound,
+          effects: nextAudioEffects,
+          phase: "enter",
+          internalId: `render:${id}:${++soundGeneration}`,
+        });
+        continue;
+      }
+
+      const prevSound = prevSoundById.get(id);
+      if (prevSound.src !== nextSound.src) {
+        continue;
+      }
+
+      const currentKey = currentSoundKeyById.get(id);
+      const instance = currentKey ? sounds.get(currentKey) : null;
+      if (instance) {
+        updateSoundInstance({
+          instance,
+          sound: nextSound,
+          effects: nextAudioEffects,
+        });
       }
     }
-    audioPlayers = audioPlayers.filter(
-      (player) => !toRemoveAudioPlayerIds.includes(player.id),
-    );
+
+    for (const [id, channel] of removedChannels) {
+      if (!channel) continue;
+      const duration = channelCleanupDurations.get(id) ?? 0;
+      channel.cleanupTimeoutId = schedule(() => {
+        cleanupChannel(channel);
+        channels.delete(id);
+      }, duration);
+    }
+  };
+
+  const add = (element) => {
+    const audio = {
+      id: element.id,
+      type: "sound",
+      src: element.url ?? element.src,
+      loop: element.loop ?? false,
+      volume: (element.volume ?? 1) * 100,
+      startDelayMs: element.startDelayMs ?? 0,
+    };
+
+    directAudios.set(element.id, audio);
+  };
+
+  const remove = (id) => {
+    directAudios.delete(id);
+    currentSoundKeyById.delete(id);
+    const internalId = `direct:${id}`;
+    const instance = sounds.get(internalId);
+    if (instance) {
+      removeSoundInstance(instance, [], 0);
+    }
+  };
+
+  const getById = (id) => directAudios.get(id);
+
+  const tick = () => {
+    const channel = ensureRootChannel(DIRECT_CHANNEL_ID);
+    for (const audio of directAudios.values()) {
+      const internalId = `direct:${audio.id}`;
+      const instance = sounds.get(internalId);
+      if (!instance) {
+        const directSound = { ...audio, channelId: DIRECT_CHANNEL_ID };
+        addSoundInstance({
+          sound: directSound,
+          effects: [],
+          phase: "enter",
+          internalId,
+        });
+        continue;
+      }
+
+      if (instance.src !== audio.src) {
+        removeSoundInstance(instance, [], 0);
+        const directSound = { ...audio, channelId: DIRECT_CHANNEL_ID };
+        addSoundInstance({
+          sound: directSound,
+          effects: [],
+          phase: "enter",
+          internalId,
+        });
+        continue;
+      }
+
+      updateSoundInstance({
+        instance,
+        sound: { ...audio, channelId: DIRECT_CHANNEL_ID },
+        effects: [],
+      });
+    }
+
+    for (const [internalId, instance] of sounds) {
+      if (internalId.startsWith("direct:") && !directAudios.has(instance.id)) {
+        removeSoundInstance(instance, [], 0);
+        currentSoundKeyById.delete(instance.id);
+      }
+    }
+
+    return channel;
   };
 
   const destroy = () => {
-    for (const player of audioPlayers) {
-      player.stop();
+    for (const sound of sounds.values()) {
+      cleanupSound(sound);
     }
-    audioPlayers = [];
-    stageAudios = [];
+    for (const channel of channels.values()) {
+      cleanupChannel(channel);
+    }
+
+    sounds.clear();
+    currentSoundKeyById.clear();
+    channels.clear();
+    directAudios.clear();
   };
 
   return {
@@ -176,7 +773,14 @@ export const createAudioStage = () => {
     remove,
     getById,
     tick,
+    renderGraph,
     destroy,
+    _inspect: () => ({
+      channels,
+      sounds,
+      currentSoundKeyById,
+      directAudios,
+    }),
   };
 };
 

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -227,6 +227,8 @@ const playSound = (sound) => {
     sound.pendingTimeoutId = null;
   }
 
+  resumeAudioContext(getAudioContext());
+
   const start = () => {
     sound.pendingTimeoutId = null;
     sound.source = createSourceForSound(sound);

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -36,6 +36,12 @@ const disconnect = (node) => {
 const getParamValue = (param, fallback = 0) =>
   typeof param?.value === "number" ? param.value : fallback;
 
+const resumeAudioContext = (context = getAudioContext()) => {
+  if (context.state === "suspended" && typeof context.resume === "function") {
+    void context.resume().catch(() => {});
+  }
+};
+
 const setParamNow = (param, value, context = getAudioContext()) => {
   if (!param) return;
   if (typeof param.cancelScheduledValues === "function") {
@@ -179,6 +185,7 @@ const createSoundInstance = ({ sound, channelNode, internalId }) => {
 
 const createSourceForSound = (sound) => {
   const context = getAudioContext();
+  resumeAudioContext(context);
   const audioBuffer = AudioAsset.getAsset(sound.src);
   if (!audioBuffer) {
     console.warn("AudioStage: asset not found", sound.src);

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -208,7 +208,11 @@ const createSourceForSound = (sound) => {
       ? Math.max(sound.endAt - offset, 0)
       : undefined;
 
-  if (duration !== undefined) {
+  if (source.loop && sound.endAt !== null && sound.endAt !== undefined) {
+    source.loopStart = offset;
+    source.loopEnd = sound.endAt;
+    source.start(0, offset);
+  } else if (duration !== undefined) {
     source.start(0, offset, duration);
   } else {
     source.start(0, offset);
@@ -389,21 +393,45 @@ export const createAudioStage = () => {
     const existing = channels.get(channel.id);
     const transition = getTransitionPhase(effects, channel.id, "volume", phase);
 
+    if (existing && existing.cleanupTimeoutId !== null) {
+      const created = createChannelInstance(
+        channel,
+        getAudioContext().destination,
+      );
+      channels.set(channel.id, created);
+      applyVolume({
+        gainNode: created.gainNode,
+        targetValue: getVolumeValue(channel),
+        transition,
+      });
+      return created;
+    }
+
     if (existing) {
-      if (existing.cleanupTimeoutId !== null) {
-        clearTimeout(existing.cleanupTimeoutId);
-        existing.cleanupTimeoutId = null;
-      }
+      const currentVolumeValue = getVolumeValue(existing);
+      const nextVolumeValue = getVolumeValue(channel);
+      const volumeChanged = currentVolumeValue !== nextVolumeValue;
+      const panChanged = existing.pan !== (channel.pan ?? 0);
 
       existing.volume = channel.volume;
       existing.muted = channel.muted;
       existing.pan = channel.pan;
-      applyVolume({
-        gainNode: existing.gainNode,
-        targetValue: getVolumeValue(channel),
-        transition,
-      });
-      if (existing.pannerNode?.pan) {
+
+      if (volumeChanged && transition) {
+        applyVolume({
+          gainNode: existing.gainNode,
+          targetValue: nextVolumeValue,
+          transition,
+        });
+      } else if (volumeChanged) {
+        applyVolume({
+          gainNode: existing.gainNode,
+          targetValue: nextVolumeValue,
+          transition: null,
+        });
+      }
+
+      if (panChanged && existing.pannerNode?.pan) {
         setParamNow(existing.pannerNode.pan, channel.pan ?? 0);
       }
       return existing;
@@ -515,6 +543,11 @@ export const createAudioStage = () => {
   };
 
   const updateSoundInstance = ({ instance, sound, effects }) => {
+    const currentVolumeValue = getVolumeValue(instance);
+    const nextVolumeValue = getVolumeValue(sound);
+    const volumeChanged = currentVolumeValue !== nextVolumeValue;
+    const startDelayChanged = instance.startDelayMs !== sound.startDelayMs;
+
     if (instance.channelId !== sound.channelId) {
       const parentChannel = getParentChannelForSound(sound);
       connectSoundToChannel(instance, parentChannel.gainNode);
@@ -547,11 +580,23 @@ export const createAudioStage = () => {
       "volume",
       "update",
     );
-    applyVolume({
-      gainNode: instance.gainNode,
-      targetValue: getVolumeValue(sound),
-      transition,
-    });
+    if (volumeChanged && transition) {
+      applyVolume({
+        gainNode: instance.gainNode,
+        targetValue: nextVolumeValue,
+        transition,
+      });
+    } else if (volumeChanged) {
+      applyVolume({
+        gainNode: instance.gainNode,
+        targetValue: nextVolumeValue,
+        transition: null,
+      });
+    }
+
+    if (startDelayChanged && instance.pendingTimeoutId !== null) {
+      playSound(instance);
+    }
   };
 
   const renderGraph = ({
@@ -686,7 +731,9 @@ export const createAudioStage = () => {
       const duration = channelCleanupDurations.get(id) ?? 0;
       channel.cleanupTimeoutId = schedule(() => {
         cleanupChannel(channel);
-        channels.delete(id);
+        if (channels.get(id) === channel) {
+          channels.delete(id);
+        }
       }, duration);
     }
   };

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -55,6 +55,7 @@ const createRouteGraphics = () => {
     elements: [],
     animations: [],
     audio: [],
+    audioEffects: [],
   };
 
   /**
@@ -306,6 +307,8 @@ const createRouteGraphics = () => {
       app: appInstance,
       prevAudioTree: state.audio,
       nextAudioTree: nextState.audio,
+      prevAudioEffects: state.audioEffects,
+      nextAudioEffects: nextState.audioEffects,
       audioPlugins: plugins.audio,
     });
 

--- a/src/cli/renderConfig.js
+++ b/src/cli/renderConfig.js
@@ -311,6 +311,7 @@ const normalizeState = (value, index = 0) => {
     elements: Array.isArray(value.elements) ? value.elements : [],
     animations: Array.isArray(value.animations) ? value.animations : [],
     audio: Array.isArray(value.audio) ? value.audio : [],
+    audioEffects: Array.isArray(value.audioEffects) ? value.audioEffects : [],
     global: isPlainObject(value.global) ? value.global : {},
   };
 };

--- a/src/plugins/audio/renderAudio.js
+++ b/src/plugins/audio/renderAudio.js
@@ -1,4 +1,5 @@
 import { diffAudio } from "../../util/diffAudio.js";
+import { normalizeAudioRenderState } from "../../util/normalizeAudio.js";
 
 /**
  * Render audio using plugin system (synchronous)
@@ -6,14 +7,37 @@ import { diffAudio } from "../../util/diffAudio.js";
  * @param {import('../types.js').Application} params.app - The PixiJS application
  * @param {import('../types.js').SoundElement[]} params.prevAudioTree - Previous audio tree
  * @param {import('../types.js').SoundElement[]} params.nextAudioTree - Next audio tree
+ * @param {Object[]} [params.prevAudioEffects] - Previous audio effects
+ * @param {Object[]} [params.nextAudioEffects] - Next audio effects
  * @param {import("./audio/audioPlugin.js").AudioPlugin[]} params.audioPlugins - Array of audio plugins
  */
 export const renderAudio = ({
   app,
   prevAudioTree,
   nextAudioTree,
+  prevAudioEffects = [],
+  nextAudioEffects = [],
   audioPlugins,
 }) => {
+  normalizeAudioRenderState({
+    audio: prevAudioTree,
+    audioEffects: prevAudioEffects,
+  });
+  normalizeAudioRenderState({
+    audio: nextAudioTree,
+    audioEffects: nextAudioEffects,
+  });
+
+  if (typeof app.audioStage?.renderGraph === "function") {
+    app.audioStage.renderGraph({
+      prevAudio: prevAudioTree,
+      nextAudio: nextAudioTree,
+      prevAudioEffects,
+      nextAudioEffects,
+    });
+    return;
+  }
+
   const { toAddElement, toDeleteElement, toUpdateElement } = diffAudio(
     prevAudioTree,
     nextAudioTree,

--- a/src/plugins/audio/renderAudio.js
+++ b/src/plugins/audio/renderAudio.js
@@ -1,43 +1,16 @@
 import { diffAudio } from "../../util/diffAudio.js";
-import { normalizeAudioRenderState } from "../../util/normalizeAudio.js";
+import {
+  filterGraphAudio,
+  filterPluginAudio,
+  normalizeAudioRenderState,
+} from "../../util/normalizeAudio.js";
 
-/**
- * Render audio using plugin system (synchronous)
- * @param {Object} params
- * @param {import('../types.js').Application} params.app - The PixiJS application
- * @param {import('../types.js').SoundElement[]} params.prevAudioTree - Previous audio tree
- * @param {import('../types.js').SoundElement[]} params.nextAudioTree - Next audio tree
- * @param {Object[]} [params.prevAudioEffects] - Previous audio effects
- * @param {Object[]} [params.nextAudioEffects] - Next audio effects
- * @param {import("./audio/audioPlugin.js").AudioPlugin[]} params.audioPlugins - Array of audio plugins
- */
-export const renderAudio = ({
+const renderPluginDiff = ({
   app,
   prevAudioTree,
   nextAudioTree,
-  prevAudioEffects = [],
-  nextAudioEffects = [],
   audioPlugins,
 }) => {
-  normalizeAudioRenderState({
-    audio: prevAudioTree,
-    audioEffects: prevAudioEffects,
-  });
-  normalizeAudioRenderState({
-    audio: nextAudioTree,
-    audioEffects: nextAudioEffects,
-  });
-
-  if (typeof app.audioStage?.renderGraph === "function") {
-    app.audioStage.renderGraph({
-      prevAudio: prevAudioTree,
-      nextAudio: nextAudioTree,
-      prevAudioEffects,
-      nextAudioEffects,
-    });
-    return;
-  }
-
   const { toAddElement, toDeleteElement, toUpdateElement } = diffAudio(
     prevAudioTree,
     nextAudioTree,
@@ -82,4 +55,55 @@ export const renderAudio = ({
       nextElement: next,
     });
   }
+};
+
+/**
+ * Render audio using plugin system (synchronous)
+ * @param {Object} params
+ * @param {import('../types.js').Application} params.app - The PixiJS application
+ * @param {import('../types.js').SoundElement[]} params.prevAudioTree - Previous audio tree
+ * @param {import('../types.js').SoundElement[]} params.nextAudioTree - Next audio tree
+ * @param {Object[]} [params.prevAudioEffects] - Previous audio effects
+ * @param {Object[]} [params.nextAudioEffects] - Next audio effects
+ * @param {import("./audio/audioPlugin.js").AudioPlugin[]} params.audioPlugins - Array of audio plugins
+ */
+export const renderAudio = ({
+  app,
+  prevAudioTree,
+  nextAudioTree,
+  prevAudioEffects = [],
+  nextAudioEffects = [],
+  audioPlugins,
+}) => {
+  normalizeAudioRenderState({
+    audio: prevAudioTree,
+    audioEffects: prevAudioEffects,
+  });
+  normalizeAudioRenderState({
+    audio: nextAudioTree,
+    audioEffects: nextAudioEffects,
+  });
+
+  if (typeof app.audioStage?.renderGraph === "function") {
+    app.audioStage.renderGraph({
+      prevAudio: filterGraphAudio(prevAudioTree),
+      nextAudio: filterGraphAudio(nextAudioTree),
+      prevAudioEffects,
+      nextAudioEffects,
+    });
+    renderPluginDiff({
+      app,
+      prevAudioTree: filterPluginAudio(prevAudioTree),
+      nextAudioTree: filterPluginAudio(nextAudioTree),
+      audioPlugins,
+    });
+    return;
+  }
+
+  renderPluginDiff({
+    app,
+    prevAudioTree,
+    nextAudioTree,
+    audioPlugins,
+  });
 };

--- a/src/plugins/audio/sound/addSound.js
+++ b/src/plugins/audio/sound/addSound.js
@@ -7,7 +7,7 @@ const createAudioElement = (element) => ({
   id: element.id,
   url: element.src,
   loop: element.loop ?? false,
-  volume: normalizeVolume(element.volume, 80),
+  volume: normalizeVolume(element.volume, 100),
 });
 
 export const hasPendingSound = (id) => pendingTimeoutById.has(id);
@@ -23,11 +23,11 @@ export const scheduleSound = ({ app, element }) => {
   const audioElement = createAudioElement(element);
   cancelPendingSound(audioElement.id);
 
-  if (element.delay && element.delay > 0) {
+  if (element.startDelayMs && element.startDelayMs > 0) {
     const timeoutId = setTimeout(() => {
       pendingTimeoutById.delete(audioElement.id);
       app.audioStage.add(audioElement);
-    }, element.delay);
+    }, element.startDelayMs);
     pendingTimeoutById.set(audioElement.id, timeoutId);
     return;
   }

--- a/src/plugins/audio/sound/updateSound.js
+++ b/src/plugins/audio/sound/updateSound.js
@@ -14,7 +14,7 @@ import { normalizeVolume } from "../../../util/normalizeVolume.js";
  */
 export const updateSound = ({ app, prevElement, nextElement }) => {
   const id = prevElement.id;
-  const nextDelay = nextElement.delay ?? 0;
+  const nextDelay = nextElement.startDelayMs ?? 0;
 
   // Delayed sound updates are rescheduled from scratch.
   if (nextDelay > 0) {
@@ -30,7 +30,7 @@ export const updateSound = ({ app, prevElement, nextElement }) => {
       id,
       url: nextElement.src,
       loop: nextElement.loop ?? false,
-      volume: normalizeVolume(nextElement.volume, 80),
+      volume: normalizeVolume(nextElement.volume, 100),
     });
     return;
   }
@@ -41,12 +41,12 @@ export const updateSound = ({ app, prevElement, nextElement }) => {
       id,
       url: nextElement.src,
       loop: nextElement.loop ?? false,
-      volume: normalizeVolume(nextElement.volume, 80),
+      volume: normalizeVolume(nextElement.volume, 100),
     });
     return;
   }
 
   audioElement.url = nextElement.src;
   audioElement.loop = nextElement.loop ?? false;
-  audioElement.volume = normalizeVolume(nextElement.volume, 80);
+  audioElement.volume = normalizeVolume(nextElement.volume, 100);
 };

--- a/src/schemas/audio/audio-channel.yaml
+++ b/src/schemas/audio/audio-channel.yaml
@@ -1,0 +1,36 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: Audio Channel
+description: Schema for an audio bus/container
+type: object
+required:
+  - id
+  - type
+properties:
+  id:
+    type: string
+    description: Unique identifier
+  type:
+    const: audio-channel
+    description: Audio channel
+  volume:
+    type: number
+    description: Channel volume. 0 means muted. 100 means original full volume.
+    default: 100
+    minimum: 0
+    maximum: 100
+  muted:
+    type: boolean
+    description: Whether the channel is muted
+    default: false
+  pan:
+    type: number
+    description: Stereo pan. -1 means left. 1 means right.
+    default: 0
+    minimum: -1
+    maximum: 1
+  children:
+    type: array
+    description: Sound nodes owned by this channel
+    default: []
+    items:
+      $ref: "sound.yaml"

--- a/src/schemas/audio/audio-transition.yaml
+++ b/src/schemas/audio/audio-transition.yaml
@@ -1,0 +1,81 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: Audio Transition
+description: Schema for audio property automation
+type: object
+required:
+  - id
+  - type
+  - targetId
+  - properties
+properties:
+  id:
+    type: string
+    description: Unique identifier
+  type:
+    const: audioTransition
+    description: Audio transition
+  targetId:
+    type: string
+    description: Audio node ID to automate
+  properties:
+    type: object
+    description: Property automation map
+    properties:
+      volume:
+        type: object
+        properties:
+          enter:
+            $ref: "#/definitions/enterPhase"
+          exit:
+            $ref: "#/definitions/exitPhase"
+          update:
+            $ref: "#/definitions/updatePhase"
+        additionalProperties: false
+    additionalProperties: false
+definitions:
+  enterPhase:
+    type: object
+    required:
+      - from
+      - duration
+      - easing
+    properties:
+      from:
+        type: number
+        minimum: 0
+        maximum: 100
+      duration:
+        type: number
+        minimum: 0
+      easing:
+        const: linear
+    additionalProperties: false
+  exitPhase:
+    type: object
+    required:
+      - to
+      - duration
+      - easing
+    properties:
+      to:
+        type: number
+        minimum: 0
+        maximum: 100
+      duration:
+        type: number
+        minimum: 0
+      easing:
+        const: linear
+    additionalProperties: false
+  updatePhase:
+    type: object
+    required:
+      - duration
+      - easing
+    properties:
+      duration:
+        type: number
+        minimum: 0
+      easing:
+        const: linear
+    additionalProperties: false

--- a/src/schemas/audio/sound.yaml
+++ b/src/schemas/audio/sound.yaml
@@ -19,15 +19,42 @@ properties:
   volume:
     type: number
     description: Volume. 0 means muted. 100 means original full volume.
-    default: 80
+    default: 100
     minimum: 0
     maximum: 100
+  muted:
+    type: boolean
+    description: Whether the sound is muted
+    default: false
+  pan:
+    type: number
+    description: Stereo pan. -1 means left. 1 means right.
+    default: 0
+    minimum: -1
+    maximum: 1
   loop:
     type: boolean
     description: Loop
     default: false
-  delay:
+  startDelayMs:
     type: number
     description: Delay in milliseconds before playing the sound
     default: 0
+    minimum: 0
+  playbackRate:
+    type: number
+    description: Playback speed multiplier
+    default: 1
+    minimum: 0
+  startAt:
+    type: number
+    description: Start offset in seconds
+    default: 0
+    minimum: 0
+  endAt:
+    type:
+      - number
+      - "null"
+    description: Optional end time in seconds
+    default: null
     minimum: 0

--- a/src/types.js
+++ b/src/types.js
@@ -550,9 +550,32 @@
  * @property {string} id - Unique identifier
  * @property {string} type - Should be "sound"
  * @property {string} src - Source of the sound
- * @property {number} [volume=80] - Volume (0-100, 80 default)
+ * @property {number} [volume=100] - Volume (0-100, 100 default)
+ * @property {boolean} [muted=false] - Whether the sound is muted
+ * @property {number} [pan=0] - Stereo pan from -1 to 1
  * @property {boolean} [loop=false] - Whether to loop the sound
- * @property {number} [delay=0] - Delay in milliseconds before playing
+ * @property {number} [startDelayMs=0] - Delay in milliseconds before playing
+ * @property {number} [playbackRate=1] - Playback speed multiplier
+ * @property {number} [startAt=0] - Start offset in seconds
+ * @property {number|null} [endAt=null] - Optional end time in seconds
+ */
+
+/**
+ * @typedef {Object} AudioChannelElement
+ * @property {string} id - Unique identifier
+ * @property {string} type - Should be "audio-channel"
+ * @property {number} [volume=100] - Volume (0-100, 100 default)
+ * @property {boolean} [muted=false] - Whether the channel is muted
+ * @property {number} [pan=0] - Stereo pan from -1 to 1
+ * @property {SoundElement[]} [children=[]] - Sound nodes owned by the channel
+ */
+
+/**
+ * @typedef {Object} AudioTransition
+ * @property {string} id - Unique identifier
+ * @property {string} type - Should be "audioTransition"
+ * @property {string} targetId - Target sound or audio-channel id
+ * @property {Object} properties - Transition properties
  */
 
 /**
@@ -702,6 +725,8 @@ export const DEFAULT_TEXT_STYLE = {
  * @property {string} id - ID
  * @property {E[]} elements - Array of elements
  * @property {T[]} animations - Array of animations
+ * @property {(SoundElement|AudioChannelElement)[]} audio - Array of audio nodes
+ * @property {AudioTransition[]} audioEffects - Array of audio effects
  * @property {GlobalConfiguration} [global] - Global configuration options
  */
 

--- a/src/util/diffAudio.js
+++ b/src/util/diffAudio.js
@@ -40,7 +40,12 @@ export const diffAudio = (prevElements = [], nextElements = []) => {
       prevEl.src !== nextEl.src ||
       prevEl.volume !== nextEl.volume ||
       prevEl.loop !== nextEl.loop ||
-      prevEl.delay !== nextEl.delay
+      prevEl.startDelayMs !== nextEl.startDelayMs ||
+      prevEl.muted !== nextEl.muted ||
+      prevEl.pan !== nextEl.pan ||
+      prevEl.playbackRate !== nextEl.playbackRate ||
+      prevEl.startAt !== nextEl.startAt ||
+      prevEl.endAt !== nextEl.endAt
     ) {
       //Update element
       toUpdateElement.push({

--- a/src/util/diffAudio.js
+++ b/src/util/diffAudio.js
@@ -1,3 +1,5 @@
+import { isDeepEqual } from "./isDeepEqual.js";
+
 /**
  * @typedef {import("../types.js").DiffElementResult} DiffElementResult
  * @typedef {import("../types.js").SoundElement} SoundElement
@@ -36,17 +38,7 @@ export const diffAudio = (prevElements = [], nextElements = []) => {
       toAddElement.push(nextEl);
     } else if (prevEl && !nextEl) {
       toDeleteElement.push(prevEl);
-    } else if (
-      prevEl.src !== nextEl.src ||
-      prevEl.volume !== nextEl.volume ||
-      prevEl.loop !== nextEl.loop ||
-      prevEl.startDelayMs !== nextEl.startDelayMs ||
-      prevEl.muted !== nextEl.muted ||
-      prevEl.pan !== nextEl.pan ||
-      prevEl.playbackRate !== nextEl.playbackRate ||
-      prevEl.startAt !== nextEl.startAt ||
-      prevEl.endAt !== nextEl.endAt
-    ) {
+    } else if (!isDeepEqual(prevEl, nextEl)) {
       //Update element
       toUpdateElement.push({
         prev: prevEl,

--- a/src/util/normalizeAudio.js
+++ b/src/util/normalizeAudio.js
@@ -1,0 +1,314 @@
+const AUDIO_NODE_TYPES = new Set(["audio-channel", "sound"]);
+const AUDIO_EFFECT_TYPES = new Set(["audioTransition"]);
+const AUDIO_TRANSITION_PHASES = new Set(["enter", "exit", "update"]);
+const AUDIO_TRANSITION_PROPERTIES = new Set(["volume"]);
+const AUDIO_EASINGS = new Set(["linear"]);
+const AUDIO_TRANSITION_PHASE_KEYS = {
+  enter: new Set(["from", "duration", "easing"]),
+  exit: new Set(["to", "duration", "easing"]),
+  update: new Set(["duration", "easing"]),
+};
+
+const isRecord = (value) =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const assertRecord = (value, path) => {
+  if (!isRecord(value)) {
+    throw new Error(`Input error: ${path} must be an object.`);
+  }
+};
+
+const assertNonEmptyString = (value, path) => {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Input error: ${path} must be a non-empty string.`);
+  }
+};
+
+const assertNumber = (value, path, { min, max } = {}) => {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    throw new Error(`Input error: ${path} must be a number.`);
+  }
+
+  if (min !== undefined && value < min) {
+    throw new Error(
+      `Input error: ${path} must be greater than or equal to ${min}.`,
+    );
+  }
+
+  if (max !== undefined && value > max) {
+    throw new Error(
+      `Input error: ${path} must be less than or equal to ${max}.`,
+    );
+  }
+};
+
+const assertOptionalBoolean = (value, path) => {
+  if (value !== undefined && typeof value !== "boolean") {
+    throw new Error(`Input error: ${path} must be a boolean.`);
+  }
+};
+
+const assertOptionalNumber = (value, path, range) => {
+  if (value !== undefined && value !== null) {
+    assertNumber(value, path, range);
+  }
+};
+
+const assertUniqueId = (ids, id, path) => {
+  if (ids.has(id)) {
+    throw new Error(
+      `Input error: duplicate audio render-state id "${id}" at ${path}.`,
+    );
+  }
+  ids.add(id);
+};
+
+const validateSound = (node, path, ids, flattenedSounds, channelId = null) => {
+  assertNonEmptyString(node.id, `${path}.id`);
+  assertUniqueId(ids, node.id, `${path}.id`);
+  assertNonEmptyString(node.src, `${path}.src`);
+
+  if (node.delay !== undefined) {
+    throw new Error(
+      `Input error: ${path}.delay is not supported. Use ${path}.startDelayMs instead.`,
+    );
+  }
+
+  assertOptionalNumber(node.volume, `${path}.volume`, { min: 0, max: 100 });
+  assertOptionalBoolean(node.muted, `${path}.muted`);
+  assertOptionalNumber(node.pan, `${path}.pan`, { min: -1, max: 1 });
+  assertOptionalBoolean(node.loop, `${path}.loop`);
+  assertOptionalNumber(node.startDelayMs, `${path}.startDelayMs`, { min: 0 });
+  assertOptionalNumber(node.playbackRate, `${path}.playbackRate`, { min: 0 });
+  assertOptionalNumber(node.startAt, `${path}.startAt`, { min: 0 });
+  assertOptionalNumber(node.endAt, `${path}.endAt`, { min: 0 });
+
+  if (
+    node.endAt !== undefined &&
+    node.endAt !== null &&
+    node.startAt !== undefined &&
+    node.endAt < node.startAt
+  ) {
+    throw new Error(
+      `Input error: ${path}.endAt must be greater than or equal to startAt.`,
+    );
+  }
+
+  flattenedSounds.push({
+    id: node.id,
+    type: "sound",
+    src: node.src,
+    volume: node.volume ?? 100,
+    muted: node.muted ?? false,
+    pan: node.pan ?? 0,
+    loop: node.loop ?? false,
+    startDelayMs: node.startDelayMs ?? 0,
+    playbackRate: node.playbackRate ?? 1,
+    startAt: node.startAt ?? 0,
+    endAt: node.endAt ?? null,
+    channelId,
+  });
+};
+
+const validateChannel = (
+  node,
+  path,
+  ids,
+  flattenedChannels,
+  flattenedSounds,
+) => {
+  assertNonEmptyString(node.id, `${path}.id`);
+  assertUniqueId(ids, node.id, `${path}.id`);
+
+  assertOptionalNumber(node.volume, `${path}.volume`, { min: 0, max: 100 });
+  assertOptionalBoolean(node.muted, `${path}.muted`);
+  assertOptionalNumber(node.pan, `${path}.pan`, { min: -1, max: 1 });
+
+  if (node.children !== undefined && !Array.isArray(node.children)) {
+    throw new Error(`Input error: ${path}.children must be an array.`);
+  }
+
+  flattenedChannels.push({
+    id: node.id,
+    type: "audio-channel",
+    volume: node.volume ?? 100,
+    muted: node.muted ?? false,
+    pan: node.pan ?? 0,
+  });
+
+  for (const [index, child] of (node.children ?? []).entries()) {
+    const childPath = `${path}.children[${index}]`;
+    assertRecord(child, childPath);
+
+    if (child.type === "audio-channel") {
+      throw new Error(
+        `Input error: nested audio-channel nodes are not supported at ${childPath}.`,
+      );
+    }
+
+    if (child.type !== "sound") {
+      throw new Error(`Input error: ${childPath}.type must be "sound".`);
+    }
+
+    validateSound(child, childPath, ids, flattenedSounds, node.id);
+  }
+};
+
+const validateAudioNodes = (audio, ids) => {
+  if (!Array.isArray(audio)) {
+    throw new Error("Input error: `audio` must be an array.");
+  }
+
+  const flattenedChannels = [];
+  const flattenedSounds = [];
+
+  for (const [index, node] of audio.entries()) {
+    const path = `audio[${index}]`;
+    assertRecord(node, path);
+
+    if (!AUDIO_NODE_TYPES.has(node.type)) {
+      throw new Error(
+        `Input error: unsupported audio node type "${node.type}" at ${path}.`,
+      );
+    }
+
+    if (node.type === "audio-channel") {
+      validateChannel(node, path, ids, flattenedChannels, flattenedSounds);
+    } else {
+      validateSound(node, path, ids, flattenedSounds);
+    }
+  }
+
+  return {
+    channels: flattenedChannels,
+    sounds: flattenedSounds,
+  };
+};
+
+const validateTransitionPhase = (phase, phaseName, path, propertyName) => {
+  assertRecord(phase, path);
+
+  for (const key of Object.keys(phase)) {
+    if (!AUDIO_TRANSITION_PHASE_KEYS[phaseName].has(key)) {
+      throw new Error(
+        `Input error: unsupported audio transition field "${key}" at ${path}.`,
+      );
+    }
+  }
+
+  if (phase.duration === undefined) {
+    throw new Error(`Input error: ${path}.duration is required.`);
+  }
+  assertNumber(phase.duration, `${path}.duration`, { min: 0 });
+
+  if (phase.easing === undefined) {
+    throw new Error(`Input error: ${path}.easing is required.`);
+  }
+  if (!AUDIO_EASINGS.has(phase.easing)) {
+    throw new Error(
+      `Input error: ${path}.easing "${phase.easing}" is not supported.`,
+    );
+  }
+
+  if (phaseName === "enter") {
+    if (phase.from === undefined) {
+      throw new Error(`Input error: ${path}.from is required.`);
+    }
+    assertNumber(phase.from, `${path}.from`, { min: 0, max: 100 });
+  }
+
+  if (phaseName === "exit") {
+    if (phase.to === undefined) {
+      throw new Error(`Input error: ${path}.to is required.`);
+    }
+    assertNumber(phase.to, `${path}.to`, { min: 0, max: 100 });
+  }
+
+  if (propertyName !== "volume") {
+    throw new Error(
+      `Input error: unsupported audio transition property "${propertyName}" at ${path}.`,
+    );
+  }
+};
+
+const validateAudioTransition = (effect, path, nodeIds) => {
+  assertNonEmptyString(effect.targetId, `${path}.targetId`);
+  if (!nodeIds.has(effect.targetId)) {
+    throw new Error(
+      `Input error: ${path}.targetId "${effect.targetId}" does not resolve to an audio node.`,
+    );
+  }
+
+  assertRecord(effect.properties, `${path}.properties`);
+
+  for (const [propertyName, propertyTransitions] of Object.entries(
+    effect.properties,
+  )) {
+    if (!AUDIO_TRANSITION_PROPERTIES.has(propertyName)) {
+      throw new Error(
+        `Input error: unsupported audio transition property "${propertyName}" at ${path}.properties.`,
+      );
+    }
+
+    assertRecord(propertyTransitions, `${path}.properties.${propertyName}`);
+
+    for (const [phaseName, phase] of Object.entries(propertyTransitions)) {
+      if (!AUDIO_TRANSITION_PHASES.has(phaseName)) {
+        throw new Error(
+          `Input error: unsupported audio transition phase "${phaseName}" at ${path}.properties.${propertyName}.`,
+        );
+      }
+
+      validateTransitionPhase(
+        phase,
+        phaseName,
+        `${path}.properties.${propertyName}.${phaseName}`,
+        propertyName,
+      );
+    }
+  }
+};
+
+const validateAudioEffects = (audioEffects, ids, nodeIds) => {
+  if (!Array.isArray(audioEffects)) {
+    throw new Error("Input error: `audioEffects` must be an array.");
+  }
+
+  for (const [index, effect] of audioEffects.entries()) {
+    const path = `audioEffects[${index}]`;
+    assertRecord(effect, path);
+    assertNonEmptyString(effect.id, `${path}.id`);
+    assertUniqueId(ids, effect.id, `${path}.id`);
+
+    if (!AUDIO_EFFECT_TYPES.has(effect.type)) {
+      throw new Error(
+        `Input error: unsupported audio effect type "${effect.type}" at ${path}.`,
+      );
+    }
+
+    if (effect.type === "audioTransition") {
+      validateAudioTransition(effect, path, nodeIds);
+    }
+  }
+};
+
+export const flattenAudioNodes = (audio = []) => {
+  const ids = new Set();
+  return validateAudioNodes(audio, ids);
+};
+
+export const normalizeAudioRenderState = ({
+  audio = [],
+  audioEffects = [],
+} = {}) => {
+  const ids = new Set();
+  const flattened = validateAudioNodes(audio, ids);
+  const nodeIds = new Set(ids);
+  validateAudioEffects(audioEffects, ids, nodeIds);
+
+  return {
+    audio,
+    audioEffects,
+    ...flattened,
+  };
+};

--- a/src/util/normalizeAudio.js
+++ b/src/util/normalizeAudio.js
@@ -161,27 +161,36 @@ const validateAudioNodes = (audio, ids) => {
 
   const flattenedChannels = [];
   const flattenedSounds = [];
+  const builtinNodeIds = new Set();
 
   for (const [index, node] of audio.entries()) {
     const path = `audio[${index}]`;
     assertRecord(node, path);
 
     if (!AUDIO_NODE_TYPES.has(node.type)) {
-      throw new Error(
-        `Input error: unsupported audio node type "${node.type}" at ${path}.`,
-      );
+      assertNonEmptyString(node.id, `${path}.id`);
+      assertUniqueId(ids, node.id, `${path}.id`);
+      continue;
     }
 
     if (node.type === "audio-channel") {
       validateChannel(node, path, ids, flattenedChannels, flattenedSounds);
+      builtinNodeIds.add(node.id);
+      for (const sound of flattenedSounds) {
+        if (sound.channelId === node.id) {
+          builtinNodeIds.add(sound.id);
+        }
+      }
     } else {
       validateSound(node, path, ids, flattenedSounds);
+      builtinNodeIds.add(node.id);
     }
   }
 
   return {
     channels: flattenedChannels,
     sounds: flattenedSounds,
+    builtinNodeIds,
   };
 };
 
@@ -303,12 +312,19 @@ export const normalizeAudioRenderState = ({
 } = {}) => {
   const ids = new Set();
   const flattened = validateAudioNodes(audio, ids);
-  const nodeIds = new Set(ids);
-  validateAudioEffects(audioEffects, ids, nodeIds);
+  validateAudioEffects(audioEffects, ids, flattened.builtinNodeIds);
 
   return {
     audio,
     audioEffects,
-    ...flattened,
+    channels: flattened.channels,
+    sounds: flattened.sounds,
   };
 };
+
+export const isGraphAudioNode = (node) => AUDIO_NODE_TYPES.has(node?.type);
+
+export const filterGraphAudio = (audio = []) => audio.filter(isGraphAudioNode);
+
+export const filterPluginAudio = (audio = []) =>
+  audio.filter((node) => !isGraphAudioNode(node));

--- a/src/util/normalizeRenderState.js
+++ b/src/util/normalizeRenderState.js
@@ -1,4 +1,5 @@
 import { normalizeAnimations } from "./normalizeAnimations.js";
+import { normalizeAudioRenderState } from "./normalizeAudio.js";
 
 /**
  * Normalize render state and enforce public state contract.
@@ -23,6 +24,7 @@ export const normalizeRenderState = (state = {}) => {
     elements: state.elements ?? [],
     animations: state.animations ?? [],
     audio: state.audio ?? [],
+    audioEffects: state.audioEffects ?? [],
   };
 
   if (!Array.isArray(normalizedState.elements)) {
@@ -37,7 +39,15 @@ export const normalizeRenderState = (state = {}) => {
     throw new Error("Input error: `audio` must be an array.");
   }
 
+  if (!Array.isArray(normalizedState.audioEffects)) {
+    throw new Error("Input error: `audioEffects` must be an array.");
+  }
+
   normalizedState.animations = normalizeAnimations(normalizedState.animations);
+  normalizeAudioRenderState({
+    audio: normalizedState.audio,
+    audioEffects: normalizedState.audioEffects,
+  });
 
   return normalizedState;
 };

--- a/vt/specs/audio/channel-mixer.yaml
+++ b/vt/specs/audio/channel-mixer.yaml
@@ -1,0 +1,168 @@
+---
+title: Audio Manual - Channel Mixer
+description: Manual fixture for channel volume, sound volume, mute, pan, and moving a continuing sound between channels. Use the state pager or n/b keys.
+specs:
+  - state 1 is silent so pressing n starts audio from a user gesture
+  - state 2 should play bgm-1 through the music channel at moderate level
+  - state 3 should raise channel gain without restarting the same sound
+  - state 4 should mute the child sound while the channel stays present
+  - state 5 should unmute and pan the sound left
+  - state 6 should move the same sound id to a second channel and pan right without restarting
+---
+states:
+  - id: channel-ready
+    elements:
+      - id: ready
+        type: rect
+        x: 160
+        "y": 160
+        width: 180
+        height: 180
+        fill: "#4D4D4D"
+    audio: []
+  - id: channel-music-moderate
+    elements:
+      - id: meter
+        type: rect
+        x: 160
+        "y": 160
+        width: 240
+        height: 240
+        fill: "#737373"
+      - id: channel-a
+        type: rect
+        x: 520
+        "y": 220
+        width: 160
+        height: 160
+        fill: "#A6A6A6"
+    audio:
+      - id: music
+        type: audio-channel
+        volume: 45
+        children:
+          - id: bgm-bed
+            type: sound
+            src: bgm-1
+            loop: true
+            volume: 80
+  - id: channel-music-louder
+    elements:
+      - id: meter
+        type: rect
+        x: 160
+        "y": 160
+        width: 480
+        height: 240
+        fill: "#D9D9D9"
+      - id: channel-a
+        type: rect
+        x: 520
+        "y": 220
+        width: 160
+        height: 160
+        fill: "#FFFFFF"
+    audio:
+      - id: music
+        type: audio-channel
+        volume: 90
+        children:
+          - id: bgm-bed
+            type: sound
+            src: bgm-1
+            loop: true
+            volume: 80
+    audioEffects:
+      - id: music-volume-update
+        type: audioTransition
+        targetId: music
+        properties:
+          volume:
+            update:
+              duration: 1200
+              easing: linear
+  - id: channel-child-muted
+    elements:
+      - id: meter
+        type: rect
+        x: 160
+        "y": 160
+        width: 120
+        height: 240
+        fill: "#4D4D4D"
+      - id: channel-a
+        type: rect
+        x: 520
+        "y": 220
+        width: 160
+        height: 160
+        fill: "#737373"
+    audio:
+      - id: music
+        type: audio-channel
+        volume: 90
+        children:
+          - id: bgm-bed
+            type: sound
+            src: bgm-1
+            loop: true
+            volume: 80
+            muted: true
+  - id: channel-child-left-pan
+    elements:
+      - id: meter
+        type: rect
+        x: 160
+        "y": 160
+        width: 360
+        height: 240
+        fill: "#A6A6A6"
+      - id: channel-a
+        type: rect
+        x: 320
+        "y": 220
+        width: 160
+        height: 160
+        fill: "#FFFFFF"
+    audio:
+      - id: music
+        type: audio-channel
+        volume: 70
+        children:
+          - id: bgm-bed
+            type: sound
+            src: bgm-1
+            loop: true
+            volume: 80
+            pan: -1
+  - id: channel-move-right-pan
+    elements:
+      - id: meter
+        type: rect
+        x: 160
+        "y": 160
+        width: 360
+        height: 240
+        fill: "#A6A6A6"
+      - id: channel-b
+        type: rect
+        x: 800
+        "y": 220
+        width: 160
+        height: 160
+        fill: "#FFFFFF"
+    audio:
+      - id: music
+        type: audio-channel
+        volume: 70
+        children: []
+      - id: effects
+        type: audio-channel
+        volume: 70
+        children:
+          - id: bgm-bed
+            type: sound
+            src: bgm-1
+            loop: true
+            volume: 80
+            pan: 1

--- a/vt/specs/audio/channel-mixer.yaml
+++ b/vt/specs/audio/channel-mixer.yaml
@@ -11,31 +11,8 @@ specs:
 ---
 states:
   - id: channel-ready
-    elements:
-      - id: ready
-        type: rect
-        x: 160
-        "y": 160
-        width: 180
-        height: 180
-        fill: "#4D4D4D"
     audio: []
   - id: channel-music-moderate
-    elements:
-      - id: meter
-        type: rect
-        x: 160
-        "y": 160
-        width: 240
-        height: 240
-        fill: "#737373"
-      - id: channel-a
-        type: rect
-        x: 520
-        "y": 220
-        width: 160
-        height: 160
-        fill: "#A6A6A6"
     audio:
       - id: music
         type: audio-channel
@@ -47,21 +24,6 @@ states:
             loop: true
             volume: 80
   - id: channel-music-louder
-    elements:
-      - id: meter
-        type: rect
-        x: 160
-        "y": 160
-        width: 480
-        height: 240
-        fill: "#D9D9D9"
-      - id: channel-a
-        type: rect
-        x: 520
-        "y": 220
-        width: 160
-        height: 160
-        fill: "#FFFFFF"
     audio:
       - id: music
         type: audio-channel
@@ -82,21 +44,6 @@ states:
               duration: 1200
               easing: linear
   - id: channel-child-muted
-    elements:
-      - id: meter
-        type: rect
-        x: 160
-        "y": 160
-        width: 120
-        height: 240
-        fill: "#4D4D4D"
-      - id: channel-a
-        type: rect
-        x: 520
-        "y": 220
-        width: 160
-        height: 160
-        fill: "#737373"
     audio:
       - id: music
         type: audio-channel
@@ -109,21 +56,6 @@ states:
             volume: 80
             muted: true
   - id: channel-child-left-pan
-    elements:
-      - id: meter
-        type: rect
-        x: 160
-        "y": 160
-        width: 360
-        height: 240
-        fill: "#A6A6A6"
-      - id: channel-a
-        type: rect
-        x: 320
-        "y": 220
-        width: 160
-        height: 160
-        fill: "#FFFFFF"
     audio:
       - id: music
         type: audio-channel
@@ -136,21 +68,6 @@ states:
             volume: 80
             pan: -1
   - id: channel-move-right-pan
-    elements:
-      - id: meter
-        type: rect
-        x: 160
-        "y": 160
-        width: 360
-        height: 240
-        fill: "#A6A6A6"
-      - id: channel-b
-        type: rect
-        x: 800
-        "y": 220
-        width: 160
-        height: 160
-        fill: "#FFFFFF"
     audio:
       - id: music
         type: audio-channel

--- a/vt/specs/audio/channel-mixer.yaml
+++ b/vt/specs/audio/channel-mixer.yaml
@@ -1,6 +1,7 @@
 ---
 title: Audio Manual - Channel Mixer
 description: Manual fixture for channel volume, sound volume, mute, pan, and moving a continuing sound between channels. Use the state pager or n/b keys.
+skipScreenshot: true
 specs:
   - state 1 is silent so pressing n starts audio from a user gesture
   - state 2 should play bgm-1 through the music channel at moderate level

--- a/vt/specs/audio/flat-sounds.yaml
+++ b/vt/specs/audio/flat-sounds.yaml
@@ -10,24 +10,8 @@ specs:
 ---
 states:
   - id: flat-ready
-    elements:
-      - id: ready
-        type: rect
-        x: 180
-        "y": 180
-        width: 180
-        height: 180
-        fill: "#4D4D4D"
     audio: []
   - id: flat-bgm-start
-    elements:
-      - id: marker
-        type: rect
-        x: 180
-        "y": 180
-        width: 220
-        height: 220
-        fill: "#737373"
     audio:
       - id: flat-bgm
         type: sound
@@ -45,21 +29,6 @@ states:
               duration: 1000
               easing: linear
   - id: flat-bgm-continue-quieter
-    elements:
-      - id: marker
-        type: rect
-        x: 180
-        "y": 180
-        width: 220
-        height: 220
-        fill: "#A6A6A6"
-      - id: level
-        type: rect
-        x: 520
-        "y": 260
-        width: 160
-        height: 80
-        fill: "#737373"
     audio:
       - id: flat-bgm
         type: sound
@@ -80,21 +49,6 @@ states:
               duration: 1000
               easing: linear
   - id: flat-bgm-replace-source
-    elements:
-      - id: marker
-        type: rect
-        x: 180
-        "y": 180
-        width: 220
-        height: 220
-        fill: "#D9D9D9"
-      - id: level
-        type: rect
-        x: 520
-        "y": 220
-        width: 260
-        height: 160
-        fill: "#A6A6A6"
     audio:
       - id: flat-bgm
         type: sound
@@ -116,21 +70,6 @@ states:
               duration: 1000
               easing: linear
   - id: flat-one-shot-first
-    elements:
-      - id: marker
-        type: rect
-        x: 180
-        "y": 180
-        width: 220
-        height: 220
-        fill: "#FFFFFF"
-      - id: pulse
-        type: rect
-        x: 860
-        "y": 260
-        width: 80
-        height: 80
-        fill: "#D9D9D9"
     audio:
       - id: flat-bgm
         type: sound
@@ -142,21 +81,6 @@ states:
         src: sfx-1
         volume: 100
   - id: flat-one-shot-second
-    elements:
-      - id: marker
-        type: rect
-        x: 180
-        "y": 180
-        width: 220
-        height: 220
-        fill: "#FFFFFF"
-      - id: pulse
-        type: rect
-        x: 960
-        "y": 260
-        width: 80
-        height: 80
-        fill: "#D9D9D9"
     audio:
       - id: flat-bgm
         type: sound

--- a/vt/specs/audio/flat-sounds.yaml
+++ b/vt/specs/audio/flat-sounds.yaml
@@ -1,0 +1,169 @@
+---
+title: Audio Manual - Flat Sounds
+description: Manual fixture for flat sound compatibility, continuing same-id sounds, source replacement, and one-shot replay ids. Use the state pager or n/b keys.
+specs:
+  - state 1 is silent so pressing n starts audio from a user gesture
+  - state 2 should play bgm-1 as a flat looping sound
+  - state 3 should keep the same id and source, changing volume without replaying
+  - state 4 should keep the same id but replace the source with bgm-2
+  - states 5 and 6 should replay sfx-1 because the one-shot ids change
+---
+states:
+  - id: flat-ready
+    elements:
+      - id: ready
+        type: rect
+        x: 180
+        "y": 180
+        width: 180
+        height: 180
+        fill: "#4D4D4D"
+    audio: []
+  - id: flat-bgm-start
+    elements:
+      - id: marker
+        type: rect
+        x: 180
+        "y": 180
+        width: 220
+        height: 220
+        fill: "#737373"
+    audio:
+      - id: flat-bgm
+        type: sound
+        src: bgm-1
+        loop: true
+        volume: 60
+    audioEffects:
+      - id: flat-bgm-enter
+        type: audioTransition
+        targetId: flat-bgm
+        properties:
+          volume:
+            enter:
+              from: 0
+              duration: 1000
+              easing: linear
+  - id: flat-bgm-continue-quieter
+    elements:
+      - id: marker
+        type: rect
+        x: 180
+        "y": 180
+        width: 220
+        height: 220
+        fill: "#A6A6A6"
+      - id: level
+        type: rect
+        x: 520
+        "y": 260
+        width: 160
+        height: 80
+        fill: "#737373"
+    audio:
+      - id: flat-bgm
+        type: sound
+        src: bgm-1
+        loop: true
+        volume: 25
+    audioEffects:
+      - id: flat-bgm-update
+        type: audioTransition
+        targetId: flat-bgm
+        properties:
+          volume:
+            update:
+              duration: 800
+              easing: linear
+            exit:
+              to: 0
+              duration: 1000
+              easing: linear
+  - id: flat-bgm-replace-source
+    elements:
+      - id: marker
+        type: rect
+        x: 180
+        "y": 180
+        width: 220
+        height: 220
+        fill: "#D9D9D9"
+      - id: level
+        type: rect
+        x: 520
+        "y": 220
+        width: 260
+        height: 160
+        fill: "#A6A6A6"
+    audio:
+      - id: flat-bgm
+        type: sound
+        src: bgm-2
+        loop: true
+        volume: 55
+    audioEffects:
+      - id: flat-bgm-replace-enter
+        type: audioTransition
+        targetId: flat-bgm
+        properties:
+          volume:
+            enter:
+              from: 0
+              duration: 1000
+              easing: linear
+            exit:
+              to: 0
+              duration: 1000
+              easing: linear
+  - id: flat-one-shot-first
+    elements:
+      - id: marker
+        type: rect
+        x: 180
+        "y": 180
+        width: 220
+        height: 220
+        fill: "#FFFFFF"
+      - id: pulse
+        type: rect
+        x: 860
+        "y": 260
+        width: 80
+        height: 80
+        fill: "#D9D9D9"
+    audio:
+      - id: flat-bgm
+        type: sound
+        src: bgm-2
+        loop: true
+        volume: 45
+      - id: one-shot-1
+        type: sound
+        src: sfx-1
+        volume: 100
+  - id: flat-one-shot-second
+    elements:
+      - id: marker
+        type: rect
+        x: 180
+        "y": 180
+        width: 220
+        height: 220
+        fill: "#FFFFFF"
+      - id: pulse
+        type: rect
+        x: 960
+        "y": 260
+        width: 80
+        height: 80
+        fill: "#D9D9D9"
+    audio:
+      - id: flat-bgm
+        type: sound
+        src: bgm-2
+        loop: true
+        volume: 45
+      - id: one-shot-2
+        type: sound
+        src: sfx-1
+        volume: 100

--- a/vt/specs/audio/flat-sounds.yaml
+++ b/vt/specs/audio/flat-sounds.yaml
@@ -1,6 +1,7 @@
 ---
 title: Audio Manual - Flat Sounds
 description: Manual fixture for flat sound compatibility, continuing same-id sounds, source replacement, and one-shot replay ids. Use the state pager or n/b keys.
+skipScreenshot: true
 specs:
   - state 1 is silent so pressing n starts audio from a user gesture
   - state 2 should play bgm-1 as a flat looping sound

--- a/vt/specs/audio/playback-options.yaml
+++ b/vt/specs/audio/playback-options.yaml
@@ -1,0 +1,102 @@
+---
+title: Audio Manual - Playback Options
+description: Manual fixture for startDelayMs, playbackRate, startAt, endAt, loop, and stopping audio. Use the state pager or n/b keys.
+specs:
+  - state 1 is silent so pressing n starts audio from a user gesture
+  - state 2 should play sfx-1 after a one second delay
+  - state 3 should play a fast partial bgm-3 segment
+  - state 4 should loop a slower bgm-3 segment
+  - state 5 should remove all audio
+---
+states:
+  - id: playback-ready
+    elements:
+      - id: ready
+        type: rect
+        x: 180
+        "y": 260
+        width: 180
+        height: 180
+        fill: "#4D4D4D"
+    audio: []
+  - id: delayed-sfx
+    elements:
+      - id: delay-track
+        type: rect
+        x: 180
+        "y": 310
+        width: 520
+        height: 80
+        fill: "#737373"
+      - id: delay-marker
+        type: rect
+        x: 180
+        "y": 260
+        width: 80
+        height: 180
+        fill: "#D9D9D9"
+    audio:
+      - id: delayed-sfx
+        type: sound
+        src: sfx-1
+        volume: 100
+        startDelayMs: 1000
+  - id: partial-fast-segment
+    elements:
+      - id: segment
+        type: rect
+        x: 260
+        "y": 240
+        width: 360
+        height: 180
+        fill: "#A6A6A6"
+      - id: speed
+        type: rect
+        x: 760
+        "y": 210
+        width: 140
+        height: 240
+        fill: "#FFFFFF"
+    audio:
+      - id: partial-fast
+        type: sound
+        src: bgm-3
+        volume: 70
+        playbackRate: 1.5
+        startAt: 1
+        endAt: 5
+  - id: partial-slow-loop
+    elements:
+      - id: segment
+        type: rect
+        x: 260
+        "y": 240
+        width: 360
+        height: 180
+        fill: "#A6A6A6"
+      - id: speed
+        type: rect
+        x: 760
+        "y": 270
+        width: 140
+        height: 120
+        fill: "#737373"
+    audio:
+      - id: partial-loop
+        type: sound
+        src: bgm-3
+        volume: 70
+        loop: true
+        playbackRate: 0.75
+        startAt: 0
+        endAt: 4
+  - id: stop-all-audio
+    elements:
+      - id: stop
+        type: rect
+        x: 420
+        "y": 220
+        width: 280
+        height: 280
+        fill: "#4D4D4D"
+    audio: []

--- a/vt/specs/audio/playback-options.yaml
+++ b/vt/specs/audio/playback-options.yaml
@@ -10,31 +10,8 @@ specs:
 ---
 states:
   - id: playback-ready
-    elements:
-      - id: ready
-        type: rect
-        x: 180
-        "y": 260
-        width: 180
-        height: 180
-        fill: "#4D4D4D"
     audio: []
   - id: delayed-sfx
-    elements:
-      - id: delay-track
-        type: rect
-        x: 180
-        "y": 310
-        width: 520
-        height: 80
-        fill: "#737373"
-      - id: delay-marker
-        type: rect
-        x: 180
-        "y": 260
-        width: 80
-        height: 180
-        fill: "#D9D9D9"
     audio:
       - id: delayed-sfx
         type: sound
@@ -42,21 +19,6 @@ states:
         volume: 100
         startDelayMs: 1000
   - id: partial-fast-segment
-    elements:
-      - id: segment
-        type: rect
-        x: 260
-        "y": 240
-        width: 360
-        height: 180
-        fill: "#A6A6A6"
-      - id: speed
-        type: rect
-        x: 760
-        "y": 210
-        width: 140
-        height: 240
-        fill: "#FFFFFF"
     audio:
       - id: partial-fast
         type: sound
@@ -66,21 +28,6 @@ states:
         startAt: 1
         endAt: 5
   - id: partial-slow-loop
-    elements:
-      - id: segment
-        type: rect
-        x: 260
-        "y": 240
-        width: 360
-        height: 180
-        fill: "#A6A6A6"
-      - id: speed
-        type: rect
-        x: 760
-        "y": 270
-        width: 140
-        height: 120
-        fill: "#737373"
     audio:
       - id: partial-loop
         type: sound
@@ -91,12 +38,4 @@ states:
         startAt: 0
         endAt: 4
   - id: stop-all-audio
-    elements:
-      - id: stop
-        type: rect
-        x: 420
-        "y": 220
-        width: 280
-        height: 280
-        fill: "#4D4D4D"
     audio: []

--- a/vt/specs/audio/playback-options.yaml
+++ b/vt/specs/audio/playback-options.yaml
@@ -1,6 +1,7 @@
 ---
 title: Audio Manual - Playback Options
 description: Manual fixture for startDelayMs, playbackRate, startAt, endAt, loop, and stopping audio. Use the state pager or n/b keys.
+skipScreenshot: true
 specs:
   - state 1 is silent so pressing n starts audio from a user gesture
   - state 2 should play sfx-1 after a one second delay

--- a/vt/specs/audio/volume-transitions.yaml
+++ b/vt/specs/audio/volume-transitions.yaml
@@ -1,0 +1,146 @@
+---
+title: Audio Manual - Volume Transitions
+description: Manual fixture for audioTransition enter, update, exit, and same-id source crossfade. Use the state pager or n/b keys.
+specs:
+  - state 1 is silent baseline
+  - state 2 should fade in bgm-1 through a channel
+  - state 3 should ramp the channel down
+  - state 4 should crossfade the same sound id from bgm-1 to bgm-2
+  - state 5 should fade out and clean up the remaining audio
+---
+states:
+  - id: transition-silent
+    elements:
+      - id: silent
+        type: rect
+        x: 240
+        "y": 220
+        width: 240
+        height: 240
+        fill: "#4D4D4D"
+    audio: []
+  - id: transition-enter
+    elements:
+      - id: level
+        type: rect
+        x: 240
+        "y": 220
+        width: 320
+        height: 240
+        fill: "#A6A6A6"
+    audio:
+      - id: music
+        type: audio-channel
+        volume: 80
+        children:
+          - id: transition-bgm
+            type: sound
+            src: bgm-1
+            loop: true
+            volume: 100
+    audioEffects:
+      - id: music-enter
+        type: audioTransition
+        targetId: music
+        properties:
+          volume:
+            enter:
+              from: 0
+              duration: 2000
+              easing: linear
+  - id: transition-update-down
+    elements:
+      - id: level
+        type: rect
+        x: 240
+        "y": 220
+        width: 180
+        height: 240
+        fill: "#737373"
+    audio:
+      - id: music
+        type: audio-channel
+        volume: 30
+        children:
+          - id: transition-bgm
+            type: sound
+            src: bgm-1
+            loop: true
+            volume: 100
+    audioEffects:
+      - id: music-update-down
+        type: audioTransition
+        targetId: music
+        properties:
+          volume:
+            update:
+              duration: 1500
+              easing: linear
+      - id: transition-bgm-exit-ready
+        type: audioTransition
+        targetId: transition-bgm
+        properties:
+          volume:
+            exit:
+              to: 0
+              duration: 1200
+              easing: linear
+  - id: transition-crossfade-source
+    elements:
+      - id: level
+        type: rect
+        x: 240
+        "y": 220
+        width: 320
+        height: 240
+        fill: "#D9D9D9"
+      - id: source
+        type: rect
+        x: 720
+        "y": 220
+        width: 240
+        height: 240
+        fill: "#A6A6A6"
+    audio:
+      - id: music
+        type: audio-channel
+        volume: 80
+        children:
+          - id: transition-bgm
+            type: sound
+            src: bgm-2
+            loop: true
+            volume: 100
+    audioEffects:
+      - id: transition-bgm-enter
+        type: audioTransition
+        targetId: transition-bgm
+        properties:
+          volume:
+            enter:
+              from: 0
+              duration: 1200
+              easing: linear
+            exit:
+              to: 0
+              duration: 1200
+              easing: linear
+      - id: music-exit-ready
+        type: audioTransition
+        targetId: music
+        properties:
+          volume:
+            exit:
+              to: 0
+              duration: 2000
+              easing: linear
+  - id: transition-exit
+    elements:
+      - id: silent
+        type: rect
+        x: 240
+        "y": 220
+        width: 240
+        height: 240
+        fill: "#4D4D4D"
+    audio: []

--- a/vt/specs/audio/volume-transitions.yaml
+++ b/vt/specs/audio/volume-transitions.yaml
@@ -10,24 +10,8 @@ specs:
 ---
 states:
   - id: transition-silent
-    elements:
-      - id: silent
-        type: rect
-        x: 240
-        "y": 220
-        width: 240
-        height: 240
-        fill: "#4D4D4D"
     audio: []
   - id: transition-enter
-    elements:
-      - id: level
-        type: rect
-        x: 240
-        "y": 220
-        width: 320
-        height: 240
-        fill: "#A6A6A6"
     audio:
       - id: music
         type: audio-channel
@@ -49,14 +33,6 @@ states:
               duration: 2000
               easing: linear
   - id: transition-update-down
-    elements:
-      - id: level
-        type: rect
-        x: 240
-        "y": 220
-        width: 180
-        height: 240
-        fill: "#737373"
     audio:
       - id: music
         type: audio-channel
@@ -86,21 +62,6 @@ states:
               duration: 1200
               easing: linear
   - id: transition-crossfade-source
-    elements:
-      - id: level
-        type: rect
-        x: 240
-        "y": 220
-        width: 320
-        height: 240
-        fill: "#D9D9D9"
-      - id: source
-        type: rect
-        x: 720
-        "y": 220
-        width: 240
-        height: 240
-        fill: "#A6A6A6"
     audio:
       - id: music
         type: audio-channel
@@ -135,12 +96,4 @@ states:
               duration: 2000
               easing: linear
   - id: transition-exit
-    elements:
-      - id: silent
-        type: rect
-        x: 240
-        "y": 220
-        width: 240
-        height: 240
-        fill: "#4D4D4D"
     audio: []

--- a/vt/specs/audio/volume-transitions.yaml
+++ b/vt/specs/audio/volume-transitions.yaml
@@ -1,6 +1,7 @@
 ---
 title: Audio Manual - Volume Transitions
 description: Manual fixture for audioTransition enter, update, exit, and same-id source crossfade. Use the state pager or n/b keys.
+skipScreenshot: true
 specs:
   - state 1 is silent baseline
   - state 2 should fade in bgm-1 through a channel

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -352,20 +352,20 @@
         },
         "sfx-1": { url: "/public/sfx-1.mp3", type: "audio/mpeg" },
         "sfx-2": { url: "/public/sfx-2.wav", type: "audio/wav" },
+        "bgm-1": { url: "/public/bgm-1.mp3", type: "audio/mpeg" },
+        "bgm-2": { url: "/public/bgm-2.mp3", type: "audio/mpeg" },
+        "bgm-3": { url: "/public/bgm-3.mp3", type: "audio/mpeg" },
       };
 
-      const shouldLoadOptionalMedia =
+      const shouldLoadOptionalVideo =
         !window?.RTGL_VT_DEBUG &&
         (window?.RTGL_VT_INCLUDE_MEDIA === true ||
           new URLSearchParams(window.location.search).get("media") === "1");
 
-      // Keep video/audio opt-in for manual browser runs so pages that do not
-      // use media do not block on video preload.
-      if (shouldLoadOptionalMedia) {
+      // Keep video opt-in for manual browser runs so pages that do not use
+      // video do not block on video preload.
+      if (shouldLoadOptionalVideo) {
         Object.assign(assetsObject, {
-          "bgm-1": { url: "/public/bgm-1.mp3", type: "audio/mpeg" },
-          "bgm-2": { url: "/public/bgm-2.mp3", type: "audio/mpeg" },
-          "bgm-3": { url: "/public/bgm-3.mp3", type: "audio/mpeg" },
           "video-sample": {
             url: "/public/video_sample.mp4",
             type: "video/mp4",

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -408,6 +408,10 @@
       const vtState = Object.assign({}, ...vtDocuments);
       const states = vtState.states ?? [];
       const useBrowserScreenshot = vtState.useBrowserScreenshot === true;
+      const stateHasAudio = (state) =>
+        (Array.isArray(state?.audio) && state.audio.length > 0) ||
+        (Array.isArray(state?.audioEffects) && state.audioEffects.length > 0);
+      const hasAudioStates = states.some(stateHasAudio);
       if (!useBrowserScreenshot) {
         let vtScreenshotHookPrimed = false;
         const waitForStableScreenshotFrame = async () => {
@@ -553,6 +557,33 @@
         }
         updatePager();
       };
+
+      let hasStartedAudioFixtureFromPointer = false;
+      const startAudioFixtureFromPointer = (event) => {
+        if (!hasAudioStates || hasStartedAudioFixtureFromPointer) {
+          return;
+        }
+        if (event.target?.closest?.(".vt-state-pager")) {
+          return;
+        }
+        if (stateHasAudio(states[index])) {
+          return;
+        }
+
+        const nextAudioStateIndex = states.findIndex(
+          (state, stateIndex) => stateIndex > index && stateHasAudio(state),
+        );
+        if (nextAudioStateIndex === -1) {
+          return;
+        }
+
+        hasStartedAudioFixtureFromPointer = true;
+        renderState(nextAudioStateIndex);
+      };
+
+      document.addEventListener("pointerdown", startAudioFixtureFromPointer, {
+        capture: true,
+      });
 
       await app.init({
         width: 1280,

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -543,6 +543,7 @@
           elements: state.elements ?? [],
           animations: state.animations ?? [],
           audio: state.audio ?? [],
+          audioEffects: state.audioEffects ?? [],
           global: state.global ?? {},
         };
 


### PR DESCRIPTION
## Summary
- Implement channel-based audio graph runtime with audio-channel, flat sound compatibility, volume transitions, and same-id source replacement crossfades
- Add strict audio normalization/validation, schemas/types/docs, and remove legacy sound.delay in favor of startDelayMs
- Add audio graph, renderAudio, normalization test coverage, and manual VT audio fixtures

## Manual VT fixtures
- Audio Manual - Channel Mixer
- Audio Manual - Flat Sounds
- Audio Manual - Playback Options
- Audio Manual - Volume Transitions

## Tests
- bun run lint
- bun run test
- bun run build
- bun run vt:generate