### PR TITLE
Fix CLI video asset rendering

### DIFF
--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -307,11 +307,27 @@ describe("RouteGraphics public API", () => {
     expect(app.findElementByLabel("missing-label")).toBeNull();
   }, 15000);
 
-  it("uses Pixi loadParser overrides for extensionless video URLs", async () => {
+  it("loads video assets through an early-ready HTML video texture", async () => {
     const { app, pixiMock } = await setupRouteGraphics();
     const createObjectURL = vi
       .spyOn(URL, "createObjectURL")
       .mockReturnValue("blob:http://route-graphics/video");
+    const originalCreateElement = document.createElement.bind(document);
+    const createElement = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tagName, ...args) => {
+        const element = originalCreateElement(tagName, ...args);
+
+        if (tagName === "video") {
+          Object.defineProperty(element, "readyState", {
+            value: window.HTMLMediaElement.HAVE_CURRENT_DATA,
+            configurable: true,
+          });
+          element.load = vi.fn();
+        }
+
+        return element;
+      });
 
     pixiMock.Assets.load.mockResolvedValue({ source: "loaded" });
 
@@ -328,25 +344,21 @@ describe("RouteGraphics public API", () => {
         },
       });
     } finally {
+      createElement.mockRestore();
       createObjectURL.mockRestore();
     }
 
