### PR TITLE
Add rich text segments to text elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/pages/docs/nodes/text.md
+++ b/playground/pages/docs/nodes/text.md
@@ -5,7 +5,7 @@ tags: documentation
 sidebarId: node-text
 ---
 
-`text` renders a single Pixi text object with styling and interaction handlers.
+`text` renders static text with styling and interaction handlers. `content` may be a string or an array of rich text segments.
 
 Try it in the [Playground](/playground/?template=interactive-elements).
 
@@ -15,23 +15,23 @@ Try it in the [Playground](/playground/?template=interactive-elements).
 
 ## Field Reference
 
-| Field        | Type   | Required            | Default         | Notes                                                                    |
-| ------------ | ------ | ------------------- | --------------- | ------------------------------------------------------------------------ |
-| `id`         | string | Yes                 | -               | Element id.                                                              |
-| `type`       | string | Yes                 | -               | Must be `text`.                                                          |
-| `x`          | number | Yes (public schema) | `0` at runtime  | Position before anchor transform.                                        |
-| `y`          | number | Yes (public schema) | `0` at runtime  | Position before anchor transform.                                        |
-| `content`    | string | No                  | `""`            | Converted to string at parse time.                                       |
-| `width`      | number | No                  | auto            | Fixed layout box width. Also enables wrapping (`wordWrapWidth = width`). |
-| `anchorX`    | number | No                  | `0`             | Can be outside `0..1`.                                                   |
-| `anchorY`    | number | No                  | `0`             | Can be outside `0..1`.                                                   |
-| `alpha`      | number | No                  | `1`             | Opacity `0..1`.                                                          |
-| `textStyle`  | object | No                  | engine defaults | See table below.                                                         |
-| `hover`      | object | No                  | -               | Hover style, cursor, sound, payload.                                     |
-| `click`      | object | No                  | -               | Press style, sound, payload.                                             |
-| `rightClick` | object | No                  | -               | Right-press style, sound, payload.                                       |
-| `scrollUp`   | object | No                  | -               | Wheel-up payload hook.                                                   |
-| `scrollDown` | object | No                  | -               | Wheel-down payload hook.                                                 |
+| Field        | Type            | Required            | Default         | Notes                                                                            |
+| ------------ | --------------- | ------------------- | --------------- | -------------------------------------------------------------------------------- |
+| `id`         | string          | Yes                 | -               | Element id.                                                                      |
+| `type`       | string          | Yes                 | -               | Must be `text`.                                                                  |
+| `x`          | number          | Yes (public schema) | `0` at runtime  | Position before anchor transform.                                                |
+| `y`          | number          | Yes (public schema) | `0` at runtime  | Position before anchor transform.                                                |
+| `content`    | string \| array | No                  | `""`            | Strings render as one Pixi text object. Arrays render static rich text segments. |
+| `width`      | number          | No                  | auto            | Fixed layout box width. Also enables wrapping (`wordWrapWidth = width`).         |
+| `anchorX`    | number          | No                  | `0`             | Can be outside `0..1`.                                                           |
+| `anchorY`    | number          | No                  | `0`             | Can be outside `0..1`.                                                           |
+| `alpha`      | number          | No                  | `1`             | Opacity `0..1`.                                                                  |
+| `textStyle`  | object          | No                  | engine defaults | See table below.                                                                 |
+| `hover`      | object          | No                  | -               | Hover style, cursor, sound, payload.                                             |
+| `click`      | object          | No                  | -               | Press style, sound, payload.                                                     |
+| `rightClick` | object          | No                  | -               | Right-press style, sound, payload.                                               |
+| `scrollUp`   | object          | No                  | -               | Wheel-up payload hook.                                                           |
+| `scrollDown` | object          | No                  | -               | Wheel-down payload hook.                                                         |
 
 ### `textStyle`
 
@@ -61,11 +61,32 @@ Try it in the [Playground](/playground/?template=interactive-elements).
 | `offsetX` | number | `2`     |
 | `offsetY` | number | `2`     |
 
+### `content[]` item shape
+
+Array content uses the same static rich text segment shape as `text-revealing`, without reveal timing, indicators, or completion behavior.
+
+| Field       | Type   | Required | Notes                                                              |
+| ----------- | ------ | -------- | ------------------------------------------------------------------ |
+| `text`      | string | Yes      | Segment text.                                                      |
+| `textStyle` | object | No       | Overrides root style for this segment.                             |
+| `furigana`  | object | No       | `{ text, textStyle, placement, gap }` rendered beside the segment. |
+
+### `content[].furigana`
+
+| Field       | Type              | Required | Default |
+| ----------- | ----------------- | -------- | ------- |
+| `text`      | string            | Yes      | -       |
+| `textStyle` | object            | No       | segment |
+| `placement` | `top` \| `bottom` | No       | `top`   |
+| `gap`       | number `>= 0`     | No       | `0`     |
+
 ## Layout Notes
 
 - When `width` is omitted, the text box width matches the rendered text width.
 - When `width` is provided, the text box width stays fixed to that value.
 - `align: center` and `align: right` place the rendered text inside that fixed-width box.
+- String content uses one Pixi text object. Array content uses a container with one Pixi text object per segment part.
+- Interaction `textStyle` overrides apply to every rendered rich text part. Rich text wrapping is calculated from the base state, so avoid layout-changing interaction styles on segmented content.
 
 ## Emitted Events
 
@@ -86,6 +107,30 @@ elements:
     x: 40
     y: 32
     content: "Route Graphics"
