### PR TITLE
fix audio node volume normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/util/normalizeAudio.spec.js
+++ b/spec/util/normalizeAudio.spec.js
@@ -68,6 +68,46 @@ describe("normalizeAudioRenderState", () => {
     ]);
   });
 
+  it("clamps audio node volumes and defaults omitted volumes to 100", () => {
+    const result = flattenAudioNodes([
+      {
+        id: "music",
+        type: "audio-channel",
+        volume: 500,
+        children: [
+          {
+            id: "bgm",
+            type: "sound",
+            src: "theme",
+            volume: -10,
+          },
+        ],
+      },
+      {
+        id: "click",
+        type: "sound",
+        src: "click-sfx",
+      },
+    ]);
+
+    expect(result.channels[0].volume).toBe(100);
+    expect(result.sounds[0].volume).toBe(0);
+    expect(result.sounds[1].volume).toBe(100);
+  });
+
+  it("still rejects non-number audio node volumes", () => {
+    expect(() =>
+      flattenAudioNodes([
+        {
+          id: "sfx",
+          type: "sound",
+          src: "click-sfx",
+          volume: "100",
+        },
+      ]),
+    ).toThrow("audio[0].volume must be a number");
+  });
+
   it("rejects duplicate IDs across nodes and effects", () => {
     expect(() =>
       normalizeAudioRenderState({

--- a/src/util/normalizeAudio.js
+++ b/src/util/normalizeAudio.js
@@ -54,6 +54,15 @@ const assertOptionalNumber = (value, path, range) => {
   }
 };
 
+const normalizeVolumeValue = (value, path) => {
+  if (value === undefined || value === null) {
+    return 100;
+  }
+
+  assertNumber(value, path);
+  return Math.max(0, Math.min(100, value));
+};
+
 const assertUniqueId = (ids, id, path) => {
   if (ids.has(id)) {
     throw new Error(
@@ -74,7 +83,7 @@ const validateSound = (node, path, ids, flattenedSounds, channelId = null) => {
     );
   }
 
-  assertOptionalNumber(node.volume, `${path}.volume`, { min: 0, max: 100 });
+  const volume = normalizeVolumeValue(node.volume, `${path}.volume`);
   assertOptionalBoolean(node.muted, `${path}.muted`);
   assertOptionalNumber(node.pan, `${path}.pan`, { min: -1, max: 1 });
   assertOptionalBoolean(node.loop, `${path}.loop`);
@@ -98,7 +107,7 @@ const validateSound = (node, path, ids, flattenedSounds, channelId = null) => {
     id: node.id,
     type: "sound",
     src: node.src,
-    volume: node.volume ?? 100,
+    volume,
     muted: node.muted ?? false,
     pan: node.pan ?? 0,
     loop: node.loop ?? false,
@@ -120,7 +129,7 @@ const validateChannel = (
   assertNonEmptyString(node.id, `${path}.id`);
   assertUniqueId(ids, node.id, `${path}.id`);
 
-  assertOptionalNumber(node.volume, `${path}.volume`, { min: 0, max: 100 });
+  const volume = normalizeVolumeValue(node.volume, `${path}.volume`);
   assertOptionalBoolean(node.muted, `${path}.muted`);
   assertOptionalNumber(node.pan, `${path}.pan`, { min: -1, max: 1 });
 
@@ -131,7 +140,7 @@ const validateChannel = (
   flattenedChannels.push({
     id: node.id,
     type: "audio-channel",
-    volume: node.volume ?? 100,
+    volume,
     muted: node.muted ?? false,
     pan: node.pan ?? 0,
   });


### PR DESCRIPTION
## Summary
- clamp built-in audio channel/sound volume values to the renderer's 0-100 range
- keep omitted/null audio volumes defaulting to 100
- keep non-number audio volumes invalid
- bump package version to `1.17.2`

## Testing
- `bun run test spec/util/normalizeAudio.spec.js`
- pre-push hook: `bunx prettier --check src`
- pre-push hook: `vitest run`