### PR TITLE
Fix update animation lifecycle

### DIFF
--- a/docs/animation-model.md
+++ b/docs/animation-model.md
@@ -91,16 +91,15 @@ Use it for:
 - fading a persistent element
 - scaling a portrait in place
 - changing properties on an already-mounted element
-- only when the same target persists across the state change
+- simple "in" animations on a newly mounted live element
+- simple "out" animations before a live element is removed
 
 Do not use `update` for:
 
-- first show / enter
-- final hide / exit
 - prev/next replacement handoffs
 
-Higher-level adapters should reject those cases and require `transition`
-instead.
+Use `transition` instead when the animation needs a previous/next visual
+handoff, including masked reveals, dissolves, exits, and replacements.
 
 `update` supports:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/elements/addContainer.spec.js
+++ b/spec/elements/addContainer.spec.js
@@ -38,7 +38,9 @@ describe("addContainer", () => {
           },
         ],
       },
-      animations: [{ id: "child-enter", targetId: "child-1", type: "transition" }],
+      animations: [
+        { id: "child-enter", targetId: "child-1", type: "transition" },
+      ],
       eventHandler: vi.fn(),
       animationBus: { dispatch: vi.fn() },
       elementPlugins: [],
@@ -64,6 +66,67 @@ describe("addContainer", () => {
         renderContext,
       }),
     );
+  });
+
+  it("dispatches update animations when the container is newly added", () => {
+    const parent = new Container();
+    const animationBus = { dispatch: vi.fn() };
+    const completionTracker = {
+      getVersion: () => 11,
+      track: vi.fn(),
+      complete: vi.fn(),
+    };
+
+    addContainer({
+      app: { audioStage: { add: vi.fn() } },
+      parent,
+      element: {
+        id: "container-1",
+        type: "container",
+        x: 20,
+        y: 30,
+        alpha: 1,
+        children: [],
+      },
+      animations: [
+        {
+          id: "container-enter",
+          targetId: "container-1",
+          type: "update",
+          tween: {
+            alpha: {
+              initialValue: 0,
+              keyframes: [{ duration: 300, value: 1, easing: "linear" }],
+            },
+          },
+        },
+      ],
+      eventHandler: vi.fn(),
+      animationBus,
+      elementPlugins: [],
+      renderContext: createRenderContext(),
+      zIndex: 0,
+      completionTracker,
+      signal: new AbortController().signal,
+    });
+
+    const container = parent.getChildByLabel("container-1");
+
+    expect(completionTracker.track).toHaveBeenCalledWith(11);
+    expect(animationBus.dispatch).toHaveBeenCalledWith({
+      type: "START",
+      payload: expect.objectContaining({
+        id: "container-enter",
+        animationType: "update",
+        targetId: "container-1",
+        element: container,
+        targetState: {
+          x: 20,
+          y: 30,
+          alpha: 1,
+        },
+      }),
+    });
   });
 
   it("falls back to direct child add when sibling ids are duplicated", () => {
@@ -102,7 +165,9 @@ describe("addContainer", () => {
           },
         ],
       },
-      animations: [{ id: "child-enter", targetId: "child-1", type: "transition" }],
+      animations: [
+        { id: "child-enter", targetId: "child-1", type: "transition" },
+      ],
       eventHandler: vi.fn(),
       animationBus: { dispatch: vi.fn() },
       elementPlugins: [childPlugin],

--- a/spec/elements/animatedSpriteRendering.spec.js
+++ b/spec/elements/animatedSpriteRendering.spec.js
@@ -149,6 +149,67 @@ describe("spritesheet animation rendering", () => {
     expect(app.render).toHaveBeenCalledTimes(1);
   });
 
+  it("dispatches update animations after asynchronously adding a spritesheet animation", async () => {
+    const app = {
+      debug: true,
+      render: vi.fn(),
+    };
+    const animationBus = { dispatch: vi.fn() };
+    const completionTracker = {
+      getVersion: () => 2,
+      track: vi.fn(),
+      complete: vi.fn(),
+    };
+    const parent = {
+      destroyed: false,
+      addChild: vi.fn(),
+    };
+    const renderContext = {};
+
+    await addAnimatedSprite({
+      app,
+      parent,
+      element: createAnimatedSpriteElement(),
+      animations: [
+        {
+          id: "animated-sprite-enter",
+          targetId: "animated-sprite-1",
+          type: "update",
+          tween: {
+            alpha: {
+              initialValue: 0,
+              keyframes: [{ duration: 300, value: 1, easing: "linear" }],
+            },
+          },
+        },
+      ],
+      animationBus,
+      completionTracker,
+      renderContext,
+      zIndex: 3,
+      signal: undefined,
+    });
+
+    const addedSprite = parent.addChild.mock.calls[0][0];
+
+    expect(dispatchLiveAnimations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetId: "animated-sprite-1",
+        animationBus,
+        completionTracker,
+        element: addedSprite,
+        targetState: expect.objectContaining({
+          x: 200,
+          y: 150,
+          width: 100,
+          height: 100,
+          alpha: 1,
+        }),
+        renderContext,
+      }),
+    );
+  });
+
   it("renders after replacing spritesheet animation frame textures asynchronously", async () => {
     const app = {
       debug: false,

--- a/spec/elements/inputPlugin.spec.js
+++ b/spec/elements/inputPlugin.spec.js
@@ -1,6 +1,7 @@
 import { Container } from "pixi.js";
 import { describe, expect, it, vi } from "vitest";
 import { addInput } from "../../src/plugins/elements/input/addInput.js";
+import { deleteInput } from "../../src/plugins/elements/input/deleteInput.js";
 import { parseInput } from "../../src/plugins/elements/input/parseInput.js";
 import { updateInput } from "../../src/plugins/elements/input/updateInput.js";
 
@@ -277,5 +278,76 @@ describe("input plugin", () => {
     inputContainer.emit("pointerup", {
       global: { x: 120, y: 52 },
     });
+  });
+
+  it("runs update animations before unmounting a deleted input", () => {
+    const parent = new Container();
+    const { app } = createApp();
+    const element = parseInput({
+      state: {
+        id: "name",
+        type: "input",
+        x: 20,
+        y: 40,
+        width: 200,
+        height: 44,
+      },
+    });
+    const animationBus = { dispatch: vi.fn() };
+    const completionTracker = {
+      getVersion: () => 4,
+      track: vi.fn(),
+      complete: vi.fn(),
+    };
+
+    addInput({
+      app,
+      parent,
+      element,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    const inputContainer = parent.getChildByLabel("name");
+
+    deleteInput({
+      app,
+      parent,
+      element,
+      animations: [
+        {
+          id: "input-exit",
+          targetId: "name",
+          type: "update",
+          tween: {
+            alpha: {
+              keyframes: [{ duration: 300, value: 0, easing: "linear" }],
+            },
+          },
+        },
+      ],
+      animationBus,
+      completionTracker,
+    });
+
+    expect(app.inputDomBridge.unmount).not.toHaveBeenCalled();
+    expect(completionTracker.track).toHaveBeenCalledWith(4);
+    expect(animationBus.dispatch).toHaveBeenCalledWith({
+      type: "START",
+      payload: expect.objectContaining({
+        id: "input-exit",
+        animationType: "update",
+        targetId: "name",
+        element: inputContainer,
+        targetState: null,
+      }),
+    });
+
+    const onComplete =
+      animationBus.dispatch.mock.calls[0][0].payload.onComplete;
+    onComplete();
+
+    expect(app.inputDomBridge.unmount).toHaveBeenCalledWith("name");
+    expect(inputContainer.destroyed).toBe(true);
   });
 });

--- a/spec/elements/renderElements.addUpdate.spec.js
+++ b/spec/elements/renderElements.addUpdate.spec.js
@@ -64,4 +64,68 @@ describe("renderElements add-time update animations", () => {
       }),
     ]);
   });