+```
+
+## Example: Static Rich Text
+
+```yaml
+elements:
+  - id: rich-label
+    type: text
+    x: 40
+    y: 96
+    width: 480
+    textStyle:
+      fill: "#FFFFFF"
+      fontSize: 28
+      fontFamily: Arial
+    content:
+      - text: "Route "
+      - text: "Graphics"
+        textStyle:
+          fill: "#D9D9D9"
+          fontWeight: bold
+      - text: " supports inline segments."
+        textStyle:
+          fill: "#A6A6A6"
 ```
 
 ## Example: Interactive Styled Text

--- a/spec/elements/addTextRichContent.spec.js
+++ b/spec/elements/addTextRichContent.spec.js
@@ -1,0 +1,204 @@
+import { Container } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
+import { addText } from "../../src/plugins/elements/text/addText.js";
+import { parseText } from "../../src/plugins/elements/text/parseText.js";
+import { updateText } from "../../src/plugins/elements/text/updateText.js";
+
+const createSharedParams = () => ({
+  app: {
+    audioStage: {
+      add: vi.fn(),
+    },
+  },
+  animations: [],
+  animationBus: {
+    dispatch: vi.fn(),
+  },
+  completionTracker: {
+    getVersion: () => 0,
+    track: () => {},
+    complete: () => {},
+  },
+  eventHandler: vi.fn(),
+});
+
+describe("text rich content", () => {
+  it("renders array content as styled text segment objects", () => {
+    const parent = new Container();
+    const element = parseText({
+      state: {
+        id: "rich-text",
+        type: "text",
+        x: 20,
+        y: 30,
+        width: 260,
+        textStyle: {
+          fontSize: 24,
+          fontFamily: "Arial",
+          fill: "#FFFFFF",
+        },
+        content: [
+          { text: "HP" },
+          {
+            text: "42",
+            textStyle: {
+              fill: "#D9D9D9",
+              fontWeight: "bold",
+            },
+          },
+        ],
+      },
+    });
+
+    addText({
+      ...createSharedParams(),
+      parent,
+      element,
+      zIndex: 0,
+    });
+
+    const text = parent.getChildByLabel("rich-text");
+    const line = text.children[0];
+
+    expect(text.children).toHaveLength(1);
+    expect(line.children).toHaveLength(2);
+    expect(line.children[0].text).toBe("HP");
+    expect(line.children[0].style.fill).toBe("#FFFFFF");
+    expect(line.children[1].text).toBe("42");
+    expect(line.children[1].style.fill).toBe("#D9D9D9");
+    expect(line.children[1].style.fontWeight).toBe("bold");
+  });
+
+  it("updates between plain and rich text display objects", () => {
+    const parent = new Container();
+    const shared = createSharedParams();
+    const prevElement = parseText({
+      state: {
+        id: "updating-text",
+        type: "text",
+        x: 20,
+        y: 30,
+        content: "Plain",
+      },
+    });
+    const nextElement = parseText({
+      state: {
+        id: "updating-text",
+        type: "text",
+        x: 20,
+        y: 30,
+        content: [
+          { text: "Rich" },
+          {
+            text: "Text",
+            textStyle: {
+              fill: "#A6A6A6",
+            },
+          },
+        ],
+      },
+    });
+
+    addText({
+      ...shared,
+      parent,
+      element: prevElement,
+      zIndex: 0,
+    });
+
+    updateText({
+      ...shared,
+      parent,
+      prevElement,
+      nextElement,
+      zIndex: 0,
+    });
+
+    const text = parent.getChildByLabel("updating-text");
+
+    expect(text.children[0].children[0].text).toBe("Rich");
+    expect(text.children[0].children[1].text).toBe("Text");
+    expect(text.children[0].children[1].style.fill).toBe("#A6A6A6");
+  });
+
+  it("wraps rich content using textStyle.wordWrapWidth when width is omitted", () => {
+    const element = parseText({
+      state: {
+        id: "style-wrapped-rich-text",
+        type: "text",
+        x: 20,
+        y: 30,
+        textStyle: {
+          fontSize: 20,
+          fontFamily: "Arial",
+          fill: "#FFFFFF",
+          wordWrap: true,
+          wordWrapWidth: 100,
+        },
+        content: [{ text: "Alpha beta gamma delta" }],
+      },
+    });
+
+    expect(element.content.length).toBeGreaterThan(1);
+    expect(element.textStyle.wordWrapWidth).toBe(100);
+    expect(element.content[0].lineParts[0].text).not.toBe(
+      "Alpha beta gamma delta",
+    );
+    expect(element.content[0].lineParts[0].textStyle.wordWrapWidth).toBe(100);
+  });
+
+  it.each([
+    ["center", (bounds) => bounds.x + bounds.width / 2, 100],
+    ["right", (bounds) => bounds.x + bounds.width, 200],
+  ])(
+    "aligns %s rich text by visible line bounds when furigana extends left",
+    (align, getVisiblePosition, expectedPosition) => {
+      const parent = new Container();
+      const element = parseText({
+        state: {
+          id: `${align}-furigana-rich-text`,
+          type: "text",
+          x: 20,
+          y: 30,
+          width: 200,
+          textStyle: {
+            fontSize: 32,
+            fontFamily: "Arial",
+            fill: "#FFFFFF",
+            align,
+          },
+          content: [
+            {
+              text: "日",
+              furigana: {
+                text: "wide annotation",
+                textStyle: {
+                  fontSize: 16,
+                  fontFamily: "Arial",
+                  fill: "#D9D9D9",
+                },
+              },
+            },
+          ],
+        },
+      });
+
+      addText({
+        ...createSharedParams(),
+        parent,
+        element,
+        zIndex: 0,
+      });
+
+      const text = parent.getChildByLabel(`${align}-furigana-rich-text`);
+      const line = text.children[0];
+      const bounds = line.getLocalBounds();
+
+      expect(bounds.x).toBeLessThan(0);
+      expect(line.x + getVisiblePosition(bounds, element.width)).toBeCloseTo(
+        expectedPosition,
+        1,
+      );
+    },
+  );
+});

--- a/spec/parser/parseText.test.yaml
+++ b/spec/parser/parseText.test.yaml
@@ -122,6 +122,97 @@ out:
     strokeWidth: 0
     wordWrapWidth: 200
 ---
+case: Test parsing text with rich content segments
+in:
+  - state:
+      id: rich-text
+      type: text
+      content:
+        - text: HP
+        - text: '42'
+          textStyle:
+            fill: '#D9D9D9'
+            fontWeight: bold
+        - text: OK
+          textStyle:
+            fill: '#A6A6A6'
+      x: 100
+      'y': 50
+      width: 260
+      textStyle:
+        fontSize: 24
+        fontFamily: Arial
+        fill: '#FFFFFF'
+out:
+  id: rich-text
+  type: text
+  width: 260
+  height: 29
+  x: 100
+  'y': 50
+  originX: 0
+  originY: 0
+  alpha: 1
+  content:
+    - lineParts:
+        - text: HP
+          textStyle:
+            fill: '#FFFFFF'
+            fontFamily: Arial
+            fontSize: 24
+            align: left
+            lineHeight: 29
+            wordWrap: true
+            breakWords: false
+            strokeColor: transparent
+            strokeWidth: 0
+            wordWrapWidth: 260
+          x: 0
+          'y': 0
+        - text: '42'
+          textStyle:
+            fill: '#D9D9D9'
+            fontFamily: Arial
+            fontSize: 24
+            align: left
+            lineHeight: 29
+            wordWrap: true
+            breakWords: false
+            strokeColor: transparent
+            strokeWidth: 0
+            wordWrapWidth: 226
+            fontWeight: bold
+          x: 34
+          'y': 0
+        - text: OK
+          textStyle:
+            fill: '#A6A6A6'
+            fontFamily: Arial
+            fontSize: 24
+            align: left
+            lineHeight: 29
+            wordWrap: true
+            breakWords: false
+            strokeColor: transparent
+            strokeWidth: 0
+            wordWrapWidth: 199
+          x: 61
+          'y': 0
+      'y': 0
+      lineMaxHeight: 29
+  measuredWidth: 96
+  textStyle:
+    fill: '#FFFFFF'
+    fontFamily: Arial
+    fontSize: 24
+    align: left
+    lineHeight: 29
+    wordWrap: true
+    breakWords: false
+    strokeColor: transparent
+    strokeWidth: 0
+    wordWrapWidth: 260
+---
 case: Test parsing simple text object with no textStyle
 in:
   - state:

--- a/src/plugins/elements/text-revealing/parseTextRevealing.js
+++ b/src/plugins/elements/text-revealing/parseTextRevealing.js
@@ -18,7 +18,7 @@ const LEGACY_TOP_FURIGANA_OFFSET = 2;
 const FURIGANA_PLACEMENTS = ["top", "bottom"];
 const FURIGANA_PLACEMENT_SET = new Set(FURIGANA_PLACEMENTS);
 
-const normalizeFuriganaPlacement = (placement, path) => {
+export const normalizeFuriganaPlacement = (placement, path) => {
   if (placement === undefined) {
     return DEFAULT_FURIGANA_PLACEMENT;
   }
@@ -34,7 +34,7 @@ const normalizeFuriganaPlacement = (placement, path) => {
   );
 };
 
-const normalizeFuriganaGap = (gap, path) => {
+export const normalizeFuriganaGap = (gap, path) => {
   if (gap === undefined) {
     return 0;
   }
@@ -170,7 +170,11 @@ const consumeMeasuredLineFromSource = (
  * @param {number} wordWrapWidth - Maximum width for wrapping
  * @returns {Object} Object containing chunks and dimensions
  */
-const createTextChunks = (segments, wordWrapWidth) => {
+export const createTextChunks = (
+  segments,
+  wordWrapWidth,
+  { minimumWidth = wordWrapWidth } = {},
+) => {
   const chunks = [];
   let lineParts = [];
   let x = 0;
@@ -217,10 +221,12 @@ const createTextChunks = (segments, wordWrapWidth) => {
 
     const originalText = segment.text;
     const remainingWidth = Math.max(1, Math.round(wordWrapWidth - x));
-    const styleWithWordWrap = {
-      ...segment.textStyle,
-      wordWrapWidth: remainingWidth,
-    };
+    const styleWithWordWrap = segment.textStyle.wordWrap
+      ? {
+          ...segment.textStyle,
+          wordWrapWidth: remainingWidth,
+        }
+      : segment.textStyle;
 
     const measurements = CanvasTextMetrics.measureText(
       segment.text,
@@ -400,37 +406,21 @@ const createTextChunks = (segments, wordWrapWidth) => {
 
   return {
     chunks,
-    width: Math.max(maxTotalWidth, wordWrapWidth),
+    width: Math.max(maxTotalWidth, minimumWidth),
     height: finalHeight,
   };
 };
 
-/**
- * Parse text-revealing object and calculate final position after anchor adjustment
- * @param {Object} params
- * @param {BaseElement} params.state - The text-revealing state to parse
- * @param {Array} params.parserPlugins - Array of parser plugins (not used by this parser)
- * @returns {TextRevealingComputedNode}
- */
-export const parseTextRevealing = ({ state }) => {
-  const defaultTextStyle = mergeTextStyle(
-    {
-      ...DEFAULT_TEXT_STYLE,
-      wordWrap: true,
-    },
-    state.textStyle,
-  );
-
-  const processedContent = (state.content || []).map((item, itemIndex) => {
-    // TODO: if breakwords is true this will crash
+export const prepareRichTextSegments = ({ content, defaultTextStyle, width }) =>
+  (content || []).map((item, itemIndex) => {
     const itemTextStyle = mergeTextStyle(defaultTextStyle, item.textStyle);
 
     itemTextStyle.lineHeight = Math.round(
       itemTextStyle.lineHeight * itemTextStyle.fontSize,
     );
 
-    if (state.width) {
-      itemTextStyle.wordWrapWidth = state.width;
+    if (typeof width === "number") {
+      itemTextStyle.wordWrapWidth = width;
       itemTextStyle.wordWrap = true;
     }
 
@@ -445,8 +435,8 @@ export const parseTextRevealing = ({ state }) => {
         furiganaTextStyle.lineHeight * furiganaTextStyle.fontSize,
       );
 
-      if (state.width) {
-        furiganaTextStyle.wordWrapWidth = state.width;
+      if (typeof width === "number") {
+        furiganaTextStyle.wordWrapWidth = width;
         furiganaTextStyle.wordWrap = true;
       }
 
@@ -464,7 +454,6 @@ export const parseTextRevealing = ({ state }) => {
       };
     }
 
-    // Replace trailing spaces with non-breaking spaces
     const convertedText = String(item.text).replace(/ +$/, (match) =>
       "\u00A0".repeat(match.length),
     );
@@ -474,6 +463,28 @@ export const parseTextRevealing = ({ state }) => {
       textStyle: itemTextStyle,
       ...(furigana && { furigana }),
     };
+  });
+
+/**
+ * Parse text-revealing object and calculate final position after anchor adjustment
+ * @param {Object} params
+ * @param {BaseElement} params.state - The text-revealing state to parse
+ * @param {Array} params.parserPlugins - Array of parser plugins (not used by this parser)
+ * @returns {TextRevealingComputedNode}
+ */
+export const parseTextRevealing = ({ state }) => {
+  const defaultTextStyle = mergeTextStyle(
+    {
+      ...DEFAULT_TEXT_STYLE,
+      wordWrap: true,
+    },
+    state.textStyle,
+  );
+
+  const processedContent = prepareRichTextSegments({
+    content: state.content,
+    defaultTextStyle,
+    width: state.width || undefined,
   });
 
   // Calculate text dimensions using unified chunk approach

--- a/src/plugins/elements/text/addText.js
+++ b/src/plugins/elements/text/addText.js
@@ -1,6 +1,5 @@
 import { Text } from "pixi.js";
 import applyTextStyle from "../../../util/applyTextStyle.js";
-import { normalizeVolume } from "../../../util/normalizeVolume.js";
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
 import {
   getTextLayoutPosition,
@@ -8,13 +7,56 @@ import {
   positionTextInLayoutBox,
   syncTextAnchorRatios,
 } from "./textLayout.js";
-import { isPrimaryPointerEvent } from "../util/isPrimaryPointerEvent.js";
+import { bindTextInteractions } from "./textInteractions.js";
 import {
-  createHoverStateController,
-  createPressStateController,
-  createRightPressStateController,
-} from "../util/hoverInheritance.js";
-import { setupScrollInteraction } from "../util/setupScrollInteraction.js";
+  createRichTextDisplayObject,
+  getRichTextLayoutPosition,
+  isRichTextComputedNode,
+  renderRichTextDisplayObject,
+} from "./richTextDisplay.js";
+
+export const getTextAnimationTargetState = (textComputedNode) => ({
+  ...(isRichTextComputedNode(textComputedNode)
+    ? getRichTextLayoutPosition(textComputedNode)
+    : getTextLayoutPosition(textComputedNode)),
+  alpha: textComputedNode.alpha,
+});
+
+export const createTextDisplayObject = (textComputedNode, zIndex) => {
+  if (isRichTextComputedNode(textComputedNode)) {
+    return createRichTextDisplayObject(textComputedNode, zIndex);
+  }
+
+  const text = new Text({
+    label: textComputedNode.id,
+  });
+
+  text.zIndex = zIndex;
+  text.text = textComputedNode.content;
+  applyTextStyle(text, textComputedNode.textStyle);
+  syncTextAnchorRatios(text, textComputedNode);
+  text.alpha = textComputedNode.alpha;
+  positionTextInLayoutBox(text, textComputedNode);
+
+  return text;
+};
+
+export const applyTextDisplayStyle = (
+  displayObject,
+  textComputedNode,
+  overrideStyle,
+) => {
+  if (isRichTextComputedNode(textComputedNode)) {
+    renderRichTextDisplayObject(displayObject, textComputedNode, overrideStyle);
+    return;
+  }
+
+  applyInteractiveTextStyle(
+    displayObject,
+    textComputedNode.textStyle,
+    overrideStyle,
+  );
+};
 
 /**
  * Add text element to the stage (synchronous)
@@ -31,194 +73,16 @@ export const addText = ({
   renderContext,
   zIndex,
 }) => {
-  const text = new Text({
-    label: textComputedNode.id,
+  const text = createTextDisplayObject(textComputedNode, zIndex);
+
+  bindTextInteractions({
+    app,
+    displayObject: text,
+    textComputedNode,
+    eventHandler,
+    applyStyle: (overrideStyle) =>
+      applyTextDisplayStyle(text, textComputedNode, overrideStyle),
   });
-  text.zIndex = zIndex;
-
-  // Apply initial state
-  text.text = textComputedNode.content;
-  applyTextStyle(text, textComputedNode.textStyle);
-  syncTextAnchorRatios(text, textComputedNode);
-  text.alpha = textComputedNode.alpha;
-  positionTextInLayoutBox(text, textComputedNode);
-
-  const hoverEvents = textComputedNode?.hover;
-  const clickEvents = textComputedNode?.click;
-  const rightClickEvents = textComputedNode?.rightClick;
-  const scrollUpEvent = textComputedNode?.scrollUp;
-  const scrollDownEvent = textComputedNode?.scrollDown;
-
-  let hoverController = null;
-  let pressController = null;
-  let rightPressController = null;
-
-  const updateTextStyle = () => {
-    const isHovering = hoverController?.isHovering() ?? false;
-    const isPressed = pressController?.isPressed() ?? false;
-    const isRightPressed = rightPressController?.isPressed() ?? false;
-
-    if (isRightPressed && rightClickEvents?.textStyle) {
-      applyInteractiveTextStyle(
-        text,
-        textComputedNode.textStyle,
-        rightClickEvents.textStyle,
-      );
-    } else if (isPressed && clickEvents?.textStyle) {
-      applyInteractiveTextStyle(
-        text,
-        textComputedNode.textStyle,
-        clickEvents.textStyle,
-      );
-    } else if (isHovering && hoverEvents?.textStyle) {
-      applyInteractiveTextStyle(
-        text,
-        textComputedNode.textStyle,
-        hoverEvents.textStyle,
-      );
-    } else {
-      applyInteractiveTextStyle(text, textComputedNode.textStyle);
-    }
-  };
-
-  if (hoverEvents) {
-    const { cursor, soundSrc, payload } = hoverEvents;
-    text.eventMode = "static";
-    hoverController = createHoverStateController({
-      displayObject: text,
-      onHoverChange: updateTextStyle,
-    });
-
-    const overListener = () => {
-      hoverController.setDirectHover(true);
-      if (payload && eventHandler)
-        eventHandler(`hover`, {
-          _event: {
-            id: text.label,
-          },
-          ...payload,
-        });
-      if (cursor) text.cursor = cursor;
-      if (soundSrc)
-        app.audioStage.add({
-          id: `hover-${Date.now()}`,
-          url: soundSrc,
-          loop: false,
-        });
-    };
-
-    const outListener = () => {
-      hoverController.setDirectHover(false);
-      text.cursor = "auto";
-    };
-
-    text.on("pointerover", overListener);
-    text.on("pointerout", outListener);
-  }
-
-  if (clickEvents) {
-    const { soundSrc, soundVolume, payload } = clickEvents;
-    text.eventMode = "static";
-    pressController = createPressStateController({
-      displayObject: text,
-      onPressChange: updateTextStyle,
-    });
-
-    const clickListener = (event) => {
-      if (!isPrimaryPointerEvent(event)) {
-        return;
-      }
-
-      pressController.setDirectPress(true);
-    };
-
-    const releaseListener = (event) => {
-      if (!isPrimaryPointerEvent(event)) {
-        return;
-      }
-
-      pressController.setDirectPress(false);
-
-      if (payload && eventHandler)
-        eventHandler(`click`, {
-          _event: {
-            id: text.label,
-          },
-          ...payload,
-        });
-      if (soundSrc)
-        app.audioStage.add({
-          id: `click-${Date.now()}`,
-          url: soundSrc,
-          loop: false,
-          volume: normalizeVolume(soundVolume),
-        });
-    };
-
-    const outListener = () => {
-      pressController.setDirectPress(false);
-    };
-
-    text.on("pointerdown", clickListener);
-    text.on("pointerup", releaseListener);
-    text.on("pointerupoutside", outListener);
-  }
-
-  if (rightClickEvents) {
-    const { soundSrc, payload } = rightClickEvents;
-    text.eventMode = "static";
-    rightPressController = createRightPressStateController({
-      displayObject: text,
-      onPressChange: updateTextStyle,
-    });
-
-    const rightPressListener = () => {
-      rightPressController.setDirectPress(true);
-    };
-
-    const rightReleaseListener = () => {
-      rightPressController.setDirectPress(false);
-    };
-
-    const rightClickListener = () => {
-      rightPressController.setDirectPress(false);
-
-      if (payload && eventHandler) {
-        eventHandler(`rightClick`, {
-          _event: {
-            id: text.label,
-          },
-          ...payload,
-        });
-      }
-      if (soundSrc) {
-        app.audioStage.add({
-          id: `rightClick-${Date.now()}`,
-          url: soundSrc,
-          loop: false,
-        });
-      }
-    };
-
-    const rightOutListener = () => {
-      rightPressController.setDirectPress(false);
-    };
-
-    text.on("rightdown", rightPressListener);
-    text.on("rightup", rightReleaseListener);
-    text.on("rightclick", rightClickListener);
-    text.on("rightupoutside", rightOutListener);
-  }
-
-  if (scrollUpEvent || scrollDownEvent) {
-    setupScrollInteraction({
-      canvas: app.canvas,
-      displayObject: text,
-      scrollUpEvent,
-      scrollDownEvent,
-      eventHandler,
-    });
-  }
 
   parent.addChild(text);
 
@@ -228,10 +92,7 @@ export const addText = ({
     animationBus,
     completionTracker,
     element: text,
-    targetState: {
-      ...getTextLayoutPosition(textComputedNode),
-      alpha: textComputedNode.alpha,
-    },
+    targetState: getTextAnimationTargetState(textComputedNode),
     renderContext,
   });
 };

--- a/src/plugins/elements/text/deleteText.js
+++ b/src/plugins/elements/text/deleteText.js
@@ -1,4 +1,5 @@
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import { clearTextInteractions } from "./textInteractions.js";
 
 /**
  * Delete text element (synchronous)
@@ -24,15 +25,15 @@ export const deleteText = ({
     targetState: null,
     onComplete: () => {
       if (text && !text.destroyed) {
-        text._cleanupScrollInteraction?.();
-        text.destroy();
+        clearTextInteractions(text);
+        text.destroy({ children: true });
       }
     },
   });
 
   if (!dispatched) {
     // No animation, destroy immediately
-    text._cleanupScrollInteraction?.();
-    text.destroy();
+    clearTextInteractions(text);
+    text.destroy({ children: true });
   }
 };

--- a/src/plugins/elements/text/parseText.js
+++ b/src/plugins/elements/text/parseText.js
@@ -3,6 +3,29 @@ import { parseCommonObject } from "../util/parseCommonObject.js";
 import { DEFAULT_TEXT_STYLE } from "../../../types.js";
 import { toPixiTextStyle } from "../../../util/toPixiTextStyle.js";
 import { mergeTextStyle } from "../../../util/mergeTextStyle.js";
+import {
+  createTextChunks,
+  prepareRichTextSegments,
+} from "../text-revealing/parseTextRevealing.js";
+
+const RICH_TEXT_NO_WRAP_WIDTH = 100000;
+
+const getRichTextWordWrapWidth = (state, textStyle) => {
+  if (typeof state.width === "number") {
+    return state.width;
+  }
+
+  if (
+    textStyle.wordWrap &&
+    typeof textStyle.wordWrapWidth === "number" &&
+    Number.isFinite(textStyle.wordWrapWidth) &&
+    textStyle.wordWrapWidth > 0
+  ) {
+    return textStyle.wordWrapWidth;
+  }
+
+  return RICH_TEXT_NO_WRAP_WIDTH;
+};
 
 /**
  * @typedef {import('../../../types.js').BaseElement} BaseElement
@@ -17,7 +40,9 @@ import { mergeTextStyle } from "../../../util/mergeTextStyle.js";
  * @returns {TextComputedNode}
  */
 export const parseText = ({ state }) => {
-  const textStyle = mergeTextStyle(DEFAULT_TEXT_STYLE, state.textStyle);
+  const contentIsRich = Array.isArray(state.content);
+  const baseTextStyle = mergeTextStyle(DEFAULT_TEXT_STYLE, state.textStyle);
+  const textStyle = { ...baseTextStyle };
 
   textStyle.lineHeight = Math.round(textStyle.fontSize * textStyle.lineHeight);
 
@@ -27,7 +52,66 @@ export const parseText = ({ state }) => {
     textStyle.wordWrap = true;
   }
 
-  // Convert content to string for measurement
+  if (contentIsRich) {
+    const wordWrapWidth = getRichTextWordWrapWidth(state, baseTextStyle);
+    const processedContent = prepareRichTextSegments({
+      content: state.content,
+      defaultTextStyle: baseTextStyle,
+      width: typeof state.width === "number" ? state.width : undefined,
+    });
+    const {
+      chunks,
+      width: calculatedWidth,
+      height: calculatedHeight,
+    } = createTextChunks(processedContent, wordWrapWidth, {
+      minimumWidth: 0,
+    });
+    const roundedMeasuredWidth = Math.round(calculatedWidth);
+    const roundedHeight = Math.round(calculatedHeight);
+    const layoutWidth =
+      typeof state.width === "number"
+        ? Math.round(state.width)
+        : roundedMeasuredWidth;
+
+    let computedObj = parseCommonObject({
+      ...state,
+      width: layoutWidth,
+      height: roundedHeight,
+    });
+
+    const computedText = {
+      ...computedObj,
+      content: chunks,
+      measuredWidth: roundedMeasuredWidth,
+      textStyle: {
+        ...textStyle,
+      },
+      ...(state.hover && { hover: state.hover }),
+      ...(state.click && { click: state.click }),
+      ...(state.rightClick && { rightClick: state.rightClick }),
+      ...(state.scrollUp && { scrollUp: state.scrollUp }),
+      ...(state.scrollDown && { scrollDown: state.scrollDown }),
+    };
+
+    Object.defineProperties(computedText, {
+      __anchorXRatio: {
+        value: state.anchorX ?? 0,
+        enumerable: false,
+      },
+      __anchorYRatio: {
+        value: state.anchorY ?? 0,
+        enumerable: false,
+      },
+      __fixedWidth: {
+        value: typeof state.width === "number",
+        enumerable: false,
+      },
+    });
+
+    return computedText;
+  }
+
+  // Convert string content to string for measurement
   const contentString = String(state.content ?? "");
 
   const { width, height } = CanvasTextMetrics.measureText(

--- a/src/plugins/elements/text/richTextDisplay.js
+++ b/src/plugins/elements/text/richTextDisplay.js
@@ -1,0 +1,124 @@
+import { Container, Rectangle, Text, TextStyle } from "pixi.js";
+import { mergeTextStyle } from "../../../util/mergeTextStyle.js";
+import { toPixiTextStyle } from "../../../util/toPixiTextStyle.js";
+import { DEFAULT_TEXT_STYLE } from "../../../types.js";
+
+const RICH_TEXT_DISPLAY = Symbol("routeGraphicsRichTextDisplay");
+
+const getTextAlign = (style) => style?.align ?? DEFAULT_TEXT_STYLE.align;
+
+const getHorizontalOffset = (layoutWidth, lineBounds, align) => {
+  const remainingWidth = Math.max(0, layoutWidth - lineBounds.width);
+  let visibleLeft = 0;
+
+  if (align === "center") {
+    visibleLeft = remainingWidth / 2;
+  } else if (align === "right") {
+    visibleLeft = remainingWidth;
+  }
+
+  return visibleLeft - lineBounds.x;
+};
+
+const destroyChildren = (container) => {
+  const children = container.removeChildren();
+
+  children.forEach((child) => {
+    child.destroy({ children: true });
+  });
+};
+
+const createTextObject = ({ text, style, x, y }) =>
+  new Text({
+    text,
+    style: new TextStyle(toPixiTextStyle(style)),
+    x: Math.round(x),
+    y: Math.round(y),
+  });
+
+const applyOverrideStyle = (style, overrideStyle) =>
+  overrideStyle ? mergeTextStyle(style, overrideStyle) : style;
+
+export const isRichTextComputedNode = (element) =>
+  Array.isArray(element?.content);
+
+export const isRichTextDisplayObject = (displayObject) =>
+  Boolean(displayObject?.[RICH_TEXT_DISPLAY]);
+
+export const getRichTextLayoutPosition = (element) => ({
+  x: element.x,
+  y: element.y,
+});
+
+export const renderRichTextDisplayObject = (
+  container,
+  element,
+  overrideStyle,
+) => {
+  destroyChildren(container);
+
+  container.label = element.id;
+  container.x = Math.round(element.x ?? 0);
+  container.y = Math.round(element.y ?? 0);
+  container.alpha = element.alpha ?? 1;
+
+  const layoutWidth = element.width ?? element.measuredWidth ?? 0;
+
+  for (let chunkIndex = 0; chunkIndex < element.content.length; chunkIndex++) {
+    const chunk = element.content[chunkIndex];
+    const lineContainer = new Container({
+      label: `${element.id}-line-${chunkIndex}`,
+    });
+
+    for (const part of chunk.lineParts ?? []) {
+      if (part.furigana) {
+        lineContainer.addChild(
+          createTextObject({
+            text: part.furigana.text,
+            style: applyOverrideStyle(part.furigana.textStyle, overrideStyle),
+            x: part.furigana.x,
+            y: part.furigana.y,
+          }),
+        );
+      }
+
+      lineContainer.addChild(
+        createTextObject({
+          text: part.text,
+          style: applyOverrideStyle(part.textStyle, overrideStyle),
+          x: part.x,
+          y: part.y,
+        }),
+      );
+    }
+
+    const lineBounds = lineContainer.getLocalBounds();
+
+    lineContainer.x = getHorizontalOffset(
+      layoutWidth,
+      lineBounds,
+      getTextAlign(element.textStyle),
+    );
+
+    container.addChild(lineContainer);
+  }
+
+  container.hitArea = new Rectangle(
+    0,
+    0,
+    Math.max(0, layoutWidth),
+    Math.max(0, element.height ?? 0),
+  );
+};
+
+export const createRichTextDisplayObject = (element, zIndex) => {
+  const container = new Container({
+    label: element.id,
+  });
+
+  container[RICH_TEXT_DISPLAY] = true;
+  container.zIndex = zIndex;
+  renderRichTextDisplayObject(container, element);
+
+  return container;
+};

--- a/src/plugins/elements/text/textInteractions.js
+++ b/src/plugins/elements/text/textInteractions.js
@@ -1,0 +1,206 @@
+import { normalizeVolume } from "../../../util/normalizeVolume.js";
+import { isPrimaryPointerEvent } from "../util/isPrimaryPointerEvent.js";
+import {
+  clearInheritedHoverTarget,
+  clearInheritedPressTarget,
+  clearInheritedRightPressTarget,
+  createHoverStateController,
+  createPressStateController,
+  createRightPressStateController,
+} from "../util/hoverInheritance.js";
+import { setupScrollInteraction } from "../util/setupScrollInteraction.js";
+
+export const clearTextInteractions = (displayObject) => {
+  displayObject._cleanupScrollInteraction?.();
+  displayObject.removeAllListeners("pointerover");
+  displayObject.removeAllListeners("pointerout");
+  displayObject.removeAllListeners("pointerdown");
+  displayObject.removeAllListeners("pointerupoutside");
+  displayObject.removeAllListeners("pointerup");
+  displayObject.removeAllListeners("rightdown");
+  displayObject.removeAllListeners("rightclick");
+  displayObject.removeAllListeners("rightup");
+  displayObject.removeAllListeners("rightupoutside");
+  displayObject.removeAllListeners("wheel");
+  clearInheritedHoverTarget(displayObject);
+  clearInheritedPressTarget(displayObject);
+  clearInheritedRightPressTarget(displayObject);
+  displayObject.cursor = "auto";
+  displayObject.eventMode = "auto";
+};
+
+export const bindTextInteractions = ({
+  app,
+  displayObject,
+  textComputedNode,
+  eventHandler,
+  applyStyle,
+}) => {
+  const hoverEvents = textComputedNode?.hover;
+  const clickEvents = textComputedNode?.click;
+  const rightClickEvents = textComputedNode?.rightClick;
+  const scrollUpEvent = textComputedNode?.scrollUp;
+  const scrollDownEvent = textComputedNode?.scrollDown;
+
+  let hoverController = null;
+  let pressController = null;
+  let rightPressController = null;
+
+  const updateTextStyle = () => {
+    const isHovering = hoverController?.isHovering() ?? false;
+    const isPressed = pressController?.isPressed() ?? false;
+    const isRightPressed = rightPressController?.isPressed() ?? false;
+
+    if (isRightPressed && rightClickEvents?.textStyle) {
+      applyStyle(rightClickEvents.textStyle);
+    } else if (isPressed && clickEvents?.textStyle) {
+      applyStyle(clickEvents.textStyle);
+    } else if (isHovering && hoverEvents?.textStyle) {
+      applyStyle(hoverEvents.textStyle);
+    } else {
+      applyStyle();
+    }
+  };
+
+  if (hoverEvents) {
+    const { cursor, soundSrc, payload } = hoverEvents;
+
+    displayObject.eventMode = "static";
+    hoverController = createHoverStateController({
+      displayObject,
+      onHoverChange: updateTextStyle,
+    });
+
+    const overListener = () => {
+      hoverController.setDirectHover(true);
+      if (payload && eventHandler)
+        eventHandler(`hover`, {
+          _event: {
+            id: displayObject.label,
+          },
+          ...payload,
+        });
+      if (cursor) displayObject.cursor = cursor;
+      if (soundSrc)
+        app.audioStage.add({
+          id: `hover-${Date.now()}`,
+          url: soundSrc,
+          loop: false,
+        });
+    };
+
+    const outListener = () => {
+      hoverController.setDirectHover(false);
+      displayObject.cursor = "auto";
+    };
+
+    displayObject.on("pointerover", overListener);
+    displayObject.on("pointerout", outListener);
+  }
+
+  if (clickEvents) {
+    const { soundSrc, soundVolume, payload } = clickEvents;
+
+    displayObject.eventMode = "static";
+    pressController = createPressStateController({
+      displayObject,
+      onPressChange: updateTextStyle,
+    });
+
+    const clickListener = (event) => {
+      if (!isPrimaryPointerEvent(event)) {
+        return;
+      }
+
+      pressController.setDirectPress(true);
+    };
+
+    const releaseListener = (event) => {
+      if (!isPrimaryPointerEvent(event)) {
+        return;
+      }
+
+      pressController.setDirectPress(false);
+
+      if (payload && eventHandler)
+        eventHandler(`click`, {
+          _event: {
+            id: displayObject.label,
+          },
+          ...payload,
+        });
+      if (soundSrc)
+        app.audioStage.add({
+          id: `click-${Date.now()}`,
+          url: soundSrc,
+          loop: false,
+          volume: normalizeVolume(soundVolume),
+        });
+    };
+
+    const outListener = () => {
+      pressController.setDirectPress(false);
+    };
+
+    displayObject.on("pointerdown", clickListener);
+    displayObject.on("pointerup", releaseListener);
+    displayObject.on("pointerupoutside", outListener);
+  }
+
+  if (rightClickEvents) {
+    const { soundSrc, payload } = rightClickEvents;
+
+    displayObject.eventMode = "static";
+    rightPressController = createRightPressStateController({
+      displayObject,
+      onPressChange: updateTextStyle,
+    });
+
+    const rightPressListener = () => {
+      rightPressController.setDirectPress(true);
+    };
+
+    const rightReleaseListener = () => {
+      rightPressController.setDirectPress(false);
+    };
+
+    const rightClickListener = () => {
+      rightPressController.setDirectPress(false);
+
+      if (payload && eventHandler) {
+        eventHandler(`rightClick`, {
+          _event: {
+            id: displayObject.label,
+          },
+          ...payload,
+        });
+      }
+      if (soundSrc) {
+        app.audioStage.add({
+          id: `rightClick-${Date.now()}`,
+          url: soundSrc,
+          loop: false,
+        });
+      }
+    };
+
+    const rightOutListener = () => {
+      rightPressController.setDirectPress(false);
+    };
+
+    displayObject.on("rightdown", rightPressListener);
+    displayObject.on("rightup", rightReleaseListener);
+    displayObject.on("rightclick", rightClickListener);
+    displayObject.on("rightupoutside", rightOutListener);
+  }
+
+  if (scrollUpEvent || scrollDownEvent) {
+    setupScrollInteraction({
+      canvas: app.canvas,
+      displayObject,
+      scrollUpEvent,
+      scrollDownEvent,
+      eventHandler,
+    });
+  }
+};

--- a/src/plugins/elements/text/updateText.js
+++ b/src/plugins/elements/text/updateText.js
@@ -1,23 +1,83 @@
 import applyTextStyle from "../../../util/applyTextStyle.js";
 import { isDeepEqual } from "../../../util/isDeepEqual.js";
-import { normalizeVolume } from "../../../util/normalizeVolume.js";
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import { positionTextInLayoutBox, syncTextAnchorRatios } from "./textLayout.js";
 import {
-  getTextLayoutPosition,
-  applyInteractiveTextStyle,
-  positionTextInLayoutBox,
-  syncTextAnchorRatios,
-} from "./textLayout.js";
-import { isPrimaryPointerEvent } from "../util/isPrimaryPointerEvent.js";
+  applyTextDisplayStyle,
+  createTextDisplayObject,
+  getTextAnimationTargetState,
+} from "./addText.js";
 import {
-  clearInheritedHoverTarget,
-  clearInheritedPressTarget,
-  clearInheritedRightPressTarget,
-  createHoverStateController,
-  createPressStateController,
-  createRightPressStateController,
-} from "../util/hoverInheritance.js";
-import { setupScrollInteraction } from "../util/setupScrollInteraction.js";
+  isRichTextComputedNode,
+  isRichTextDisplayObject,
+  renderRichTextDisplayObject,
+} from "./richTextDisplay.js";
+import {
+  bindTextInteractions,
+  clearTextInteractions,
+} from "./textInteractions.js";
+
+const displayKindChanged = (displayObject, textComputedNode) =>
+  isRichTextDisplayObject(displayObject) !==
+  isRichTextComputedNode(textComputedNode);
+
+const replaceTextDisplayObject = ({
+  app,
+  parent,
+  displayObject,
+  textComputedNode,
+  eventHandler,
+  zIndex,
+}) => {
+  clearTextInteractions(displayObject);
+
+  const replacement = createTextDisplayObject(textComputedNode, zIndex);
+
+  bindTextInteractions({
+    app,
+    displayObject: replacement,
+    textComputedNode,
+    eventHandler,
+    applyStyle: (overrideStyle) =>
+      applyTextDisplayStyle(replacement, textComputedNode, overrideStyle),
+  });
+
+  parent.addChild(replacement);
+  displayObject.destroy({ children: true });
+
+  return replacement;
+};
+
+const updatePlainTextDisplayObject = (displayObject, textComputedNode) => {
+  displayObject.text = textComputedNode.content;
+  applyTextStyle(displayObject, textComputedNode.textStyle);
+  syncTextAnchorRatios(displayObject, textComputedNode);
+  positionTextInLayoutBox(displayObject, textComputedNode);
+  displayObject.alpha = textComputedNode.alpha;
+};
+
+const updateTextDisplayObject = ({
+  displayObject,
+  textComputedNode,
+  app,
+  eventHandler,
+}) => {
+  if (isRichTextComputedNode(textComputedNode)) {
+    renderRichTextDisplayObject(displayObject, textComputedNode);
+  } else {
+    updatePlainTextDisplayObject(displayObject, textComputedNode);
+  }
+
+  clearTextInteractions(displayObject);
+  bindTextInteractions({
+    app,
+    displayObject,
+    textComputedNode,
+    eventHandler,
+    applyStyle: (overrideStyle) =>
+      applyTextDisplayStyle(displayObject, textComputedNode, overrideStyle),
+  });
+};
 
 /**
  * Update text element (synchronous)
@@ -34,7 +94,7 @@ export const updateText = ({
   completionTracker,
   zIndex,
 }) => {
-  const textElement = parent.children.find(
+  let textElement = parent.children.find(
     (child) => child.label === prevTextComputedNode.id,
   );
 
@@ -42,212 +102,29 @@ export const updateText = ({
 
   textElement.zIndex = zIndex;
 
-  const { alpha } = nextTextComputedNode;
-
   const updateElement = () => {
-    if (!isDeepEqual(prevTextComputedNode, nextTextComputedNode)) {
-      textElement._cleanupScrollInteraction?.();
-      textElement.text = nextTextComputedNode.content;
-      applyTextStyle(textElement, nextTextComputedNode.textStyle);
-      syncTextAnchorRatios(textElement, nextTextComputedNode);
-
-      positionTextInLayoutBox(textElement, nextTextComputedNode);
-      textElement.alpha = alpha;
-
-      textElement.removeAllListeners("pointerover");
-      textElement.removeAllListeners("pointerout");
-      textElement.removeAllListeners("pointerdown");
-      textElement.removeAllListeners("pointerupoutside");
-      textElement.removeAllListeners("pointerup");
-      textElement.removeAllListeners("rightdown");
-      textElement.removeAllListeners("rightclick");
-      textElement.removeAllListeners("rightup");
-      textElement.removeAllListeners("rightupoutside");
-      textElement.removeAllListeners("wheel");
-      clearInheritedHoverTarget(textElement);
-      clearInheritedPressTarget(textElement);
-      clearInheritedRightPressTarget(textElement);
-
-      const hoverEvents = nextTextComputedNode?.hover;
-      const clickEvents = nextTextComputedNode?.click;
-      const rightClickEvents = nextTextComputedNode?.rightClick;
-      const scrollUpEvent = nextTextComputedNode?.scrollUp;
-      const scrollDownEvent = nextTextComputedNode?.scrollDown;
-
-      let hoverController = null;
-      let pressController = null;
-      let rightPressController = null;
-
-      const updateTextStyle = () => {
-        const isHovering = hoverController?.isHovering() ?? false;
-        const isPressed = pressController?.isPressed() ?? false;
-        const isRightPressed = rightPressController?.isPressed() ?? false;
-
-        if (isRightPressed && rightClickEvents?.textStyle) {
-          applyInteractiveTextStyle(
-            textElement,
-            nextTextComputedNode.textStyle,
-            rightClickEvents.textStyle,
-          );
-        } else if (isPressed && clickEvents?.textStyle) {
-          applyInteractiveTextStyle(
-            textElement,
-            nextTextComputedNode.textStyle,
-            clickEvents.textStyle,
-          );
-        } else if (isHovering && hoverEvents?.textStyle) {
-          applyInteractiveTextStyle(
-            textElement,
-            nextTextComputedNode.textStyle,
-            hoverEvents.textStyle,
-          );
-        } else {
-          applyInteractiveTextStyle(
-            textElement,
-            nextTextComputedNode.textStyle,
-          );
-        }
-      };
-
-      if (hoverEvents) {
-        const { cursor, soundSrc, payload } = hoverEvents;
-        textElement.eventMode = "static";
-        hoverController = createHoverStateController({
-          displayObject: textElement,
-          onHoverChange: updateTextStyle,
-        });
-
-        const overListener = () => {
-          hoverController.setDirectHover(true);
-          if (payload && eventHandler)
-            eventHandler(`hover`, {
-              _event: {
-                id: textElement.label,
-              },
-              ...payload,
-            });
-          if (cursor) textElement.cursor = cursor;
-          if (soundSrc)
-            app.audioStage.add({
-              id: `hover-${Date.now()}`,
-              url: soundSrc,
-              loop: false,
-            });
-        };
-
-        const outListener = () => {
-          hoverController.setDirectHover(false);
-          textElement.cursor = "auto";
-        };
-
-        textElement.on("pointerover", overListener);
-        textElement.on("pointerout", outListener);
-      }
-
-      if (clickEvents) {
-        const { soundSrc, soundVolume, payload } = clickEvents;
-        textElement.eventMode = "static";
-        pressController = createPressStateController({
-          displayObject: textElement,
-          onPressChange: updateTextStyle,
-        });
-
-        const clickListener = (event) => {
-          if (!isPrimaryPointerEvent(event)) {
-            return;
-          }
-
-          pressController.setDirectPress(true);
-        };
-
-        const releaseListener = (event) => {
-          if (!isPrimaryPointerEvent(event)) {
-            return;
-          }
-
-          pressController.setDirectPress(false);
-
-          if (payload && eventHandler)
-            eventHandler(`click`, {
-              _event: {
-                id: textElement.label,
-              },
-              ...payload,
-            });
-          if (soundSrc)
-            app.audioStage.add({
-              id: `click-${Date.now()}`,
-              url: soundSrc,
-              loop: false,
-              volume: normalizeVolume(soundVolume),
-            });
-        };
-
-        const outListener = () => {
-          pressController.setDirectPress(false);
-        };
-
-        textElement.on("pointerdown", clickListener);
-        textElement.on("pointerup", releaseListener);
-        textElement.on("pointerupoutside", outListener);
-      }
-
-      if (rightClickEvents) {
-        const { soundSrc, payload } = rightClickEvents;
-        textElement.eventMode = "static";
-        rightPressController = createRightPressStateController({
-          displayObject: textElement,
-          onPressChange: updateTextStyle,
-        });
-
-        const rightPressListener = () => {
-          rightPressController.setDirectPress(true);
-        };
-
-        const rightReleaseListener = () => {
-          rightPressController.setDirectPress(false);
-        };
-
-        const rightClickListener = () => {
-          rightPressController.setDirectPress(false);
-
-          if (payload && eventHandler) {
-            eventHandler(`rightClick`, {
-              _event: {
-                id: textElement.label,
-              },
-              ...payload,
-            });
-          }
-          if (soundSrc) {
-            app.audioStage.add({
-              id: `rightClick-${Date.now()}`,
-              url: soundSrc,
-              loop: false,
-            });
-          }
-        };
-
-        const rightOutListener = () => {
-          rightPressController.setDirectPress(false);
-        };
-
-        textElement.on("rightdown", rightPressListener);
-        textElement.on("rightup", rightReleaseListener);
-        textElement.on("rightclick", rightClickListener);
-        textElement.on("rightupoutside", rightOutListener);
-      }
-
-      if (scrollUpEvent || scrollDownEvent) {
-        setupScrollInteraction({
-          canvas: app.canvas,
-          displayObject: textElement,
-          scrollUpEvent,
-          scrollDownEvent,
-          eventHandler,
-        });
-      }
+    if (isDeepEqual(prevTextComputedNode, nextTextComputedNode)) {
+      return;
     }
+
+    if (displayKindChanged(textElement, nextTextComputedNode)) {
+      textElement = replaceTextDisplayObject({
+        app,
+        parent,
+        displayObject: textElement,
+        textComputedNode: nextTextComputedNode,
+        eventHandler,
+        zIndex,
+      });
+      return;
+    }
+
+    updateTextDisplayObject({
+      displayObject: textElement,
+      textComputedNode: nextTextComputedNode,
+      app,
+      eventHandler,
+    });
   };
 
   const dispatched = dispatchLiveAnimations({
@@ -256,17 +133,13 @@ export const updateText = ({
     animationBus,
     completionTracker,
     element: textElement,
-    targetState: {
-      ...getTextLayoutPosition(nextTextComputedNode),
-      alpha,
-    },
+    targetState: getTextAnimationTargetState(nextTextComputedNode),
     onComplete: () => {
       updateElement();
     },
   });
 
   if (!dispatched) {
-    // No animations, update immediately
     updateElement();
   }
 };

--- a/src/schemas/elements/text.computed.yaml
+++ b/src/schemas/elements/text.computed.yaml
@@ -75,6 +75,45 @@ $def:
         description: Text stroke/outline width
       shadow:
         "$ref": "#/$def/textShadow"
+  textChunk:
+    type: object
+    properties:
+      y:
+        type: number
+        description: Y position of the line
+      lineParts:
+        type: array
+        description: Array of rich text parts in this line
+        items:
+          type: object
+          properties:
+            text:
+              type: string
+              description: The text content
+            textStyle:
+              "$ref": "#/$def/textStyle"
+            x:
+              type: number
+              description: Horizontal position
+            y:
+              type: number
+              description: Vertical position
+            furigana:
+              type: object
+              properties:
+                text:
+                  type: string
+                textStyle:
+                  "$ref": "#/$def/textStyle"
+                x:
+                  type: number
+                  description: Horizontal position relative to the parent text part
+                y:
+                  type: number
+                  description: Vertical position relative to the parent text part
+      lineMaxHeight:
+        type: number
+        description: Maximum height of text in this line
 required:
   - id
   - type
@@ -95,8 +134,12 @@ properties:
     const: text
     description: Element type, must be 'text'
   content:
-    type: string
-    description: The text content to display
+    oneOf:
+      - type: string
+      - type: array
+        items:
+          "$ref": "#/$def/textChunk"
+    description: The text content to display. String content stays a single text object; array content is parsed into rich text lines.
   width:
     type: number
     description: Layout width of the text box. When input width is provided, this matches that fixed width.

--- a/src/schemas/elements/text.element.yaml
+++ b/src/schemas/elements/text.element.yaml
@@ -77,6 +77,32 @@ $def:
         description: Text stroke/outline width
       shadow:
         "$ref": "#/$def/textShadow"
+  contentSegment:
+    type: object
+    required:
+      - text
+    properties:
+      text:
+        type: string
+      textStyle:
+        "$ref": "#/$def/textStyle"
+      furigana:
+        type: object
+        properties:
+          text:
+            type: string
+          textStyle:
+            "$ref": "#/$def/textStyle"
+          placement:
+            type: string
+            enum: [top, bottom]
+            default: top
+            description: Side of the base text where furigana is placed.
+          gap:
+            type: number
+            minimum: 0
+            default: 0
+            description: Additional distance in pixels between the furigana and base text.
 properties:
   id:
     type: string
@@ -85,8 +111,12 @@ properties:
     const: text
     description: Element type, must be 'text'
   content:
-    type: string
-    description: The text content to display
+    oneOf:
+      - type: string
+      - type: array
+        items:
+          "$ref": "#/$def/contentSegment"
+    description: The text content to display. Strings render as one Pixi text object; arrays render static rich text segments.
     default: ""
   width:
     type: number

--- a/src/types.js
+++ b/src/types.js
@@ -437,7 +437,7 @@
 
 /**
  * @typedef {Object} TextComputedProps
- * @property {string} content - The text content to display
+ * @property {string | Array<TextChunk>} content - The text content to display. Arrays contain static rich text lines.
  * @property {number} measuredWidth - The rendered text width before fixed-width layout is applied
  * @property {Object} textStyle - Text style object
  * @property {TextHover} [hover]

--- a/vt/reference/textbasic/rich-text-segments-01.webp
+++ b/vt/reference/textbasic/rich-text-segments-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:365742452b226b2b08addf22ea9ad40a7dce87beb2d446fefb0a44204d66451e
+size 5550

--- a/vt/reference/textbasic/rich-text-segments-02.webp
+++ b/vt/reference/textbasic/rich-text-segments-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:365742452b226b2b08addf22ea9ad40a7dce87beb2d446fefb0a44204d66451e
+size 5550

--- a/vt/reference/textbasic/rich-text-segments-03.webp
+++ b/vt/reference/textbasic/rich-text-segments-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:644222565e378f6177101a3298641e6ef5b627ef6b52f07acb405569971a7227
+size 5560

--- a/vt/specs/textbasic/rich-text-segments.yaml
+++ b/vt/specs/textbasic/rich-text-segments.yaml
@@ -1,0 +1,112 @@
+---
+title: Rich Text Segments
+description: |
+  Text fill and segment styling are the behavior under test, so grayscale segment fills are used intentionally.
+specs:
+  - text content arrays should render multiple styled inline segments
+  - fixed-width rich text should wrap and align inside the configured text box
+  - updating from plain string text to rich text should replace the runtime display object cleanly
+steps:
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: screenshot
+---
+states:
+  - elements:
+      - id: rich-line-box
+        type: rect
+        x: 36
+        "y": 36
+        width: 420
+        height: 64
+        fill: "#4D4D4D"
+      - id: rich-line
+        type: text
+        x: 56
+        "y": 50
+        width: 380
+        textStyle:
+          fontSize: 30
+          fontFamily: Arial
+          fill: "#FFFFFF"
+        content:
+          - text: "HP"
+          - text: "42"
+            textStyle:
+              fill: "#D9D9D9"
+              fontWeight: bold
+          - text: "OK"
+            textStyle:
+              fill: "#A6A6A6"
+      - id: rich-wrap-box
+        type: rect
+        x: 36
+        "y": 132
+        width: 240
+        height: 142
+        fill: "#4D4D4D"
+      - id: rich-wrap
+        type: text
+        x: 56
+        "y": 148
+        width: 200
+        textStyle:
+          fontSize: 26
+          fontFamily: Arial
+          fill: "#FFFFFF"
+          align: center
+          lineHeight: 1.25
+          breakWords: true
+        content:
+          - text: "STATICSTATIC"
+          - text: "RICHSEGMENT"
+            textStyle:
+              fill: "#D9D9D9"
+              fontWeight: bold
+          - text: "TEXTBLOCK"
+            textStyle:
+              fill: "#A6A6A6"
+  - elements:
+      - id: rich-line-box
+        type: rect
+        x: 36
+        "y": 36
+        width: 420
+        height: 64
+        fill: "#4D4D4D"
+      - id: rich-line
+        type: text
+        x: 56
+        "y": 50
+        width: 380
+        textStyle:
+          fontSize: 30
+          fontFamily: Arial
+          fill: "#FFFFFF"
+        content: "Plain string"
+      - id: rich-wrap-box
+        type: rect
+        x: 36
+        "y": 132
+        width: 240
+        height: 142
+        fill: "#4D4D4D"
+      - id: rich-wrap
+        type: text
+        x: 56
+        "y": 148
+        width: 200
+        textStyle:
+          fontSize: 26
+          fontFamily: Arial
+          fill: "#FFFFFF"
+          align: center
+          lineHeight: 1.25
+          breakWords: true
+        content:
+          - text: "UPDATEDSTATIC"
+          - text: "RICHSEGMENTS"
+            textStyle:
+              fill: "#D9D9D9"
+              fontWeight: bold


### PR DESCRIPTION
## Summary
- Add array-based rich text segment support to the static text element while preserving the existing string path
- Share rich text segment normalization/layout with text-revealing and render segmented text via a static Pixi container
- Update schemas, docs, parser/runtime tests, VT spec/reference images, and bump package version to 1.17.0

## Verification
- bunx vitest run spec/parser/parseText.test.yaml spec/elements/addTextRichContent.spec.js
- bunx vitest run spec/parser/parseTextRevealing.test.yaml spec/parser/parseTextRevealing.newline.spec.js spec/parser/parseTextRevealing.furiganaPlacement.spec.js spec/parser/parseText.test.yaml
- bun run build
- rtgl vt screenshot --wait-event vt:ready --item textbasic/rich-text-segments.yaml --concurrency 1
- rtgl vt report --item textbasic/rich-text-segments.yaml
- pre-push hook: prettier check and full vitest run, 445 tests passed