### PR TITLE
fix: cache audio asset decodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -239,6 +239,10 @@ let currentApp = null;
 const setupRouteGraphics = async ({
   initOptions = {},
   pluginsFactory,
+  audioAsset = {
+    load: vi.fn(),
+    getAsset: vi.fn(),
+  },
 } = {}) => {
   const pixiMock = createPixiModuleMock();
 
@@ -250,10 +254,7 @@ const setupRouteGraphics = async ({
     }),
   }));
   vi.doMock("../src/AudioAsset.js", () => ({
-    AudioAsset: {
-      load: vi.fn(),
-      getAsset: vi.fn(),
-    },
+    AudioAsset: audioAsset,
   }));
 
   const resolvedPlugins = pluginsFactory
@@ -277,7 +278,7 @@ const setupRouteGraphics = async ({
 
   currentApp = app;
 
-  return { app, pixiMock };
+  return { app, pixiMock, audioAsset };
 };
 
 const getAutoAnimationTick = (pixiMock) =>
@@ -359,6 +360,43 @@ describe("RouteGraphics public API", () => {
         source: expect.any(Object),
       }),
     );
+  });
+
+  it("awaits audio asset decoding during loadAssets", async () => {
+    let resolveAudioLoad;
+    const audioLoadPromise = new Promise((resolve) => {
+      resolveAudioLoad = resolve;
+    });
+    const audioAsset = {
+      load: vi.fn(() => audioLoadPromise),
+      getAsset: vi.fn(),
+    };
+    const { app } = await setupRouteGraphics({ audioAsset });
+    let loadAssetsResolved = false;
+
+    const loadAssetsPromise = app
+      .loadAssets({
+        click: {
+          buffer: new Uint8Array([1, 2, 3]).buffer,
+          type: "audio/mpeg",
+        },
+      })
+      .then(() => {
+        loadAssetsResolved = true;
+      });
+
+    await Promise.resolve();
+
+    expect(audioAsset.load).toHaveBeenCalledWith(
+      "click",
+      expect.any(ArrayBuffer),
+    );
+    expect(loadAssetsResolved).toBe(false);
+
+    resolveAudioLoad();
+    await loadAssetsPromise;
+
+    expect(loadAssetsResolved).toBe(true);
   });
 
   it("updates the visible stage background graphic color", async () => {

--- a/spec/audio/audioAsset.spec.js
+++ b/spec/audio/audioAsset.spec.js
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const originalAudioContext = window.AudioContext;
+const originalWebkitAudioContext = window.webkitAudioContext;
+
+const setupAudioAsset = async () => {
+  vi.resetModules();
+
+  const decodedBuffer = { decoded: true };
+  const context = {
+    decodeAudioData: vi.fn(() => Promise.resolve(decodedBuffer)),
+  };
+  const AudioContextMock = vi.fn(function AudioContextMock() {
+    return context;
+  });
+  window.AudioContext = AudioContextMock;
+  window.webkitAudioContext = undefined;
+
+  const { AudioAsset } = await import("../../src/AudioAsset.js");
+
+  return {
+    AudioAsset,
+    context,
+    decodedBuffer,
+  };
+};
+
+describe("AudioAsset", () => {
+  afterEach(() => {
+    window.AudioContext = originalAudioContext;
+    window.webkitAudioContext = originalWebkitAudioContext;
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("decodes and stores audio buffers during load", async () => {
+    const { AudioAsset, context, decodedBuffer } = await setupAudioAsset();
+    const arrayBuffer = new Uint8Array([1, 2, 3]).buffer;
+
+    await expect(AudioAsset.load("click", arrayBuffer)).resolves.toBe(
+      decodedBuffer,
+    );
+
+    expect(context.decodeAudioData).toHaveBeenCalledWith(arrayBuffer);
+    expect(AudioAsset.getAsset("click")).toBe(decodedBuffer);
+  });
+
+  it("reuses an in-flight decode for duplicate load requests", async () => {
+    vi.resetModules();
+
+    let resolveDecode;
+    const decodedBuffer = { decoded: true };
+    const decodePromise = new Promise((resolve) => {
+      resolveDecode = () => resolve(decodedBuffer);
+    });
+    const context = {
+      decodeAudioData: vi.fn(() => decodePromise),
+    };
+    window.AudioContext = vi.fn(function AudioContextMock() {
+      return context;
+    });
+    window.webkitAudioContext = undefined;
+
+    const { AudioAsset } = await import("../../src/AudioAsset.js");
+    const arrayBuffer = new Uint8Array([1, 2, 3]).buffer;
+    const firstLoad = AudioAsset.load("click", arrayBuffer);
+    const secondLoad = AudioAsset.load("click", arrayBuffer);
+
+    expect(firstLoad).toBe(secondLoad);
+    expect(context.decodeAudioData).toHaveBeenCalledTimes(1);
+
+    resolveDecode();
+    await expect(firstLoad).resolves.toBe(decodedBuffer);
+    expect(AudioAsset.getAsset("click")).toBe(decodedBuffer);
+  });
+});

--- a/src/AudioAsset.js
+++ b/src/AudioAsset.js
@@ -1,20 +1,33 @@
 const audioContext = new (window.AudioContext || window.webkitAudioContext)();
 
 const loadedAssets = {};
+const loadingAssets = {};
 
-const load = async (key, arrayBuffer) => {
+const load = (key, arrayBuffer) => {
   if (loadedAssets[key]) {
-    return;
+    return loadedAssets[key];
+  }
+  if (loadingAssets[key]) {
+    return loadingAssets[key];
   }
   if (arrayBuffer.byteLength === 0) {
     return;
   }
-  try {
-    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
-    loadedAssets[key] = audioBuffer;
-  } catch (error) {
-    console.error(`AudioAsset.load: Failed to decode ${key}:`, error);
-  }
+
+  loadingAssets[key] = audioContext
+    .decodeAudioData(arrayBuffer)
+    .then((audioBuffer) => {
+      loadedAssets[key] = audioBuffer;
+      return audioBuffer;
+    })
+    .catch((error) => {
+      console.error(`AudioAsset.load: Failed to decode ${key}:`, error);
+    })
+    .finally(() => {
+      delete loadingAssets[key];
+    });
+
+  return loadingAssets[key];
 };
 
 const getAsset = (url) => {


### PR DESCRIPTION
## Summary
- cache in-flight AudioAsset decode promises so duplicate load requests for the same key share one decode
- return decoded audio buffers from AudioAsset.load/getAsset once ready
- add coverage that route-graphics loadAssets waits for audio decode completion
- bump package version to 1.17.1

## Testing
- bunx vitest run spec/audio/audioAsset.spec.js spec/RouteGraphics.publicApi.spec.js
- bunx prettier --check src/AudioAsset.js spec/audio/audioAsset.spec.js spec/RouteGraphics.publicApi.spec.js package.json
- bunx oxlint src/AudioAsset.js spec/audio/audioAsset.spec.js spec/RouteGraphics.publicApi.spec.js
- bun run build
- bun run test
- pre-push hook: bunx prettier --check src
- pre-push hook: vitest run