-    expect(pixiMock.Assets.load).toHaveBeenNthCalledWith(1, {
+    expect(pixiMock.Assets.load).toHaveBeenCalledTimes(1);
+    expect(pixiMock.Assets.load).toHaveBeenCalledWith({
       alias: "urlTexture",
       src: "blob:http://route-graphics/texture",
     });
-    expect(pixiMock.Assets.load).toHaveBeenNthCalledWith(2, {
-      alias: "bufferVideo",
-      src: "blob:http://route-graphics/video",
-      loadParser: "loadVideo",
-      data: {
-        mime: "video/mp4",
-      },
-    });
-    expect(pixiMock.Assets.load.mock.calls[0][0]).not.toHaveProperty(
-      "loadParser",
+    expect(pixiMock.Assets.cache.set).toHaveBeenCalledWith(
+      "bufferVideo",
+      expect.objectContaining({
+        source: expect.any(Object),
+      }),
     );
-    expect(pixiMock.Assets.load.mock.calls[1][0]).not.toHaveProperty("parser");
   });
 
   it("updates the visible stage background graphic color", async () => {

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -196,6 +196,79 @@ const createRouteGraphics = () => {
     videoSourceUrls.clear();
   };
 
+  const waitForVideoReady = (video, key) =>
+    new Promise((resolve, reject) => {
+      const haveCurrentData = window.HTMLMediaElement?.HAVE_CURRENT_DATA ?? 2;
+
+      if (video.readyState >= haveCurrentData) {
+        resolve();
+        return;
+      }
+
+      let timeoutId;
+      const cleanup = () => {
+        window.clearTimeout(timeoutId);
+        video.removeEventListener("loadeddata", onReady);
+        video.removeEventListener("canplay", onReady);
+        video.removeEventListener("error", onError);
+      };
+      const onReady = () => {
+        cleanup();
+        resolve();
+      };
+      const onError = () => {
+        cleanup();
+        const details = [
+          video.error?.code ? `code=${video.error.code}` : null,
+          video.error?.message ? `message=${video.error.message}` : null,
+          `networkState=${video.networkState}`,
+          `readyState=${video.readyState}`,
+          video.currentSrc ? `src=${video.currentSrc}` : null,
+        ]
+          .filter(Boolean)
+          .join(", ");
+
+        reject(
+          new Error(
+            `Failed to load video asset "${key}"${details ? ` (${details})` : ""}.`,
+          ),
+        );
+      };
+
+      timeoutId = window.setTimeout(() => {
+        cleanup();
+        reject(new Error(`Timed out loading video asset "${key}".`));
+      }, 5000);
+
+      video.addEventListener("loadeddata", onReady, { once: true });
+      video.addEventListener("canplay", onReady, { once: true });
+      video.addEventListener("error", onError, { once: true });
+    });
+
+  const loadVideoTexture = async ({ key, sourceUrl, mimeType }) => {
+    if (Assets.cache.has(key)) {
+      return Assets.cache.get(key);
+    }
+
+    const video = document.createElement("video");
+    video.preload = "auto";
+    video.playsInline = true;
+    video.setAttribute("playsinline", "");
+    if (typeof mimeType === "string" && mimeType.length > 0) {
+      video.type = mimeType;
+    }
+    const ready = waitForVideoReady(video, key);
+    video.src = sourceUrl;
+    video.load();
+
+    await ready;
+
+    const texture = Texture.from(video);
+    Assets.cache.set(key, texture);
+
+    return texture;
+  };
+
   /**
    * Apply global cursor styles to the PixiJS application
    * @param {Application} appInstance - The PixiJS application instance
@@ -651,6 +724,10 @@ const createRouteGraphics = () => {
       // to a revokable blob URL for buffer-backed inputs.
       const videoPromises = Object.entries(assetsByType.video).map(
         async ([key, asset]) => {
+          if (Assets.cache.has(key)) {
+            return Assets.cache.get(key);
+          }
+
           const sourceUrl =
             asset?.source === "url" && typeof asset?.url === "string"
               ? asset.url
@@ -663,26 +740,19 @@ const createRouteGraphics = () => {
             revokable: isRevokableBlobUrl,
           });
 
-          const videoAssetDescriptor = {
-            alias: key,
-            src: sourceUrl,
-            loadParser: "loadVideo",
-            data: {},
-          };
-
-          if (typeof asset?.type === "string" && asset.type.length > 0) {
-            videoAssetDescriptor.data.mime = asset.type;
-          }
-
-          return Assets.load(videoAssetDescriptor)
-            .then((texture) => texture)
-            .catch((error) => {
-              videoSourceUrls.delete(key);
-              if (isRevokableBlobUrl) {
-                URL.revokeObjectURL(sourceUrl);
-              }
-              throw error;
+          try {
+            return await loadVideoTexture({
+              key,
+              sourceUrl,
+              mimeType: asset?.type,
             });
+          } catch (error) {
+            videoSourceUrls.delete(key);
+            if (isRevokableBlobUrl) {
+              URL.revokeObjectURL(sourceUrl);
+            }
+            throw error;
+          }
         },
       );
 

--- a/src/cli/renderVideo.js
+++ b/src/cli/renderVideo.js
@@ -10,6 +10,78 @@ import { chromium } from "playwright";
 import { getRendererBrowserLaunchOptions } from "./browserLaunch.js";
 import { parseStateSelection } from "./stateSelection.js";
 
+const debugVideoRender = (...args) => {
+  if (process.env.ROUTE_GRAPHICS_RENDER_VIDEO_DEBUG === "1") {
+    console.error("[render-video]", ...args);
+  }
+};
+
+const isUnsupportedMediaError = (error) =>
+  /DEMUXER_ERROR_NO_SUPPORTED_STREAMS|MEDIA_ERR_SRC_NOT_SUPPORTED|no supported streams/i.test(
+    error?.message ?? "",
+  );
+
+const getPlaywrightCacheDir = () => {
+  const configuredPath = process.env.PLAYWRIGHT_BROWSERS_PATH;
+
+  if (configuredPath && configuredPath !== "0") {
+    return configuredPath;
+  }
+
+  return path.join(os.homedir(), ".cache", "ms-playwright");
+};
+
+const findCachedChromiumExecutables = async () => {
+  const cacheDir = getPlaywrightCacheDir();
+  let entries;
+
+  try {
+    entries = await fsPromises.readdir(cacheDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const candidates = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const match = /^chromium-(\d+)$/.exec(entry.name);
+    if (!match) {
+      continue;
+    }
+
+    const revision = Number.parseInt(match[1], 10);
+    for (const executableRelativePath of [
+      "chrome-linux64/chrome",
+      "chrome-linux/chrome",
+    ]) {
+      const executablePath = path.join(
+        cacheDir,
+        entry.name,
+        executableRelativePath,
+      );
+
+      try {
+        await fsPromises.access(executablePath, fs.constants.X_OK);
+      } catch {
+        continue;
+      }
+
+      candidates.push({
+        executablePath,
+        revision,
+      });
+    }
+  }
+
+  return candidates
+    .sort((left, right) => right.revision - left.revision)
+    .map((candidate) => candidate.executablePath);
+};
+
 const createWriteStreamChunkBinding = async (page, outputPath) => {
   const stream = fs.createWriteStream(outputPath);
 
@@ -57,11 +129,13 @@ const captureVideoWebm = async ({
   browserExecutablePath,
   webmPath,
 }) => {
+  debugVideoRender("launch browser");
   const browser = await chromium.launch(
     getRendererBrowserLaunchOptions(browserExecutablePath),
   );
 
   try {
+    debugVideoRender("new page", `${width}x${height}`);
     const page = await browser.newPage({
       viewport: {
         width,
@@ -73,11 +147,18 @@ const captureVideoWebm = async ({
     page.on("pageerror", (error) => {
       pageErrors.push(error.stack ?? error.message);
     });
+    page.on("console", (message) => {
+      if (process.env.ROUTE_GRAPHICS_RENDER_VIDEO_DEBUG === "1") {
+        console.error("[render-video:page]", message.type(), message.text());
+      }
+    });
 
+    debugVideoRender("goto", origin);
     await page.goto(origin, {
       waitUntil: "domcontentloaded",
     });
 
+    debugVideoRender("open chunk stream", webmPath);
     const closeChunkStream = await createWriteStreamChunkBinding(
       page,
       webmPath,
@@ -93,8 +174,15 @@ const captureVideoWebm = async ({
     };
 
     try {
+      debugVideoRender("evaluate capture script");
       const result = await page.evaluate(
         async ({ moduleUrl, renderPayload }) => {
+          const debug = (...args) => {
+            if (renderPayload.debug) {
+              console.debug("[capture]", ...args);
+            }
+          };
+
           const sleep = (ms) =>
             new Promise((resolve) => {
               window.setTimeout(resolve, Math.max(0, ms));
@@ -150,6 +238,7 @@ const captureVideoWebm = async ({
           }
 
           const routeGraphicsModule = await import(moduleUrl);
+          debug("module imported");
           const {
             default: createRouteGraphics,
             animatedSpritePlugin,
@@ -203,6 +292,7 @@ const captureVideoWebm = async ({
             });
 
           try {
+            debug("app init start");
             await app.init({
               width: renderPayload.width,
               height: renderPayload.height,
@@ -245,16 +335,22 @@ const captureVideoWebm = async ({
               },
               debug: false,
             });
+            debug("app init complete");
 
             if (Object.keys(renderPayload.assets).length > 0) {
+              debug("asset load start", Object.keys(renderPayload.assets));
               await assetBufferManager.load(renderPayload.assets);
+              debug("asset buffer load complete");
               await app.loadAssets(assetBufferManager.getBufferMap());
+              debug("app asset load complete");
             }
 
             document.body.replaceChildren(app.canvas);
             await nextFrame(2);
+            debug("canvas mounted");
 
             const stream = app.canvas.captureStream(renderPayload.fps);
+            debug("capture stream created", stream.getTracks().length);
             const recorder = new MediaRecorder(stream, {
               mimeType: recorderMimeType,
             });
@@ -270,6 +366,7 @@ const captureVideoWebm = async ({
               if (!event.data || event.data.size === 0) {
                 return;
               }
+              debug("dataavailable", event.data.size);
 
               chunkWrites.push(
                 (async () => {
@@ -281,6 +378,7 @@ const captureVideoWebm = async ({
             });
 
             recorder.start(250);
+            debug("recorder started");
 
             try {
               for (
@@ -292,9 +390,11 @@ const captureVideoWebm = async ({
                 const state = renderPayload.states[stateIndex];
                 const waitForComplete = createRenderCompleteWaiter(state.id);
 
+                debug("render state start", state.id);
                 app.render(state);
                 app.render(state);
                 await waitForComplete;
+                debug("render state complete", state.id);
 
                 const isFinal =
                   renderIndex === renderPayload.stateIndexes.length - 1;
@@ -305,17 +405,23 @@ const captureVideoWebm = async ({
                     : renderPayload.holdMS;
 
                 if (hold > 0) {
+                  debug("hold start", hold);
                   await sleep(hold);
+                  debug("hold complete", hold);
                 }
               }
 
               await nextFrame(2);
+              debug("post-render frames complete");
             } finally {
               if (recorder.state !== "inactive") {
+                debug("recorder stop requested");
                 recorder.stop();
               }
               await stopped;
+              debug("recorder stopped");
               await Promise.all(chunkWrites);
+              debug("chunk writes complete");
               stream.getTracks().forEach((track) => {
                 track.stop();
               });
@@ -347,11 +453,14 @@ const captureVideoWebm = async ({
             initialHoldMS,
             finalHoldMS,
             maxStateDurationMS,
+            debug: process.env.ROUTE_GRAPHICS_RENDER_VIDEO_DEBUG === "1",
           },
         },
       );
 
+      debugVideoRender("evaluate complete");
       await closeChunksOnce();
+      debugVideoRender("chunk stream closed");
 
       if (pageErrors.length > 0) {
         throw new Error(pageErrors.join("\n"));
@@ -412,6 +521,41 @@ const transcodeWebmToMp4 = async ({ ffmpegPath, inputPath, outputPath }) => {
   ]);
 };
 
+const captureVideoWebmWithBrowserFallback = async (options) => {
+  try {
+    return await captureVideoWebm(options);
+  } catch (error) {
+    if (options.browserExecutablePath || !isUnsupportedMediaError(error)) {
+      throw error;
+    }
+
+    const fallbackExecutables = await findCachedChromiumExecutables();
+    const errors = [error];
+
+    for (const executablePath of fallbackExecutables) {
+      debugVideoRender("retry with cached chromium", executablePath);
+
+      try {
+        return await captureVideoWebm({
+          ...options,
+          browserExecutablePath: executablePath,
+        });
+      } catch (fallbackError) {
+        errors.push(fallbackError);
+
+        if (!isUnsupportedMediaError(fallbackError)) {
+          throw fallbackError;
+        }
+      }
+    }
+
+    const lastError = errors.at(-1) ?? error;
+    throw new Error(
+      `${lastError.message}\nThe selected Chromium build cannot decode at least one input video stream. Install or select a codec-capable Chrome/Chromium with --browser-executable.`,
+    );
+  }
+};
+
 export const renderMp4 = async ({
   cliOptions,
   definition,
@@ -435,7 +579,8 @@ export const renderMp4 = async ({
 
   try {
     const renderStartedAt = performance.now();
-    const captureInfo = await captureVideoWebm({
+    debugVideoRender("capture webm start", webmPath);
+    const captureInfo = await captureVideoWebmWithBrowserFallback({
       origin,
       width,
       height,
@@ -453,14 +598,20 @@ export const renderMp4 = async ({
       webmPath,
     });
     const renderDurationMS = performance.now() - renderStartedAt;
+    debugVideoRender(
+      "capture webm complete",
+      `${Math.round(renderDurationMS)}ms`,
+    );
 
     const writeStartedAt = performance.now();
+    debugVideoRender("transcode start", outputPath);
     await transcodeWebmToMp4({
       ffmpegPath,
       inputPath: webmPath,
       outputPath,
     });
     const writeDurationMS = performance.now() - writeStartedAt;
+    debugVideoRender("transcode complete", `${Math.round(writeDurationMS)}ms`);
 
     return {
       inputPath,


### PR DESCRIPTION
## Summary
- load video assets through an HTML video texture after early media readiness instead of relying on Pixi video parser overrides
- add guarded CLI video render debug logging and fallback to codec-capable cached Chromium builds when the default browser cannot decode input videos
- update the public API video asset test for the new loading path

## Tests
- bun run test spec/RouteGraphics.publicApi.spec.js spec/cli/renderPngCli.spec.js
- git push hook: prettier --check src; vitest run