+
+  it("passes update animations to deleted elements so plugins can animate before removal", () => {
+    const parent = new Container();
+    const child = new Container();
+    child.label = "rect-1";
+    parent.addChild(child);
+
+    const plugin = {
+      type: "rect",
+      add: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+
+    renderElements({
+      app: { renderer: { width: 1280, height: 720 } },
+      parent,
+      prevComputedTree: [
+        {
+          id: "rect-1",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#ffffff",
+        },
+      ],
+      nextComputedTree: [],
+      animations: [
+        {
+          id: "rect-exit-update",
+          targetId: "rect-1",
+          type: "update",
+          tween: {
+            alpha: {
+              keyframes: [{ duration: 300, value: 0, easing: "linear" }],
+            },
+          },
+        },
+      ],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker: {
+        getVersion: () => 3,
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      eventHandler: vi.fn(),
+      elementPlugins: [plugin],
+      signal: new AbortController().signal,
+    });
+
+    expect(plugin.delete).toHaveBeenCalledTimes(1);
+
+    const { animations } = plugin.delete.mock.calls[0][0];
+
+    expect(animations.get("rect-1")).toEqual([
+      expect.objectContaining({
+        id: "rect-exit-update",
+        targetId: "rect-1",
+        type: "update",
+      }),
+    ]);
+  });
 });

