### PR TITLE
fix video texture CORS mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.17.3",
+  "version": "1.17.4",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -310,6 +310,7 @@ describe("RouteGraphics public API", () => {
 
   it("loads video assets through an early-ready HTML video texture", async () => {
     const { app, pixiMock } = await setupRouteGraphics();
+    const createdVideos = [];
     const createObjectURL = vi
       .spyOn(URL, "createObjectURL")
       .mockReturnValue("blob:http://route-graphics/video");
@@ -320,6 +321,7 @@ describe("RouteGraphics public API", () => {
         const element = originalCreateElement(tagName, ...args);
 
         if (tagName === "video") {
+          createdVideos.push(element);
           Object.defineProperty(element, "readyState", {
             value: window.HTMLMediaElement.HAVE_CURRENT_DATA,
             configurable: true,
@@ -343,6 +345,11 @@ describe("RouteGraphics public API", () => {
           buffer: new Uint8Array([1, 2, 3]).buffer,
           type: "video/mp4",
         },
+        urlVideo: {
+          source: "url",
+          url: "http://project-file.localhost/pixi-asset.mp4?path=video",
+          type: "video/mp4",
+        },
       });
     } finally {
       createElement.mockRestore();
@@ -360,6 +367,16 @@ describe("RouteGraphics public API", () => {
         source: expect.any(Object),
       }),
     );
+    expect(pixiMock.Assets.cache.set).toHaveBeenCalledWith(
+      "urlVideo",
+      expect.objectContaining({
+        source: expect.any(Object),
+      }),
+    );
+    expect(createdVideos).toHaveLength(2);
+    expect(
+      createdVideos.every((video) => video.crossOrigin === "anonymous"),
+    ).toBe(true);
   });
 
   it("awaits audio asset decoding during loadAssets", async () => {

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -252,6 +252,7 @@ const createRouteGraphics = () => {
     }
 
     const video = document.createElement("video");
+    video.crossOrigin = "anonymous";
     video.preload = "auto";
     video.playsInline = true;
     video.setAttribute("playsinline", "");


### PR DESCRIPTION
## Summary
- set video elements to anonymous CORS mode before assigning their source URL
- cover URL-backed video assets in the public API asset loading test
- bump package version to `1.17.4`

## Why
Project videos can be served from `project-file.localhost` or a localhost media server while the app runs on a different origin. Without `video.crossOrigin = "anonymous"`, the browser treats the decoded video as cross-origin data and WebGL rejects `texImage2D` uploads.

## Testing
- `bun run test spec/RouteGraphics.publicApi.spec.js`
- pre-push hook: `bunx prettier --check src`
- pre-push hook: `vitest run`