### PR TITLE
fix: clean up particle runtimes before subtree destroy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/animations/runReplaceAnimation.spec.js
+++ b/spec/animations/runReplaceAnimation.spec.js
@@ -5,7 +5,10 @@ import {
   sampleMaskReveal,
   selectSequenceMaskFrameState,
 } from "../../src/plugins/animations/replace/runReplaceAnimation.js";
-import { queueDeferredAnimatedSpritePlay } from "../../src/plugins/elements/renderContext.js";
+import {
+  queueDeferredAnimatedSpritePlay,
+  queueDeferredParticlesStart,
+} from "../../src/plugins/elements/renderContext.js";
 
 const createFrame = (x = 0, y = 0, width = 100, height = 100) => ({
   x,
@@ -649,6 +652,93 @@ describe("runReplaceAnimation", () => {
 
     expect(nextDisplayObject.visible).toBe(true);
     expect(deferredEffect).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves particle runtimes on the next live element during hidden replace mount cleanup", () => {
+    const prevDisplayObject = createDisplayObject("scene-root");
+    const nextDisplayObject = createDisplayObject("scene-root");
+    const parent = createParent(prevDisplayObject);
+    prevDisplayObject.parent = parent;
+    const tickerCallback = vi.fn();
+    const emitter = {
+      destroyed: false,
+      destroy: vi.fn(() => {
+        emitter.destroyed = true;
+      }),
+    };
+
+    const plugin = {
+      add: vi.fn(({ parent: targetParent, element, renderContext }) => {
+        nextDisplayObject.label = element.id;
+        nextDisplayObject.emitter = emitter;
+        nextDisplayObject.tickerCallback = tickerCallback;
+        queueDeferredParticlesStart(renderContext, {
+          app,
+          emitter,
+          container: nextDisplayObject,
+          tickerCallback,
+        });
+        targetParent.addChild(nextDisplayObject);
+      }),
+      delete: vi.fn(({ parent: targetParent, element }) => {
+        const child = targetParent.children.find(
+          (item) => item.label === element.id,
+        );
+        if (child) {
+          targetParent.removeChild(child);
+        }
+      }),
+    };
+
+    const animationBus = {
+      dispatch: vi.fn(),
+    };
+    const app = {
+      renderer: {
+        width: 1280,
+        height: 720,
+        generateTexture: vi.fn(() => Texture.EMPTY),
+      },
+      ticker: {
+        add: vi.fn(),
+        remove: vi.fn(),
+      },
+    };
+
+    runReplaceAnimation({
+      app,
+      parent,
+      prevElement: { id: "scene-root", type: "container" },
+      nextElement: { id: "scene-root", type: "particles" },
+      animation: {
+        id: "scene-transition",
+        targetId: "scene-root",
+        type: "transition",
+      },
+      animations: new Map(),
+      animationBus,
+      completionTracker: {
+        getVersion: () => 11,
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      eventHandler: vi.fn(),
+      elementPlugins: [],
+      plugin,
+      zIndex: 0,
+      signal: new AbortController().signal,
+    });
+
+    expect(emitter.destroy).not.toHaveBeenCalled();
+    expect(app.ticker.remove).not.toHaveBeenCalled();
+    expect(nextDisplayObject.emitter).toBe(emitter);
+    expect(nextDisplayObject.tickerCallback).toBe(tickerCallback);
+
+    const dispatched = animationBus.dispatch.mock.calls[0][0];
+    dispatched.payload.onComplete();
+
+    expect(app.ticker.add).toHaveBeenCalledWith(tickerCallback);
+    expect(nextDisplayObject.visible).toBe(true);
   });
 
   it("uses only the previous snapshot for same-id prev-only transitions", () => {

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -14,6 +14,7 @@ import { normalizeRenderState } from "./util/normalizeRenderState.js";
 import { isDeepEqual } from "./util/isDeepEqual.js";
 import { createInputDomBridge } from "./util/inputDomBridge.js";
 import { buildAnimationContinuityPlan } from "./plugins/animations/planAnimations.js";
+import { cleanupParticlesInTree } from "./plugins/elements/particles/particleRuntime.js";
 
 /**
  * @typedef {import('./types.js').RouteGraphicsInitOptions} RouteGraphicsInitOptions
@@ -565,6 +566,7 @@ const createRouteGraphics = () => {
 
       if (app?.stage) {
         pauseVideosRecursively(app.stage);
+        cleanupParticlesInTree({ app, root: app.stage });
       }
 
       if (app) app.destroy();

--- a/src/plugins/animations/replace/runReplaceAnimation.js
+++ b/src/plugins/animations/replace/runReplaceAnimation.js
@@ -921,6 +921,14 @@ const renderOffscreenContainer = ({ app, container, target, frame }) => {
   });
 };
 
+const detachChildFromParent = (child, parent) => {
+  if (!child || child.parent !== parent) {
+    return;
+  }
+
+  parent.removeChild(child);
+};
+
 const destroySubjectSnapshot = (subject, app) => {
   if (subject?.wrapper && !subject.wrapper.destroyed) {
     cleanupParticlesInTree({ app, root: subject.wrapper });
@@ -1449,8 +1457,9 @@ export const runReplaceAnimation = ({
       destroySubjectSnapshot(nextSubject, app);
     }
 
+    detachChildFromParent(nextDisplayObject, transitionMountParent);
     cleanupParticlesInTree({ app, root: transitionMountParent });
-    transitionMountParent.destroy({ children: false });
+    transitionMountParent.destroy({ children: true });
 
     if (prevDisplayObject) {
       plugin.delete({

--- a/src/plugins/animations/replace/runReplaceAnimation.js
+++ b/src/plugins/animations/replace/runReplaceAnimation.js
@@ -18,6 +18,7 @@ import {
   createRenderContext,
   flushDeferredMountOperations,
 } from "../../elements/renderContext.js";
+import { cleanupParticlesInTree } from "../../elements/particles/particleRuntime.js";
 import { getAnimationContinuitySignature } from "../planAnimations.js";
 const DEFAULT_SUBJECT_VALUES = {
   translateX: 0,
@@ -920,8 +921,9 @@ const renderOffscreenContainer = ({ app, container, target, frame }) => {
   });
 };
 
-const destroySubjectSnapshot = (subject) => {
+const destroySubjectSnapshot = (subject, app) => {
   if (subject?.wrapper && !subject.wrapper.destroyed) {
+    cleanupParticlesInTree({ app, root: subject.wrapper });
     subject.wrapper.destroy({ children: true });
   }
 
@@ -1005,9 +1007,10 @@ const createPlainOverlay = ({
     },
     destroy: () => {
       overlay.removeFromParent();
+      cleanupParticlesInTree({ app, root: overlay });
       overlay.destroy({ children: true });
-      destroySubjectSnapshot(prevSubject);
-      destroySubjectSnapshot(nextSubject);
+      destroySubjectSnapshot(prevSubject, app);
+      destroySubjectSnapshot(nextSubject, app);
     },
   };
 };
@@ -1162,13 +1165,16 @@ const createMaskedOverlay = ({
       overlay.removeFromParent();
       sprite.filters = [];
       maskFilter.destroy();
+      cleanupParticlesInTree({ app, root: overlay });
+      cleanupParticlesInTree({ app, root: prevRoot });
+      cleanupParticlesInTree({ app, root: nextRoot });
       overlay.destroy({ children: true });
       prevRoot.destroy({ children: true });
       nextRoot.destroy({ children: true });
       prevTexture.destroy(true);
       nextTexture.destroy(true);
-      destroySubjectSnapshot(prevSubject);
-      destroySubjectSnapshot(nextSubject);
+      destroySubjectSnapshot(prevSubject, app);
+      destroySubjectSnapshot(nextSubject, app);
       maskTextureController.destroy();
     },
   };
@@ -1391,8 +1397,9 @@ export const runReplaceAnimation = ({
       onCancel: () => {
         transitionSignalController?.abort();
         clearDeferredMountOperations(hiddenMountContext);
+        cleanupParticlesInTree({ app, root: transitionMountParent });
         transitionMountParent.destroy({ children: true });
-        destroySubjectSnapshot(prevSubject);
+        destroySubjectSnapshot(prevSubject, app);
         completeTransition();
       },
       onContinuationUpdate: handleContinuationUpdate,
@@ -1405,8 +1412,9 @@ export const runReplaceAnimation = ({
     if (transitionSignal?.aborted || parent.destroyed) {
       cleanupPendingTransition();
       clearDeferredMountOperations(hiddenMountContext);
+      cleanupParticlesInTree({ app, root: transitionMountParent });
       transitionMountParent.destroy({ children: true });
-      destroySubjectSnapshot(prevSubject);
+      destroySubjectSnapshot(prevSubject, app);
       completeTransition();
       return;
     }
@@ -1434,13 +1442,14 @@ export const runReplaceAnimation = ({
     });
 
     if (overlaySubjects.prevSubject !== prevSubject) {
-      destroySubjectSnapshot(prevSubject);
+      destroySubjectSnapshot(prevSubject, app);
     }
 
     if (overlaySubjects.nextSubject !== nextSubject) {
-      destroySubjectSnapshot(nextSubject);
+      destroySubjectSnapshot(nextSubject, app);
     }
 
+    cleanupParticlesInTree({ app, root: transitionMountParent });
     transitionMountParent.destroy({ children: false });
 
     if (prevDisplayObject) {

--- a/src/plugins/elements/container/deleteContainer.js
+++ b/src/plugins/elements/container/deleteContainer.js
@@ -1,4 +1,5 @@
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import { cleanupParticlesInTree } from "../particles/particleRuntime.js";
 
 /**
  * Delete container element (synchronous)
@@ -19,6 +20,7 @@ export const deleteContainer = ({
 
   const deleteElement = () => {
     if (containerElement && !containerElement.destroyed) {
+      cleanupParticlesInTree({ app, root: containerElement });
       parent.removeChild(containerElement);
       containerElement.destroy({
         children: true,

--- a/src/plugins/elements/particles/deleteParticles.js
+++ b/src/plugins/elements/particles/deleteParticles.js
@@ -1,4 +1,5 @@
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import { cleanupParticlesRuntime } from "./particleRuntime.js";
 
 export const deleteParticles = ({
   app,
@@ -14,24 +15,7 @@ export const deleteParticles = ({
 
   const deleteElement = () => {
     if (particleElement && !particleElement.destroyed) {
-      // Clean up emitter if present
-      if (particleElement.emitter) {
-        particleElement.emitter.destroy();
-      }
-
-      // Remove ticker callback if present
-      if (particleElement.tickerCallback) {
-        app.ticker.remove(particleElement.tickerCallback);
-      }
-
-      // Remove custom ticker handler if present (used in testing mode)
-      if (particleElement.customTickerHandler) {
-        window.removeEventListener(
-          "snapShotKeyFrame",
-          particleElement.customTickerHandler,
-        );
-      }
-
+      cleanupParticlesRuntime({ app, particleElement });
       particleElement.destroy({ children: true });
     }
   };

--- a/src/plugins/elements/particles/emitter/emitter.js
+++ b/src/plugins/elements/particles/emitter/emitter.js
@@ -413,8 +413,6 @@ export class Emitter {
     // Add to pool
     particle.next = this._poolFirst;
     this._poolFirst = particle;
-
-    this.particleCount--;
   }
 
   /**

--- a/src/plugins/elements/particles/emitter/emitter.js
+++ b/src/plugins/elements/particles/emitter/emitter.js
@@ -276,6 +276,48 @@ export class Emitter {
   }
 
   /**
+   * Remove a particle from the active linked list without recycling it.
+   * This is used when a particle was destroyed externally by a parent
+   * container teardown.
+   * @param {Particle} particle
+   */
+  _unlinkActiveParticle(particle) {
+    if (!particle) return false;
+
+    const isActive =
+      particle === this._activeFirst ||
+      particle === this._activeLast ||
+      particle.prev !== null ||
+      particle.next !== null;
+
+    if (!isActive) {
+      return false;
+    }
+
+    if (particle.prev) {
+      particle.prev.next = particle.next;
+    } else {
+      this._activeFirst = particle.next;
+    }
+
+    if (particle.next) {
+      particle.next.prev = particle.prev;
+    } else {
+      this._activeLast = particle.prev;
+    }
+
+    particle.prev = null;
+    particle.next = null;
+    if (!this._activeFirst) {
+      this._activeLast = null;
+      this.particleCount = 0;
+    } else {
+      this.particleCount = Math.max(0, this.particleCount - 1);
+    }
+    return true;
+  }
+
+  /**
    * Spawn a wave of particles
    * @param {number} count - Number to spawn
    * @returns {Particle|null} - First particle in spawned chain
@@ -349,27 +391,19 @@ export class Emitter {
    * @param {Particle} particle
    */
   recycle(particle) {
+    if (!particle || particle.destroyed) {
+      this._unlinkActiveParticle(particle);
+      return;
+    }
+
     // Run recycle behaviors
     for (const behavior of this.recycleBehaviors) {
       behavior.recycleParticle(particle);
     }
 
-    // Remove from active list
-    if (particle.prev) {
-      particle.prev.next = particle.next;
-    } else {
-      this._activeFirst = particle.next;
+    if (!this._unlinkActiveParticle(particle)) {
+      return;
     }
-
-    if (particle.next) {
-      particle.next.prev = particle.prev;
-    } else {
-      this._activeLast = particle.prev;
-    }
-
-    // Reset links
-    particle.prev = null;
-    particle.next = null;
 
     // Remove from display
     if (particle.parent) {
@@ -417,6 +451,12 @@ export class Emitter {
     let particle = this._activeFirst;
     while (particle) {
       const next = particle.next; // Store next before potential recycle
+
+      if (particle.destroyed || !particle.position) {
+        this._unlinkActiveParticle(particle);
+        particle = next;
+        continue;
+      }
 
       // Age particle
       particle.age += deltaSec;

--- a/src/plugins/elements/particles/emitter/emitter.test.js
+++ b/src/plugins/elements/particles/emitter/emitter.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { Container, Texture } from "pixi.js";
+import { Emitter } from "./emitter.js";
+
+describe("Emitter", () => {
+  it("ignores particles that were destroyed by an external parent teardown", () => {
+    const container = new Container();
+    const emitter = new Emitter(container, {
+      texture: Texture.EMPTY,
+      lifetime: { min: 10, max: 10 },
+      frequency: 0,
+      particlesPerWave: 1,
+      maxParticles: 1,
+    });
+
+    emitter.spawn(1);
+    const particle = emitter._activeFirst;
+    particle.destroy();
+
+    expect(() => emitter.update(0.016)).not.toThrow();
+    expect(emitter.particleCount).toBe(0);
+    expect(emitter._activeFirst).toBeNull();
+    expect(emitter._activeLast).toBeNull();
+  });
+});

--- a/src/plugins/elements/particles/emitter/emitter.test.js
+++ b/src/plugins/elements/particles/emitter/emitter.test.js
@@ -22,4 +22,30 @@ describe("Emitter", () => {
     expect(emitter._activeFirst).toBeNull();
     expect(emitter._activeLast).toBeNull();
   });
+
+  it("keeps particle counts accurate when recycling live particles", () => {
+    const container = new Container();
+    const emitter = new Emitter(container, {
+      texture: Texture.EMPTY,
+      lifetime: { min: 10, max: 10 },
+      frequency: 0,
+      particlesPerWave: 2,
+      maxParticles: 2,
+    });
+
+    emitter.spawn(2);
+    const firstParticle = emitter._activeFirst;
+
+    emitter.recycle(firstParticle);
+
+    expect(emitter.particleCount).toBe(1);
+
+    emitter.recycle(emitter._activeFirst);
+
+    expect(emitter.particleCount).toBe(0);
+
+    emitter.spawn(2);
+
+    expect(emitter.particleCount).toBe(2);
+  });
 });

--- a/src/plugins/elements/particles/emitter/particle.js
+++ b/src/plugins/elements/particles/emitter/particle.js
@@ -115,13 +115,17 @@ export class Particle extends Sprite {
   /**
    * Clean up for garbage collection
    */
-  destroy() {
+  destroy(options) {
+    if (this.destroyed) {
+      return;
+    }
+
     if (this.parent) {
       this.parent.removeChild(this);
     }
     this.emitter = null;
     this.next = null;
     this.prev = null;
-    super.destroy();
+    super.destroy(options);
   }
 }

--- a/src/plugins/elements/particles/particleRuntime.js
+++ b/src/plugins/elements/particles/particleRuntime.js
@@ -1,0 +1,60 @@
+const removeCustomTickerHandler = (particleElement) => {
+  if (!particleElement.customTickerHandler) {
+    return;
+  }
+
+  if (typeof window !== "undefined") {
+    window.removeEventListener(
+      "snapShotKeyFrame",
+      particleElement.customTickerHandler,
+    );
+  }
+  particleElement.customTickerHandler = undefined;
+};
+
+const removeTickerCallback = (app, particleElement) => {
+  if (!particleElement.tickerCallback) {
+    return;
+  }
+
+  app?.ticker?.remove?.(particleElement.tickerCallback);
+  particleElement.tickerCallback = undefined;
+};
+
+export const cleanupParticlesRuntime = ({ app, particleElement } = {}) => {
+  if (!particleElement) {
+    return;
+  }
+
+  removeTickerCallback(app, particleElement);
+  removeCustomTickerHandler(particleElement);
+
+  if (particleElement.emitter) {
+    particleElement.emitter.destroy();
+    particleElement.emitter = undefined;
+  }
+};
+
+export const cleanupParticlesInTree = ({ app, root } = {}) => {
+  if (!root) {
+    return;
+  }
+
+  const queue = [root];
+  for (const node of queue) {
+    if (!node) {
+      continue;
+    }
+
+    if (node.emitter || node.tickerCallback || node.customTickerHandler) {
+      cleanupParticlesRuntime({
+        app,
+        particleElement: node,
+      });
+    }
+
+    if (Array.isArray(node.children) && node.children.length > 0) {
+      queue.push(...node.children);
+    }
+  }
+};

--- a/src/plugins/elements/particles/particleRuntime.test.js
+++ b/src/plugins/elements/particles/particleRuntime.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { Container } from "pixi.js";
+import { cleanupParticlesInTree } from "./particleRuntime.js";
+
+describe("particle runtime cleanup", () => {
+  it("cleans nested particle emitters before a parent subtree is destroyed", () => {
+    const tickerCallback = vi.fn();
+    const customTickerHandler = vi.fn();
+    const emitter = {
+      destroy: vi.fn(),
+    };
+    const app = {
+      ticker: {
+        remove: vi.fn(),
+      },
+    };
+    const root = new Container();
+    const nested = new Container();
+    const particleElement = new Container();
+    particleElement.emitter = emitter;
+    particleElement.tickerCallback = tickerCallback;
+    particleElement.customTickerHandler = customTickerHandler;
+    nested.addChild(particleElement);
+    root.addChild(nested);
+
+    cleanupParticlesInTree({ app, root });
+    root.destroy({ children: true });
+
+    expect(app.ticker.remove).toHaveBeenCalledWith(tickerCallback);
+    expect(emitter.destroy).toHaveBeenCalledTimes(1);
+    expect(particleElement.emitter).toBeUndefined();
+    expect(particleElement.tickerCallback).toBeUndefined();
+    expect(particleElement.customTickerHandler).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- stop particle emitters, tickers, and custom ticker handlers before destroying particle-containing subtrees
- apply the cleanup path to container deletion, replace transitions, and RouteGraphics app teardown
- harden emitter updates against externally destroyed Pixi particles so stale active particles cannot crash on `x`/`y` reads
- rebase onto current `main` and bump the fix version to `1.15.1`

## Testing
- bun run test
- bun run lint
- bun run build
- push hook: bunx prettier --check src && vitest run
- client local dependency check: bunx vitest run tests/graphicsService/graphicsService.test.js tests/sceneEditor/runtime.test.js
- client local dependency check: bun run build:web
- client local dependency check: bun run lint