--- a/src/plugins/animations/planAnimations.js
+++ b/src/plugins/animations/planAnimations.js
@@ -25,6 +25,10 @@ export const groupAnimationsByTarget = (animations = []) => {
 };
 
 export const getTargetAnimations = (animationsOrMap, targetId) => {
+  if (!animationsOrMap) {
+    return [];
+  }
+
   if (animationsOrMap instanceof Map) {
     return animationsOrMap.get(targetId) ?? [];
   }

--- a/src/plugins/elements/animated-sprite/addAnimatedSprite.js
+++ b/src/plugins/elements/animated-sprite/addAnimatedSprite.js
@@ -1,7 +1,12 @@
 import { AnimatedSprite, Spritesheet, Texture } from "pixi.js";
 import { setupDebugMode } from "./util/debugUtils.js";
 import { queueDeferredAnimatedSpritePlay } from "../renderContext.js";
-import { syncBlurEffect } from "../util/blurEffect.js";
+import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import {
+  getBlurTargetState,
+  hasBlurUpdateAnimation,
+  syncBlurEffect,
+} from "../util/blurEffect.js";
 import {
   normalizeAnimatedSpriteAtlas,
   normalizeAnimatedSpriteClips,
@@ -18,6 +23,8 @@ export const addAnimatedSprite = async ({
   app,
   parent,
   element,
+  animations,
+  animationBus,
   renderContext,
   completionTracker,
   zIndex,
@@ -79,9 +86,27 @@ export const addAnimatedSprite = async ({
     animatedSprite.width = Math.round(width);
     animatedSprite.height = Math.round(height);
     animatedSprite.alpha = alpha;
-    syncBlurEffect(animatedSprite, element.blur);
+    const shouldForceBlur = hasBlurUpdateAnimation(animations, id);
+    syncBlurEffect(animatedSprite, element.blur, { force: shouldForceBlur });
 
     parent.addChild(animatedSprite);
+
+    dispatchLiveAnimations({
+      animations,
+      targetId: id,
+      animationBus,
+      completionTracker,
+      element: animatedSprite,
+      targetState: {
+        x,
+        y,
+        width,
+        height,
+        alpha,
+        ...getBlurTargetState(element, { force: shouldForceBlur }),
+      },
+      renderContext,
+    });
 
     if (typeof app.render === "function") {
       app.render();

--- a/src/plugins/elements/container/addContainer.js
+++ b/src/plugins/elements/container/addContainer.js
@@ -2,7 +2,12 @@ import { Container } from "pixi.js";
 import { setupScrolling } from "./util/scrollingUtils.js";
 import { bindContainerInteractions } from "./util/bindContainerInteractions.js";
 import { renderElements } from "../renderElements.js";
-import { syncBlurEffect } from "../util/blurEffect.js";
+import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import {
+  getBlurTargetState,
+  hasBlurUpdateAnimation,
+  syncBlurEffect,
+} from "../util/blurEffect.js";
 
 const hasDuplicateChildIds = (children = []) => {
   const seen = new Set();
@@ -83,7 +88,8 @@ export const addContainer = ({
   container.x = Math.round(x);
   container.y = Math.round(y);
   container.alpha = alpha;
-  syncBlurEffect(container, element.blur);
+  const shouldForceBlur = hasBlurUpdateAnimation(animations, id);
+  syncBlurEffect(container, element.blur, { force: shouldForceBlur });
 
   parent.addChild(container);
 
@@ -133,5 +139,20 @@ export const addContainer = ({
     container,
     element,
     eventHandler,
+  });
+
+  dispatchLiveAnimations({
+    animations,
+    targetId: id,
+    animationBus,
+    completionTracker,
+    element: container,
+    targetState: {
+      x,
+      y,
+      alpha,
+      ...getBlurTargetState(element, { force: shouldForceBlur }),
+    },
+    renderContext,
   });
 };

--- a/src/plugins/elements/input/addInput.js
+++ b/src/plugins/elements/input/addInput.js
@@ -1,4 +1,5 @@
 import { Container } from "pixi.js";
+import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
 import {
   INPUT_RUNTIME,
   buildInputRuntime,
@@ -157,7 +158,17 @@ const createCallbacks = ({
   },
 });
 
-export const addInput = ({ app, parent, element, eventHandler, zIndex }) => {
+export const addInput = ({
+  app,
+  parent,
+  element,
+  animations,
+  animationBus,
+  completionTracker,
+  eventHandler,
+  renderContext,
+  zIndex,
+}) => {
   if (
     !app.inputDomBridge?.mount ||
     !app.inputDomBridge?.focus ||
@@ -319,6 +330,20 @@ export const addInput = ({ app, parent, element, eventHandler, zIndex }) => {
   });
 
   parent.addChild(container);
+
+  dispatchLiveAnimations({
+    animations,
+    targetId: element.id,
+    animationBus,
+    completionTracker,
+    element: container,
+    targetState: {
+      x: element.x,
+      y: element.y,
+      alpha: element.alpha,
+    },
+    renderContext,
+  });
 };
 
 export default addInput;

--- a/src/plugins/elements/input/deleteInput.js
+++ b/src/plugins/elements/input/deleteInput.js
@@ -1,6 +1,14 @@
 import { INPUT_RUNTIME } from "./inputShared.js";
+import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
 
-export const deleteInput = ({ app, parent, element }) => {
+export const deleteInput = ({
+  app,
+  parent,
+  element,
+  animations,
+  animationBus,
+  completionTracker,
+}) => {
   const inputContainer = parent.getChildByLabel(element.id);
 
   if (!inputContainer) return;
@@ -12,12 +20,32 @@ export const deleteInput = ({ app, parent, element }) => {
 
   const runtime = inputContainer[INPUT_RUNTIME];
 
-  if (runtime?.tickerListener) {
-    app.ticker?.remove?.(runtime.tickerListener);
-  }
+  const deleteElement = () => {
+    if (inputContainer.destroyed) {
+      return;
+    }
 
-  app.inputDomBridge.unmount(element.id);
-  inputContainer.destroy({ children: true });
+    if (runtime?.tickerListener) {
+      app.ticker?.remove?.(runtime.tickerListener);
+    }
+
+    app.inputDomBridge.unmount(element.id);
+    inputContainer.destroy({ children: true });
+  };
+
+  const dispatched = dispatchLiveAnimations({
+    animations,
+    targetId: element.id,
+    animationBus,
+    completionTracker,
+    element: inputContainer,
+    targetState: null,
+    onComplete: deleteElement,
+  });
+
+  if (!dispatched) {
+    deleteElement();
+  }
 };
 
 export default deleteInput;

--- a/src/plugins/elements/particles/addParticles.js
+++ b/src/plugins/elements/particles/addParticles.js
@@ -2,6 +2,7 @@ import { Container, Texture, Graphics } from "pixi.js";
 import { Emitter } from "./emitter/index.js";
 import { getTexture } from "./util/registries.js";
 import { queueDeferredParticlesStart } from "../renderContext.js";
+import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
 
 /**
  * @typedef {import('pixi.js').Application} Application
@@ -109,6 +110,9 @@ export const addParticle = ({
   app,
   parent,
   element,
+  animations,
+  animationBus,
+  completionTracker,
   renderContext,
   zIndex,
 }) => {
@@ -221,4 +225,18 @@ export const addParticle = ({
   if (element.alpha !== undefined) {
     container.alpha = element.alpha;
   }
+
+  dispatchLiveAnimations({
+    animations,
+    targetId: element.id,
+    animationBus,
+    completionTracker,
+    element: container,
+    targetState: {
+      x: element.x ?? 0,
+      y: element.y ?? 0,
+      alpha: element.alpha ?? container.alpha,
+    },
+    renderContext,
+  });
 };

--- a/src/plugins/elements/renderElements.js
+++ b/src/plugins/elements/renderElements.js
@@ -158,7 +158,7 @@ export const renderElements = ({
       app,
       parent,
       element,
-      animations: [],
+      animations: animationsByTarget,
       animationBus,
       completionTracker,
       eventHandler,

--- a/src/plugins/elements/text-revealing/addTextRevealing.js
+++ b/src/plugins/elements/text-revealing/addTextRevealing.js
@@ -1,4 +1,5 @@
 import { Container } from "pixi.js";
+import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
 import { queueDeferredTextRevealAutoplay } from "../renderContext.js";
 import {
   runTextReveal,
@@ -12,6 +13,7 @@ import {
 export const addTextRevealing = async ({
   parent,
   element,
+  animations,
   animationBus,
   renderContext,
   completionTracker,
@@ -28,6 +30,20 @@ export const addTextRevealing = async ({
   if (element.y !== undefined) container.y = Math.round(element.y);
   if (element.alpha !== undefined) container.alpha = element.alpha;
   parent.addChild(container);
+
+  dispatchLiveAnimations({
+    animations,
+    targetId: element.id,
+    animationBus,
+    completionTracker,
+    element: container,
+    targetState: {
+      x: element.x ?? container.x,
+      y: element.y ?? container.y,
+      alpha: element.alpha ?? container.alpha,
+    },
+    renderContext,
+  });
 
   if (
     renderContext?.suppressAnimations &&

--- a/src/plugins/elements/video/addVideo.js
+++ b/src/plugins/elements/video/addVideo.js
@@ -2,7 +2,12 @@ import { Texture, Sprite } from "pixi.js";
 import { syncVideoPlaybackTracking } from "./playbackTracking.js";
 import { queueDeferredVideoPlay } from "../renderContext.js";
 import { normalizeVolume } from "../../../util/normalizeVolume.js";
-import { syncBlurEffect } from "../util/blurEffect.js";
+import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import {
+  getBlurTargetState,
+  hasBlurUpdateAnimation,
+  syncBlurEffect,
+} from "../util/blurEffect.js";
 
 /**
  * Add video element to the stage
@@ -11,6 +16,8 @@ import { syncBlurEffect } from "../util/blurEffect.js";
 export const addVideo = ({
   parent,
   element,
+  animations,
+  animationBus,
   renderContext,
   completionTracker,
   zIndex,
@@ -37,7 +44,8 @@ export const addVideo = ({
   sprite.width = Math.round(width);
   sprite.height = Math.round(height);
   sprite.alpha = alpha ?? 1;
-  syncBlurEffect(sprite, element.blur);
+  const shouldForceBlur = hasBlurUpdateAnimation(animations, id);
+  syncBlurEffect(sprite, element.blur, { force: shouldForceBlur });
 
   syncVideoPlaybackTracking({
     videoElement: sprite,
@@ -49,4 +57,21 @@ export const addVideo = ({
   queueDeferredVideoPlay(renderContext, video);
 
   parent.addChild(sprite);
+
+  dispatchLiveAnimations({
+    animations,
+    targetId: id,
+    animationBus,
+    completionTracker,
+    element: sprite,
+    targetState: {
+      x,
+      y,
+      width,
+      height,
+      alpha: alpha ?? 1,
+      ...getBlurTargetState(element, { force: shouldForceBlur }),
+    },
+    renderContext,
+  });
 };

--- a/vt/reference/animatedspritetransition/animated-sprite-update-enter-exit-01.webp
+++ b/vt/reference/animatedspritetransition/animated-sprite-update-enter-exit-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/animatedspritetransition/animated-sprite-update-enter-exit-02.webp
+++ b/vt/reference/animatedspritetransition/animated-sprite-update-enter-exit-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5184f0c9a44861a2e353dd7768cca7bab1528cf7b2c2b31267ead04ad0de317f
+size 5492

--- a/vt/reference/animatedspritetransition/animated-sprite-update-enter-exit-03.webp
+++ b/vt/reference/animatedspritetransition/animated-sprite-update-enter-exit-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92a751054e70024b33045af75878338b6093e0bb638f4824e48f0161eafe88d7
+size 7838

--- a/vt/reference/animatedspritetransition/animated-sprite-update-enter-exit-04.webp
+++ b/vt/reference/animatedspritetransition/animated-sprite-update-enter-exit-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5184f0c9a44861a2e353dd7768cca7bab1528cf7b2c2b31267ead04ad0de317f
+size 5492

--- a/vt/reference/animatedspritetransition/animated-sprite-update-enter-exit-05.webp
+++ b/vt/reference/animatedspritetransition/animated-sprite-update-enter-exit-05.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/containertransition/container-child-update-enter-exit-01.webp
+++ b/vt/reference/containertransition/container-child-update-enter-exit-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/containertransition/container-child-update-enter-exit-02.webp
+++ b/vt/reference/containertransition/container-child-update-enter-exit-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2eddd5dc6b3d8c613ce6a1513761e464de97c079f576e7c5f1a2ff0d010fc1f4
+size 1786

--- a/vt/reference/containertransition/container-child-update-enter-exit-03.webp
+++ b/vt/reference/containertransition/container-child-update-enter-exit-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ed7c54b0233aab47627bdcb702d2583ff0f46ac8b7ad078771377fd9110e0cf
+size 1782

--- a/vt/reference/containertransition/container-child-update-enter-exit-04.webp
+++ b/vt/reference/containertransition/container-child-update-enter-exit-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2eddd5dc6b3d8c613ce6a1513761e464de97c079f576e7c5f1a2ff0d010fc1f4
+size 1786

--- a/vt/reference/containertransition/container-child-update-enter-exit-05.webp
+++ b/vt/reference/containertransition/container-child-update-enter-exit-05.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/containertransition/container-transition-defers-child-update-enter-01.webp
+++ b/vt/reference/containertransition/container-transition-defers-child-update-enter-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/containertransition/container-transition-defers-child-update-enter-02.webp
+++ b/vt/reference/containertransition/container-transition-defers-child-update-enter-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3dbd94873f7c9b6f89e3f74fada8a94b37e4be48b7868f31b6887da44c1afc4e
+size 1766

--- a/vt/reference/containertransition/container-transition-defers-child-update-enter-03.webp
+++ b/vt/reference/containertransition/container-transition-defers-child-update-enter-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19b86e2d25e27bcc34f07c13b185d597e206a8cb33bf8a9ef7c25bdeaaddf5d6
+size 1768

--- a/vt/reference/containertransition/container-transition-defers-child-update-enter-04.webp
+++ b/vt/reference/containertransition/container-transition-defers-child-update-enter-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:491ea0625f05e483875f286c052f7aa149e1e4bffcbee157c9d1833d816484cb
+size 1768

--- a/vt/reference/containertransition/container-transition-defers-child-update-enter-05.webp
+++ b/vt/reference/containertransition/container-transition-defers-child-update-enter-05.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0078b871dc28d511788c2ba4efa5a74e0610ac2add805c030f3db455591b41f
+size 1768

--- a/vt/reference/containertransition/container-update-enter-exit-01.webp
+++ b/vt/reference/containertransition/container-update-enter-exit-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/containertransition/container-update-enter-exit-02.webp
+++ b/vt/reference/containertransition/container-update-enter-exit-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4bc04f0a1261f1f66948dad0e81229babcff7f61cabf422761e1b3287353017
+size 1868

--- a/vt/reference/containertransition/container-update-enter-exit-03.webp
+++ b/vt/reference/containertransition/container-update-enter-exit-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b7a43d41e4346711927868babb3798412a949816fa57d28ebd227f41345eb9b
+size 1872

--- a/vt/reference/containertransition/container-update-enter-exit-04.webp
+++ b/vt/reference/containertransition/container-update-enter-exit-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4bc04f0a1261f1f66948dad0e81229babcff7f61cabf422761e1b3287353017
+size 1868

--- a/vt/reference/containertransition/container-update-enter-exit-05.webp
+++ b/vt/reference/containertransition/container-update-enter-exit-05.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/input/input-update-enter-exit-01.webp
+++ b/vt/reference/input/input-update-enter-exit-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/input/input-update-enter-exit-02.webp
+++ b/vt/reference/input/input-update-enter-exit-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7349a8452c8ef24cee9597af2e12dbcd477ab9443ff081a5f4be140ed35b782c
+size 1810

--- a/vt/reference/input/input-update-enter-exit-03.webp
+++ b/vt/reference/input/input-update-enter-exit-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:183353862dcf27fa4596ed1244dba1a38734fa2a25f5ebfa96e3f05e25ad4c52
+size 2222

--- a/vt/reference/input/input-update-enter-exit-04.webp
+++ b/vt/reference/input/input-update-enter-exit-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7349a8452c8ef24cee9597af2e12dbcd477ab9443ff081a5f4be140ed35b782c
+size 1810

--- a/vt/reference/input/input-update-enter-exit-05.webp
+++ b/vt/reference/input/input-update-enter-exit-05.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/particles/particles-update-enter-exit-01.webp
+++ b/vt/reference/particles/particles-update-enter-exit-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce17100de05da573a81ec017d985b3bfd38cb60f8327f5b0ff2fe4aa0f75c052
+size 1978

--- a/vt/reference/particles/particles-update-enter-exit-02.webp
+++ b/vt/reference/particles/particles-update-enter-exit-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf935c6d5357fa6593d47a0f24dfb3ada978aa3e02d8b664e957cd940789e459
+size 2090

--- a/vt/reference/particles/particles-update-enter-exit-03.webp
+++ b/vt/reference/particles/particles-update-enter-exit-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f827dfaf29539ab838f3be16ff4a926ced4d072f4d063cc1779f4be2b06d29d
+size 2070

--- a/vt/reference/particles/particles-update-enter-exit-04.webp
+++ b/vt/reference/particles/particles-update-enter-exit-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/recttransition/rect-update-enter-exit-01.webp
+++ b/vt/reference/recttransition/rect-update-enter-exit-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/recttransition/rect-update-enter-exit-02.webp
+++ b/vt/reference/recttransition/rect-update-enter-exit-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f66c12070c68274fa6297707d761c5c337192376f5bb21348ddc3cbee109884
+size 1788

--- a/vt/reference/recttransition/rect-update-enter-exit-03.webp
+++ b/vt/reference/recttransition/rect-update-enter-exit-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe97d2e015e55dda8b9d9aa981e1e8c16b6ef2f9de7651dbddf4b683f33033bd
+size 1790

--- a/vt/reference/recttransition/rect-update-enter-exit-04.webp
+++ b/vt/reference/recttransition/rect-update-enter-exit-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f66c12070c68274fa6297707d761c5c337192376f5bb21348ddc3cbee109884
+size 1788

--- a/vt/reference/recttransition/rect-update-enter-exit-05.webp
+++ b/vt/reference/recttransition/rect-update-enter-exit-05.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/replacetransition/rect-same-id-transition-handoff-01.webp
+++ b/vt/reference/replacetransition/rect-same-id-transition-handoff-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33abbb3b57882baa17eae4cc8f2c8bdab15c86cc5fa69b5eb79d2182a3dc25d0
+size 1784

--- a/vt/reference/replacetransition/rect-same-id-transition-handoff-02.webp
+++ b/vt/reference/replacetransition/rect-same-id-transition-handoff-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01b79345c694f720c14c2fd3fbb7b597751fcd98eb9a202dd086413f07495fe0
+size 1844

--- a/vt/reference/replacetransition/rect-same-id-transition-handoff-03.webp
+++ b/vt/reference/replacetransition/rect-same-id-transition-handoff-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c033e5fba4e9d7331803e9bfda29f9a935cd8ba242b07172df7d53059a3f8da
+size 1780

--- a/vt/reference/spritetransition/sprite-update-enter-exit-01.webp
+++ b/vt/reference/spritetransition/sprite-update-enter-exit-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/spritetransition/sprite-update-enter-exit-02.webp
+++ b/vt/reference/spritetransition/sprite-update-enter-exit-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d8f9c3bcf796de40e80dd570dee9a2e8ca7351f744889af201cc268b6440814
+size 3070

--- a/vt/reference/spritetransition/sprite-update-enter-exit-03.webp
+++ b/vt/reference/spritetransition/sprite-update-enter-exit-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cd8d971145660be6ad17c61123914fb0f7a2ae7ae204b581fe4416785d078ac
+size 3814

--- a/vt/reference/spritetransition/sprite-update-enter-exit-04.webp
+++ b/vt/reference/spritetransition/sprite-update-enter-exit-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d8f9c3bcf796de40e80dd570dee9a2e8ca7351f744889af201cc268b6440814
+size 3070

--- a/vt/reference/spritetransition/sprite-update-enter-exit-05.webp
+++ b/vt/reference/spritetransition/sprite-update-enter-exit-05.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/textrevealing/text-revealing-update-enter-exit-01.webp
+++ b/vt/reference/textrevealing/text-revealing-update-enter-exit-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/textrevealing/text-revealing-update-enter-exit-02.webp
+++ b/vt/reference/textrevealing/text-revealing-update-enter-exit-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bca661a27def72e4801412441d1dd105e8eaacd5ac5fe3bd93c70ff41c0e2eb5
+size 4690

--- a/vt/reference/textrevealing/text-revealing-update-enter-exit-03.webp
+++ b/vt/reference/textrevealing/text-revealing-update-enter-exit-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec4ee0e74de5982936f95e229eafeab5816241f097083d173c74f6099263498a
+size 5622

--- a/vt/reference/textrevealing/text-revealing-update-enter-exit-04.webp
+++ b/vt/reference/textrevealing/text-revealing-update-enter-exit-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bca661a27def72e4801412441d1dd105e8eaacd5ac5fe3bd93c70ff41c0e2eb5
+size 4690

--- a/vt/reference/textrevealing/text-revealing-update-enter-exit-05.webp
+++ b/vt/reference/textrevealing/text-revealing-update-enter-exit-05.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/specs/animatedspritetransition/animated-sprite-update-enter-exit.yaml
+++ b/vt/specs/animatedspritetransition/animated-sprite-update-enter-exit.yaml
@@ -1,0 +1,113 @@
+---
+title: Animated Sprite Update Enter Exit
+description: A spritesheet animation using update animations when it is first added and before it is removed.
+specs:
+  - newly added animated sprites should fade in through an update animation
+  - removed animated sprites should fade out through an update animation before being destroyed
+  - final state should contain no animated sprite
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotAnimatedSpriteFrame"
+    detail:
+      frameIndex: 0
+      elementId: "animated-sprite1"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotAnimatedSpriteFrame"
+    detail:
+      frameIndex: 0
+      elementId: "animated-sprite1"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotAnimatedSpriteFrame"
+    detail:
+      frameIndex: 0
+      elementId: "animated-sprite1"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - id: empty
+    elements: []
+  - id: animated-sprite-entered
+    elements:
+      - id: animated-sprite1
+        type: spritesheet-animation
+        x: 360
+        "y": 160
+        width: 180
+        height: 180
+        src: fighter-spritesheet
+        atlas:
+          frames:
+            rollSequence0000.png:
+              frame:
+                x: 483
+                "y": 692
+                w: 169
+                h: 226
+              rotated: false
+              trimmed: true
+              spriteSourceSize:
+                x: 3
+                "y": 4
+                w: 169
+                h: 226
+              sourceSize:
+                w: 175
+                h: 240
+          meta:
+            format: RGBA8888
+            size:
+              w: 1024
+              h: 1024
+            scale: "1"
+        playback:
+          frames:
+            - 0
+          fps: 1
+          loop: true
+        alpha: 1
+    animations:
+      - id: animated-sprite-update-enter
+        targetId: animated-sprite1
+        type: update
+        tween:
+          alpha:
+            initialValue: 0
+            keyframes:
+              - duration: 1000
+                value: 1
+                easing: linear
+  - id: animated-sprite-removed
+    elements: []
+    animations:
+      - id: animated-sprite-update-exit
+        targetId: animated-sprite1
+        type: update
+        tween:
+          alpha:
+            keyframes:
+              - duration: 1000
+                value: 0
+                easing: linear

--- a/vt/specs/containertransition/container-child-update-enter-exit.yaml
+++ b/vt/specs/containertransition/container-child-update-enter-exit.yaml
@@ -1,0 +1,83 @@
+---
+title: Container Child Update Enter Exit
+description: A child inside a freshly added container using update animations on add and delete.
+specs:
+  - child update animations should run when a new container mounts its children
+  - child update animations should run before a child is removed from an existing container
+  - the parent container should stay mounted after the child is removed
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - id: empty
+    elements: []
+  - id: child-entered
+    elements:
+      - id: container1
+        type: container
+        x: 260
+        "y": 160
+        direction: absolute
+        children:
+          - id: child1
+            type: rect
+            x: 0
+            "y": 0
+            width: 360
+            height: 240
+            fill: "#FFFFFF"
+            alpha: 1
+    animations:
+      - id: child-update-enter
+        targetId: child1
+        type: update
+        tween:
+          alpha:
+            initialValue: 0
+            keyframes:
+              - duration: 1000
+                value: 1
+                easing: linear
+  - id: child-removed
+    elements:
+      - id: container1
+        type: container
+        x: 260
+        "y": 160
+        width: 360
+        height: 240
+        direction: absolute
+        children: []
+    animations:
+      - id: child-update-exit
+        targetId: child1
+        type: update
+        tween:
+          alpha:
+            keyframes:
+              - duration: 1000
+                value: 0
+                easing: linear

--- a/vt/specs/containertransition/container-transition-defers-child-update-enter.yaml
+++ b/vt/specs/containertransition/container-transition-defers-child-update-enter.yaml
@@ -1,0 +1,75 @@
+---
+title: Container Transition Defers Child Update Enter
+description: A parent transition owns the enter handoff before a child update animation starts.
+specs:
+  - parent transition should reveal the child at the update animation initial position
+  - child update animation should start only after the parent transition completes
+  - child should settle at the authored next-state position
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 250
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 250
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 250
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 250
+  - action: screenshot
+---
+states:
+  - id: empty
+    elements: []
+  - id: transitioned-then-updated
+    elements:
+      - id: container1
+        type: container
+        x: 0
+        "y": 0
+        width: 1280
+        height: 720
+        direction: absolute
+        alpha: 1
+        children:
+          - id: child1
+            type: rect
+            x: 560
+            "y": 180
+            width: 220
+            height: 180
+            fill: "#FFFFFF"
+            alpha: 1
+    animations:
+      - id: container-enter-transition
+        targetId: container1
+        type: transition
+        next:
+          tween:
+            alpha:
+              initialValue: 0
+              keyframes:
+                - duration: 500
+                  value: 1
+                  easing: linear
+      - id: child-enter-update
+        targetId: child1
+        type: update
+        tween:
+          x:
+            initialValue: 160
+            keyframes:
+              - duration: 500
+                value: 560
+                easing: linear

--- a/vt/specs/containertransition/container-update-enter-exit.yaml
+++ b/vt/specs/containertransition/container-update-enter-exit.yaml
@@ -1,0 +1,87 @@
+---
+title: Container Update Enter Exit
+description: A container using update animations when it is first added and before it is removed.
+specs:
+  - newly added container should fade in with its children
+  - removed container should fade out with its children before being destroyed
+  - final state should contain no container
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - id: empty
+    elements: []
+  - id: container-entered
+    elements:
+      - id: container1
+        type: container
+        x: 220
+        "y": 160
+        width: 520
+        height: 220
+        direction: horizontal
+        gapX: 24
+        gapY: 0
+        alpha: 1
+        children:
+          - id: child1
+            type: rect
+            width: 150
+            height: 180
+            fill: "#FFFFFF"
+          - id: child2
+            type: rect
+            width: 150
+            height: 180
+            fill: "#A6A6A6"
+          - id: child3
+            type: rect
+            width: 150
+            height: 180
+            fill: "#FFFFFF"
+    animations:
+      - id: container-update-enter
+        targetId: container1
+        type: update
+        tween:
+          alpha:
+            initialValue: 0
+            keyframes:
+              - duration: 1000
+                value: 1
+                easing: linear
+  - id: container-removed
+    elements: []
+    animations:
+      - id: container-update-exit
+        targetId: container1
+        type: update
+        tween:
+          alpha:
+            keyframes:
+              - duration: 1000
+                value: 0
+                easing: linear

--- a/vt/specs/input/input-update-enter-exit.yaml
+++ b/vt/specs/input/input-update-enter-exit.yaml
@@ -1,0 +1,73 @@
+---
+title: Input Update Enter Exit
+description: An input using update animations when it is first added and before it is unmounted.
+specs:
+  - newly added input should fade in through an update animation
+  - removed input should fade out through an update animation before the DOM bridge unmounts it
+  - final state should contain no input
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - id: empty
+    elements: []
+  - id: input-entered
+    elements:
+      - id: input1
+        type: input
+        x: 260
+        "y": 220
+        width: 420
+        height: 64
+        placeholder: Name
+        alpha: 1
+        textStyle:
+          fill: "#111111"
+          fontSize: 24
+          fontFamily: Arial
+    animations:
+      - id: input-update-enter
+        targetId: input1
+        type: update
+        tween:
+          alpha:
+            initialValue: 0
+            keyframes:
+              - duration: 1000
+                value: 1
+                easing: linear
+  - id: input-removed
+    elements: []
+    animations:
+      - id: input-update-exit
+        targetId: input1
+        type: update
+        tween:
+          alpha:
+            keyframes:
+              - duration: 1000
+                value: 0
+                easing: linear

--- a/vt/specs/particles/particles-update-enter-exit.yaml
+++ b/vt/specs/particles/particles-update-enter-exit.yaml
@@ -1,0 +1,159 @@
+---
+title: Particles Update Enter Exit
+description: A particle field using update animations when it is first added and before it is removed.
+specs:
+  - newly added particles should fade in through an update animation
+  - removed particles should fade out through an update animation before being destroyed
+  - final state should contain no particle field
+skipInitialScreenshot: true
+useBrowserScreenshot: true
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: wait
+    ms: 50
+  - action: customEvent
+    name: "primeVtScreenshot"
+  - action: wait
+    ms: 50
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: wait
+    ms: 50
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: wait
+    ms: 50
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: wait
+    ms: 50
+  - action: screenshot
+---
+states:
+  - id: empty
+    elements:
+      - id: stage-bg
+        type: rect
+        x: 0
+        "y": 0
+        width: 1280
+        height: 720
+        fill: "#000000"
+  - id: particles-entered
+    elements:
+      - id: stage-bg
+        type: rect
+        x: 0
+        "y": 0
+        width: 1280
+        height: 720
+        fill: "#000000"
+      - id: sparkles
+        type: particles
+        width: 1280
+        height: 720
+        alpha: 1
+        seed: 12345
+        modules:
+          emission:
+            mode: continuous
+            rate: 20
+            maxActive: 30
+            duration: infinite
+            particleLifetime:
+              min: 0.3
+              max: 0.8
+            source:
+              kind: rect
+              data:
+                x: 100
+                "y": 100
+                width: 1080
+                height: 520
+          appearance:
+            texture:
+              mode: random
+              pick: perParticle
+              items:
+                - src: snowflake
+                  weight: 3
+                - shape: circle
+                  radius: 2
+                  color: "#D9D9D9"
+                  weight: 1
+            scale:
+              mode: curve
+              keys:
+                - value: 0
+                  time: 0
+                - value: 1.5
+                  time: 0.3
+                - value: 1.5
+                  time: 0.7
+                - value: 0
+                  time: 1
+            alpha:
+              mode: curve
+              keys:
+                - value: 0
+                  time: 0
+                - value: 1
+                  time: 0.2
+                - value: 1
+                  time: 0.8
+                - value: 0
+                  time: 1
+            rotation:
+              mode: spin
+              start:
+                min: 0
+                max: 360
+              speed:
+                min: 45
+                max: 90
+    animations:
+      - id: particles-update-enter
+        targetId: sparkles
+        type: update
+        tween:
+          alpha:
+            initialValue: 0
+            keyframes:
+              - duration: 1000
+                value: 1
+                easing: linear
+  - id: particles-removed
+    elements:
+      - id: stage-bg
+        type: rect
+        x: 0
+        "y": 0
+        width: 1280
+        height: 720
+        fill: "#000000"
+    animations:
+      - id: particles-update-exit
+        targetId: sparkles
+        type: update
+        tween:
+          alpha:
+            keyframes:
+              - duration: 1000
+                value: 0
+                easing: linear

--- a/vt/specs/recttransition/rect-update-enter-exit.yaml
+++ b/vt/specs/recttransition/rect-update-enter-exit.yaml
@@ -1,0 +1,69 @@
+---
+title: Rect Update Enter Exit
+description: A rect using update animations when it is first added and before it is removed.
+specs:
+  - newly added rect should fade in through an update animation
+  - removed rect should fade out through an update animation before being destroyed
+  - final state should contain no rect
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - id: empty
+    elements: []
+  - id: rect-entered
+    elements:
+      - id: rect1
+        type: rect
+        x: 320
+        "y": 180
+        width: 360
+        height: 240
+        fill: "#FFFFFF"
+        alpha: 1
+    animations:
+      - id: rect-update-enter
+        targetId: rect1
+        type: update
+        tween:
+          alpha:
+            initialValue: 0
+            keyframes:
+              - duration: 1000
+                value: 1
+                easing: linear
+  - id: rect-removed
+    elements: []
+    animations:
+      - id: rect-update-exit
+        targetId: rect1
+        type: update
+        tween:
+          alpha:
+            keyframes:
+              - duration: 1000
+                value: 0
+                easing: linear

--- a/vt/specs/replacetransition/rect-same-id-transition-handoff.yaml
+++ b/vt/specs/replacetransition/rect-same-id-transition-handoff.yaml
@@ -1,0 +1,74 @@
+---
+title: Rect Same Id Transition Handoff
+description: A same-id rect uses type transition as a replace handoff instead of an in-place update
+specs:
+  - transition animation should run when the target id exists in both states
+  - outgoing and incoming snapshots should both be visible during the handoff
+  - final state should settle on the next live rect
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - id: same-id-transition-start
+    elements:
+      - id: rect1
+        type: rect
+        x: 220
+        "y": 180
+        width: 320
+        height: 240
+        fill: "#FFFFFF"
+        alpha: 1
+  - id: same-id-transition-end
+    elements:
+      - id: rect1
+        type: rect
+        x: 640
+        "y": 180
+        width: 320
+        height: 240
+        fill: "#A6A6A6"
+        alpha: 1
+    animations:
+      - id: rect-same-id-transition
+        targetId: rect1
+        type: transition
+        prev:
+          tween:
+            translateX:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: -0.25
+                  easing: linear
+            alpha:
+              initialValue: 1
+              keyframes:
+                - duration: 1000
+                  value: 0
+                  easing: linear
+        next:
+          tween:
+            translateX:
+              initialValue: 0.25
+              keyframes:
+                - duration: 1000
+                  value: 0
+                  easing: linear
+            alpha:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear

--- a/vt/specs/spritetransition/sprite-update-enter-exit.yaml
+++ b/vt/specs/spritetransition/sprite-update-enter-exit.yaml
@@ -1,0 +1,69 @@
+---
+title: Sprite Update Enter Exit
+description: A sprite using update animations when it is first added and before it is removed; uses a colored sprite texture intentionally to validate asset-backed alpha progression.
+specs:
+  - newly added sprite should fade in through an update animation
+  - removed sprite should fade out through an update animation before being destroyed
+  - final state should contain no sprite
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - id: empty
+    elements: []
+  - id: sprite-entered
+    elements:
+      - id: sprite1
+        type: sprite
+        src: circle-blue
+        x: 360
+        "y": 180
+        width: 220
+        height: 220
+        alpha: 1
+    animations:
+      - id: sprite-update-enter
+        targetId: sprite1
+        type: update
+        tween:
+          alpha:
+            initialValue: 0
+            keyframes:
+              - duration: 1000
+                value: 1
+                easing: linear
+  - id: sprite-removed
+    elements: []
+    animations:
+      - id: sprite-update-exit
+        targetId: sprite1
+        type: update
+        tween:
+          alpha:
+            keyframes:
+              - duration: 1000
+                value: 0
+                easing: linear

--- a/vt/specs/textrevealing/text-revealing-update-enter-exit.yaml
+++ b/vt/specs/textrevealing/text-revealing-update-enter-exit.yaml
@@ -1,0 +1,74 @@
+---
+title: Text Revealing Update Enter Exit
+description: A text-revealing element using update animations when it is first added and before it is removed.
+specs:
+  - newly added text-revealing elements should fade in through an update animation
+  - removed text-revealing elements should fade out through an update animation before being destroyed
+  - final state should contain no text-revealing element
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - id: empty
+    elements: []
+  - id: text-revealing-entered
+    elements:
+      - id: text-revealing1
+        type: text-revealing
+        content:
+          - text: Update lifecycle text
+            textStyle:
+              fontSize: 44
+              fill: "#FFFFFF"
+              fontFamily: Arial
+        x: 260
+        "y": 220
+        width: 720
+        alpha: 1
+        revealEffect: none
+    animations:
+      - id: text-revealing-update-enter
+        targetId: text-revealing1
+        type: update
+        tween:
+          alpha:
+            initialValue: 0
+            keyframes:
+              - duration: 1000
+                value: 1
+                easing: linear
+  - id: text-revealing-removed
+    elements: []
+    animations:
+      - id: text-revealing-update-exit
+        targetId: text-revealing1
+        type: update
+        tween:
+          alpha:
+            keyframes:
+              - duration: 1000
+                value: 0
+                easing: linear


### PR DESCRIPTION
## Summary
- bump package version to 1.16.1
- run update animations for newly added and removed elements
- add unit coverage and VT fixtures for update enter/exit behavior across element types
- add an explicit same-id type: transition VT handoff fixture

## Tests
- bunx vitest run
- targeted VT screenshot/report for update enter/exit fixtures: 44 images, 0 mismatches
- targeted VT screenshot/report for same-id transition handoff: 3 images, 0 mismatches