### PR TITLE
Add Ogg audio decoder fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@ _site
 node_modules
 coverage
 playground/static/RouteGraphics.js
+playground/static/chunks
 vt/static/RouteGraphics.js
 vt/static/RouteGraphics.js.map
+vt/static/chunks
 vt_old/static/RouteGraphics.js
 vt_old/static/RouteGraphics.js.map
 .claude

--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,8 @@ _site
 node_modules
 coverage
 playground/static/RouteGraphics.js
-playground/static/chunks
 vt/static/RouteGraphics.js
 vt/static/RouteGraphics.js.map
-vt/static/chunks
 vt_old/static/RouteGraphics.js
 vt_old/static/RouteGraphics.js.map
 .claude

--- a/bin/route-graphics-render.js
+++ b/bin/route-graphics-render.js
@@ -145,33 +145,6 @@ const getServedAssetPath = (assetId, assetPath) => {
   return `${toBrowserPath(assetId)}${extension}`;
 };
 
-const getDistFilePath = (pathname) => {
-  if (!pathname.startsWith("/dist/")) return null;
-
-  let relativePath;
-  try {
-    relativePath = decodeURIComponent(pathname.slice("/dist/".length));
-  } catch {
-    return null;
-  }
-  const normalizedPath = path.normalize(relativePath);
-  if (
-    normalizedPath.startsWith("..") ||
-    path.isAbsolute(normalizedPath) ||
-    normalizedPath.length === 0
-  ) {
-    return null;
-  }
-
-  return path.join(path.dirname(bundlePath), normalizedPath);
-};
-
-const getJavaScriptContentType = (filePath) => {
-  return filePath.endsWith(".map")
-    ? "application/json; charset=utf-8"
-    : "text/javascript; charset=utf-8";
-};
-
 const createRequestHandler = ({ assetRoutes }) => {
   return async (request, response) => {
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
@@ -182,25 +155,11 @@ const createRequestHandler = ({ assetRoutes }) => {
       return;
     }
 
-    const distFilePath = getDistFilePath(url.pathname);
-    if (distFilePath) {
-      try {
-        const stat = await fsPromises.stat(distFilePath);
-        if (!stat.isFile()) {
-          response.writeHead(404);
-          response.end("Not Found");
-          return;
-        }
-
-        response.writeHead(200, {
-          "content-length": stat.size,
-          "content-type": getJavaScriptContentType(distFilePath),
-        });
-        fs.createReadStream(distFilePath).pipe(response);
-      } catch {
-        response.writeHead(404);
-        response.end("Not Found");
-      }
+    if (url.pathname === "/dist/RouteGraphics.js") {
+      response.writeHead(200, {
+        "content-type": "text/javascript; charset=utf-8",
+      });
+      fs.createReadStream(bundlePath).pipe(response);
       return;
     }
 

--- a/bin/route-graphics-render.js
+++ b/bin/route-graphics-render.js
@@ -145,6 +145,28 @@ const getServedAssetPath = (assetId, assetPath) => {
   return `${toBrowserPath(assetId)}${extension}`;
 };
 
+const getDistFilePath = (pathname) => {
+  if (!pathname.startsWith("/dist/")) return null;
+
+  const relativePath = decodeURIComponent(pathname.slice("/dist/".length));
+  const normalizedPath = path.normalize(relativePath);
+  if (
+    normalizedPath.startsWith("..") ||
+    path.isAbsolute(normalizedPath) ||
+    normalizedPath.length === 0
+  ) {
+    return null;
+  }
+
+  return path.join(path.dirname(bundlePath), normalizedPath);
+};
+
+const getJavaScriptContentType = (filePath) => {
+  return filePath.endsWith(".map")
+    ? "application/json; charset=utf-8"
+    : "text/javascript; charset=utf-8";
+};
+
 const createRequestHandler = ({ assetRoutes }) => {
   return async (request, response) => {
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
@@ -155,11 +177,25 @@ const createRequestHandler = ({ assetRoutes }) => {
       return;
     }
 
-    if (url.pathname === "/dist/RouteGraphics.js") {
-      response.writeHead(200, {
-        "content-type": "text/javascript; charset=utf-8",
-      });
-      fs.createReadStream(bundlePath).pipe(response);
+    const distFilePath = getDistFilePath(url.pathname);
+    if (distFilePath) {
+      try {
+        const stat = await fsPromises.stat(distFilePath);
+        if (!stat.isFile()) {
+          response.writeHead(404);
+          response.end("Not Found");
+          return;
+        }
+
+        response.writeHead(200, {
+          "content-length": stat.size,
+          "content-type": getJavaScriptContentType(distFilePath),
+        });
+        fs.createReadStream(distFilePath).pipe(response);
+      } catch {
+        response.writeHead(404);
+        response.end("Not Found");
+      }
       return;
     }
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,12 @@
     "": {
       "dependencies": {
         "@pixi/unsafe-eval": "^7.4.3",
+        "@wasm-audio-decoders/ogg-vorbis": "^0.1.20",
         "hotkeys-js": "^4.0.0-beta.7",
         "js-yaml": "^4.1.0",
-        "playwright": "^1.44.0",
+        "ogg-opus-decoder": "^1.7.3",
         "pixi.js": "^8.7.1",
+        "playwright": "^1.44.0",
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.0.8",
@@ -106,6 +108,8 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.6", "", { "os": "win32", "cpu": "x64" }, "sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA=="],
+
+    "@eshaz/web-worker": ["@eshaz/web-worker@1.2.2", "", {}, "sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw=="],
 
     "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
 
@@ -223,6 +227,12 @@
 
     "@vitest/utils": ["@vitest/utils@4.0.8", "", { "dependencies": { "@vitest/pretty-format": "4.0.8", "tinyrainbow": "^3.0.3" } }, "sha512-pdk2phO5NDvEFfUTxcTP8RFYjVj/kfLSPIN5ebP2Mu9kcIMeAQTbknqcFEyBcC4z2pJlJI9aS5UQjcYfhmKAow=="],
 
+    "@wasm-audio-decoders/common": ["@wasm-audio-decoders/common@9.0.7", "", { "dependencies": { "@eshaz/web-worker": "1.2.2", "simple-yenc": "^1.0.4" } }, "sha512-WRaUuWSKV7pkttBygml/a6dIEpatq2nnZGFIoPTc5yPLkxL6Wk4YaslPM98OPQvWacvNZ+Py9xROGDtrFBDzag=="],
+
+    "@wasm-audio-decoders/ogg-vorbis": ["@wasm-audio-decoders/ogg-vorbis@0.1.20", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7", "codec-parser": "2.5.0" } }, "sha512-zaQPasU5usRjUDXtXOHYED5tfkR4QMXd+EH3Nrz1+4+M5pCsdD+s9YxJqb0oqnTyRu/KUujOmu5Z/m/NT47vwg=="],
+
+    "@wasm-audio-decoders/opus-ml": ["@wasm-audio-decoders/opus-ml@0.0.2", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-58rWEqDGg+CKCyEeKm2KoxxSwTWtHh/NLTW9ObR4K8CGF6VwuuGudEI1CtniS/oSRmL1nJq/eh8MKARiluw4DQ=="],
+
     "@webgpu/types": ["@webgpu/types@0.1.60", "", {}, "sha512-8B/tdfRFKdrnejqmvq95ogp8tf52oZ51p3f4QD5m5Paey/qlX4Rhhy5Y8tgFMi7Ms70HzcMMw3EQjH/jdhTwlA=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.10", "", {}, "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="],
@@ -264,6 +274,8 @@
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
     "cli-truncate": ["cli-truncate@5.1.1", "", { "dependencies": { "slice-ansi": "^7.1.0", "string-width": "^8.0.0" } }, "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A=="],
+
+    "codec-parser": ["codec-parser@2.5.0", "", {}, "sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ=="],
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
@@ -429,9 +441,13 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
+    "ogg-opus-decoder": ["ogg-opus-decoder@1.7.3", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7", "@wasm-audio-decoders/opus-ml": "0.0.2", "codec-parser": "2.5.0", "opus-decoder": "0.7.11" } }, "sha512-w47tiZpkLgdkpa+34VzYD8mHUj8I9kfWVZa82mBbNwDvB1byfLXSSzW/HxA4fI3e9kVlICSpXGFwMLV1LPdjwg=="],
+
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "opus-decoder": ["opus-decoder@0.7.11", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A=="],
 
     "oxlint": ["oxlint@1.26.0", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "1.26.0", "@oxlint/darwin-x64": "1.26.0", "@oxlint/linux-arm64-gnu": "1.26.0", "@oxlint/linux-arm64-musl": "1.26.0", "@oxlint/linux-x64-gnu": "1.26.0", "@oxlint/linux-x64-musl": "1.26.0", "@oxlint/win32-arm64": "1.26.0", "@oxlint/win32-x64": "1.26.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.4.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint", "oxc_language_server": "bin/oxc_language_server" } }, "sha512-KRpL+SMi07JQyggv5ldIF+wt2pnrKm8NLW0B+8bK+0HZsLmH9/qGA+qMWie5Vf7lnlMBllJmsuzHaKFEGY3rIA=="],
 
@@ -504,6 +520,8 @@
     "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
 
     "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
+    "simple-yenc": ["simple-yenc@1.0.4", "", {}, "sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw=="],
 
     "slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 

--- a/esbuild.js
+++ b/esbuild.js
@@ -2,6 +2,26 @@ import esbuild from "esbuild";
 import { cp, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 
+// Route Graphics always uses the default Opus decoder without speech-quality
+// enhancement. Replace its unreachable optional import so the 4 MiB ML model
+// is not embedded in the single-file bundle.
+const excludeUnusedOpusMlPlugin = {
+  name: "exclude-unused-opus-ml",
+  setup(build) {
+    build.onResolve({ filter: /^@wasm-audio-decoders\/opus-ml$/ }, () => ({
+      namespace: "unused-opus-ml",
+      path: "unused-opus-ml",
+    }));
+    build.onLoad({ filter: /.*/, namespace: "unused-opus-ml" }, () => ({
+      contents: [
+        "export const OpusMLDecoder = undefined;",
+        "export const OpusMLDecoderWebWorker = undefined;",
+      ].join("\n"),
+      loader: "js",
+    }));
+  },
+};
+
 try {
   const buildBundle = async ({ outdir, minify, sourcemap }) => {
     await Promise.all([
@@ -15,11 +35,9 @@ try {
       bundle: true,
       minify,
       sourcemap,
-      outdir,
-      entryNames: "RouteGraphics",
-      chunkNames: "chunks/[name]-[hash]",
+      outfile: path.join(outdir, "RouteGraphics.js"),
       format: "esm",
-      splitting: true,
+      plugins: [excludeUnusedOpusMlPlugin],
     });
   };
 
@@ -41,17 +59,20 @@ try {
     }),
   ]);
 
+  await rm("./.rettangoli/vt/_site/chunks", {
+    force: true,
+    recursive: true,
+  });
   await mkdir("./.rettangoli/vt/_site", { recursive: true });
   await Promise.all([
-    cp("./vt/static/RouteGraphics.js", "./.rettangoli/vt/_site/RouteGraphics.js"),
+    cp(
+      "./vt/static/RouteGraphics.js",
+      "./.rettangoli/vt/_site/RouteGraphics.js",
+    ),
     cp(
       "./vt/static/RouteGraphics.js.map",
       "./.rettangoli/vt/_site/RouteGraphics.js.map",
     ),
-    cp("./vt/static/chunks", "./.rettangoli/vt/_site/chunks", {
-      force: true,
-      recursive: true,
-    }),
   ]);
 } catch (error) {
   console.error(error);

--- a/esbuild.js
+++ b/esbuild.js
@@ -1,30 +1,56 @@
 import esbuild from "esbuild";
+import { cp, mkdir, rm } from "node:fs/promises";
+import path from "node:path";
 
 try {
+  const buildBundle = async ({ outdir, minify, sourcemap }) => {
+    await Promise.all([
+      rm(path.join(outdir, "RouteGraphics.js"), { force: true }),
+      rm(path.join(outdir, "RouteGraphics.js.map"), { force: true }),
+      rm(path.join(outdir, "chunks"), { force: true, recursive: true }),
+    ]);
+
+    await esbuild.build({
+      entryPoints: ["./src/index.js"],
+      bundle: true,
+      minify,
+      sourcemap,
+      outdir,
+      entryNames: "RouteGraphics",
+      chunkNames: "chunks/[name]-[hash]",
+      format: "esm",
+      splitting: true,
+    });
+  };
+
   await Promise.all([
-    esbuild.build({
-      entryPoints: ["./src/index.js"],
-      bundle: true,
+    buildBundle({
+      outdir: "./dist",
       minify: true,
       sourcemap: false,
-      outfile: "./dist/RouteGraphics.js",
-      format: "esm",
     }),
-    esbuild.build({
-      entryPoints: ["./src/index.js"],
-      bundle: true,
+    buildBundle({
+      outdir: "./playground/static",
       minify: true,
       sourcemap: false,
-      outfile: "./playground/static/RouteGraphics.js",
-      format: "esm",
     }),
-    esbuild.build({
-      entryPoints: ["./src/index.js"],
-      bundle: true,
+    buildBundle({
+      outdir: "./vt/static",
       minify: false,
       sourcemap: true,
-      outfile: "./vt/static/RouteGraphics.js",
-      format: "esm",
+    }),
+  ]);
+
+  await mkdir("./.rettangoli/vt/_site", { recursive: true });
+  await Promise.all([
+    cp("./vt/static/RouteGraphics.js", "./.rettangoli/vt/_site/RouteGraphics.js"),
+    cp(
+      "./vt/static/RouteGraphics.js.map",
+      "./.rettangoli/vt/_site/RouteGraphics.js.map",
+    ),
+    cp("./vt/static/chunks", "./.rettangoli/vt/_site/chunks", {
+      force: true,
+      recursive: true,
     }),
   ]);
 } catch (error) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint": "bunx prettier --check src",
     "lint:fix": "bunx prettier --write src",
     "prepare": "husky",
-    "build": "bunx esbuild ./src/index.js --bundle --minify --format=esm --outfile=./dist/RouteGraphics.js && bunx esbuild ./src/index.js --bundle --minify --format=esm --outfile=./playground/static/RouteGraphics.js && bunx esbuild ./src/index.js --bundle --sourcemap --format=esm --outfile=./vt/static/RouteGraphics.js && mkdir -p ./.rettangoli/vt/_site && cp ./vt/static/RouteGraphics.js ./.rettangoli/vt/_site/RouteGraphics.js && cp ./vt/static/RouteGraphics.js.map ./.rettangoli/vt/_site/RouteGraphics.js.map",
+    "build": "node ./esbuild.js",
     "render:png": "bun run build && node ./bin/route-graphics-render.js",
     "vt:docker:pull": "docker pull docker.io/han4wluc/rtgl:playwright-v1.57.0-rtgl-v1.1.0",
     "vt:generate": "bun run build && docker run --rm --user $(id -u):$(id -g) -e RTGL_VT_DEBUG=true -v \"$PWD:/workspace\" docker.io/han4wluc/rtgl:playwright-v1.57.0-rtgl-v1.1.0 rtgl vt generate --wait-event vt:ready",
@@ -49,10 +49,12 @@
   },
   "dependencies": {
     "@pixi/unsafe-eval": "^7.4.3",
+    "@wasm-audio-decoders/ogg-vorbis": "^0.1.20",
     "hotkeys-js": "^4.0.0-beta.7",
     "js-yaml": "^4.1.0",
-    "playwright": "^1.44.0",
-    "pixi.js": "^8.7.1"
+    "ogg-opus-decoder": "^1.7.3",
+    "pixi.js": "^8.7.1",
+    "playwright": "^1.44.0"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.8",

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -407,6 +407,7 @@ describe("RouteGraphics public API", () => {
     expect(audioAsset.load).toHaveBeenCalledWith(
       "click",
       expect.any(ArrayBuffer),
+      "audio/mpeg",
     );
     expect(loadAssetsResolved).toBe(false);
 

--- a/spec/audio/audioAsset.spec.js
+++ b/spec/audio/audioAsset.spec.js
@@ -3,18 +3,60 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const originalAudioContext = window.AudioContext;
 const originalWebkitAudioContext = window.webkitAudioContext;
 
-const setupAudioAsset = async () => {
-  vi.resetModules();
+const createOggVorbisBuffer = () => {
+  return new Uint8Array([
+    0x4f, 0x67, 0x67, 0x53, 0x00, 0x01, 0x76, 0x6f, 0x72, 0x62, 0x69, 0x73,
+  ]).buffer;
+};
 
+const createAudioContextMock = ({ decodeAudioData } = {}) => {
+  const writtenChannels = [];
+  const audioBuffer = {
+    getChannelData: vi.fn((channelIndex) => {
+      const channel = new Float32Array(2);
+      writtenChannels[channelIndex] = channel;
+      return channel;
+    }),
+  };
   const decodedBuffer = { decoded: true };
   const context = {
-    decodeAudioData: vi.fn(() => Promise.resolve(decodedBuffer)),
+    createBuffer: vi.fn(() => audioBuffer),
+    decodeAudioData:
+      decodeAudioData ?? vi.fn(() => Promise.resolve(decodedBuffer)),
+    writtenChannels,
   };
+
   const AudioContextMock = vi.fn(function AudioContextMock() {
     return context;
   });
   window.AudioContext = AudioContextMock;
   window.webkitAudioContext = undefined;
+
+  return {
+    AudioContextMock,
+    audioBuffer,
+    context,
+    decodedBuffer,
+  };
+};
+
+const mockAudioProbe = (supportValue) => {
+  const originalCreateElement = document.createElement.bind(document);
+  return vi
+    .spyOn(document, "createElement")
+    .mockImplementation((tagName, ...args) => {
+      const element = originalCreateElement(tagName, ...args);
+      if (tagName === "audio") {
+        element.canPlayType = vi.fn(() => supportValue);
+      }
+      return element;
+    });
+};
+
+const setupAudioAsset = async () => {
+  vi.resetModules();
+
+  const { context, decodedBuffer } = createAudioContextMock();
 
   const { AudioAsset } = await import("../../src/AudioAsset.js");
 
@@ -41,7 +83,10 @@ describe("AudioAsset", () => {
       decodedBuffer,
     );
 
-    expect(context.decodeAudioData).toHaveBeenCalledWith(arrayBuffer);
+    expect(context.decodeAudioData).toHaveBeenCalledTimes(1);
+    expect(new Uint8Array(context.decodeAudioData.mock.calls[0][0])).toEqual(
+      new Uint8Array([1, 2, 3]),
+    );
     expect(AudioAsset.getAsset("click")).toBe(decodedBuffer);
   });
 
@@ -53,13 +98,9 @@ describe("AudioAsset", () => {
     const decodePromise = new Promise((resolve) => {
       resolveDecode = () => resolve(decodedBuffer);
     });
-    const context = {
+    const { context } = createAudioContextMock({
       decodeAudioData: vi.fn(() => decodePromise),
-    };
-    window.AudioContext = vi.fn(function AudioContextMock() {
-      return context;
     });
-    window.webkitAudioContext = undefined;
 
     const { AudioAsset } = await import("../../src/AudioAsset.js");
     const arrayBuffer = new Uint8Array([1, 2, 3]).buffer;
@@ -72,5 +113,74 @@ describe("AudioAsset", () => {
     resolveDecode();
     await expect(firstLoad).resolves.toBe(decodedBuffer);
     expect(AudioAsset.getAsset("click")).toBe(decodedBuffer);
+  });
+
+  it("prepares the Vorbis fallback once and stores decoded PCM as an AudioBuffer", async () => {
+    const decodeFile = vi.fn(async () => ({
+      channelData: [new Float32Array([0.25, -0.5])],
+      errors: [],
+      sampleRate: 44100,
+      samplesDecoded: 2,
+    }));
+    const reset = vi.fn(async () => {});
+    const OggVorbisDecoder = vi.fn(function OggVorbisDecoder() {
+      this.ready = Promise.resolve();
+      this.decodeFile = decodeFile;
+      this.reset = reset;
+    });
+
+    vi.doMock("@wasm-audio-decoders/ogg-vorbis", () => ({
+      OggVorbisDecoder,
+    }));
+
+    mockAudioProbe("");
+    const { audioBuffer, context } = createAudioContextMock({
+      decodeAudioData: vi.fn(() =>
+        Promise.reject(new Error("native decode failed")),
+      ),
+    });
+
+    const { AudioAsset } = await import("../../src/AudioAsset.js");
+    const buffer = createOggVorbisBuffer();
+    const assetMap = {
+      sfx: {
+        buffer,
+        type: "audio/ogg",
+      },
+    };
+
+    await AudioAsset.prepareDecoders(assetMap);
+    await AudioAsset.prepareDecoders(assetMap);
+    await expect(AudioAsset.load("sfx", buffer, "audio/ogg")).resolves.toBe(
+      audioBuffer,
+    );
+
+    expect(OggVorbisDecoder).toHaveBeenCalledTimes(1);
+    expect(decodeFile).toHaveBeenCalledTimes(1);
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(context.createBuffer).toHaveBeenCalledWith(1, 2, 44100);
+    expect(context.writtenChannels[0]).toEqual(new Float32Array([0.25, -0.5]));
+    expect(AudioAsset.getAsset("sfx")).toBe(audioBuffer);
+  });
+
+  it("does not import a fallback decoder when native Ogg support is reported", async () => {
+    const OggVorbisDecoder = vi.fn();
+    vi.doMock("@wasm-audio-decoders/ogg-vorbis", () => ({
+      OggVorbisDecoder,
+    }));
+
+    mockAudioProbe("probably");
+    createAudioContextMock();
+
+    const { AudioAsset } = await import("../../src/AudioAsset.js");
+
+    await AudioAsset.prepareDecoders({
+      sfx: {
+        buffer: createOggVorbisBuffer(),
+        type: "audio/ogg",
+      },
+    });
+
+    expect(OggVorbisDecoder).not.toHaveBeenCalled();
   });
 });

--- a/spec/audio/audioAsset.spec.js
+++ b/spec/audio/audioAsset.spec.js
@@ -189,7 +189,7 @@ describe("AudioAsset", () => {
     expect(AudioAsset.getAsset("sfx")).toBe(audioBuffer);
   });
 
-  it("does not import a fallback decoder when native Ogg support is reported", async () => {
+  it("does not instantiate a fallback decoder when native Ogg support is reported", async () => {
     const OggVorbisDecoder = vi.fn();
     vi.doMock("@wasm-audio-decoders/ogg-vorbis", () => ({
       OggVorbisDecoder,

--- a/src/AudioAsset.js
+++ b/src/AudioAsset.js
@@ -1,27 +1,75 @@
-const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+import {
+  decodeOggToAudioBuffer,
+  isOggAudioType,
+  prepareOggDecoders,
+} from "./audio/oggDecoderFallback.js";
+
+let audioContext;
 
 const loadedAssets = {};
 const loadingAssets = {};
 
-const load = (key, arrayBuffer) => {
+const getAudioContext = () => {
+  if (audioContext) return audioContext;
+
+  const AudioContextCtor =
+    globalThis.window?.AudioContext ?? globalThis.window?.webkitAudioContext;
+
+  if (!AudioContextCtor) {
+    throw new Error("AudioContext is not available in this environment.");
+  }
+
+  audioContext = new AudioContextCtor();
+  return audioContext;
+};
+
+const prepareDecoders = async (assetMap) => {
+  await prepareOggDecoders(assetMap);
+};
+
+const decodeAudio = async ({ key, arrayBuffer, type, audioContext }) => {
+  try {
+    return await audioContext.decodeAudioData(arrayBuffer.slice(0));
+  } catch (error) {
+    if (!isOggAudioType(type)) {
+      console.error(`AudioAsset.load: Failed to decode ${key}:`, error);
+      return;
+    }
+
+    try {
+      return await decodeOggToAudioBuffer({
+        arrayBuffer,
+        audioContext,
+      });
+    } catch (fallbackError) {
+      console.error(`AudioAsset.load: Failed to decode ${key}:`, fallbackError);
+    }
+  }
+};
+
+const load = (key, arrayBuffer, type) => {
   if (loadedAssets[key]) {
     return loadedAssets[key];
   }
   if (loadingAssets[key]) {
     return loadingAssets[key];
   }
-  if (arrayBuffer.byteLength === 0) {
+  if (!arrayBuffer || arrayBuffer.byteLength === 0) {
     return;
   }
 
-  loadingAssets[key] = audioContext
-    .decodeAudioData(arrayBuffer)
+  const context = getAudioContext();
+  loadingAssets[key] = decodeAudio({
+    key,
+    arrayBuffer,
+    type,
+    audioContext: context,
+  })
     .then((audioBuffer) => {
-      loadedAssets[key] = audioBuffer;
+      if (audioBuffer) {
+        loadedAssets[key] = audioBuffer;
+      }
       return audioBuffer;
-    })
-    .catch((error) => {
-      console.error(`AudioAsset.load: Failed to decode ${key}:`, error);
     })
     .finally(() => {
       delete loadingAssets[key];
@@ -36,6 +84,7 @@ const getAsset = (url) => {
 };
 
 export const AudioAsset = {
+  prepareDecoders,
   load,
   getAsset,
 };

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -181,6 +181,24 @@ const createRouteGraphics = () => {
     return "texture";
   };
 
+  const inferAudioTypeFromUrl = (url) => {
+    if (typeof url !== "string") return "audio/mpeg";
+
+    const pathWithoutQuery = url.split("?")[0].split("#")[0].toLowerCase();
+    if (
+      pathWithoutQuery.endsWith(".ogg") ||
+      pathWithoutQuery.endsWith(".oga")
+    ) {
+      return "audio/ogg";
+    }
+    if (pathWithoutQuery.endsWith(".m4a")) return "audio/mp4";
+    if (pathWithoutQuery.endsWith(".aac")) return "audio/aac";
+    if (pathWithoutQuery.endsWith(".wav")) return "audio/wav";
+    if (pathWithoutQuery.endsWith(".flac")) return "audio/flac";
+
+    return "audio/mpeg";
+  };
+
   const trackVideoSourceUrl = (key, url, { revokable = false } = {}) => {
     videoSourceUrls.set(key, {
       url,
@@ -674,9 +692,10 @@ const createRouteGraphics = () => {
       }
 
       // Load audio assets using AudioAsset.load in parallel
+      await AudioAsset.prepareDecoders?.(assetsByType.audio);
       await Promise.all(
         Object.entries(assetsByType.audio).map(([key, asset]) =>
-          AudioAsset.load(key, asset.buffer),
+          AudioAsset.load(key, asset.buffer, asset.type),
         ),
       );
 
@@ -763,12 +782,34 @@ const createRouteGraphics = () => {
     },
 
     loadAudioAssets: async (urls) => {
-      return Promise.all(
+      const assets = await Promise.all(
         urls.map(async (url) => {
           const response = await fetch(url);
           const arrayBuffer = await response.arrayBuffer();
-          return AudioAsset.load(url, arrayBuffer);
+          return {
+            buffer: arrayBuffer,
+            key: url,
+            type: inferAudioTypeFromUrl(url),
+          };
         }),
+      );
+
+      const assetMap = Object.fromEntries(
+        assets.map((asset) => [
+          asset.key,
+          {
+            buffer: asset.buffer,
+            type: asset.type,
+          },
+        ]),
+      );
+
+      await AudioAsset.prepareDecoders?.(assetMap);
+
+      return Promise.all(
+        assets.map((asset) =>
+          AudioAsset.load(asset.key, asset.buffer, asset.type),
+        ),
       );
     },
 

--- a/src/audio/oggDecoderFallback.js
+++ b/src/audio/oggDecoderFallback.js
@@ -1,3 +1,6 @@
+import { OggVorbisDecoder } from "@wasm-audio-decoders/ogg-vorbis";
+import { OggOpusDecoder } from "ogg-opus-decoder";
+
 const OGG_AUDIO_TYPES = new Set(["audio/ogg", "application/ogg"]);
 
 const decoderState = {
@@ -133,13 +136,11 @@ const createAudioBuffer = ({
 
 const loadOpusDecoder = async () => {
   if (!decoderState.opus.decoderPromise) {
-    decoderState.opus.decoderPromise = import("ogg-opus-decoder").then(
-      async ({ OggOpusDecoder }) => {
-        const decoder = new OggOpusDecoder();
-        await decoder.ready;
-        return decoder;
-      },
-    );
+    decoderState.opus.decoderPromise = (async () => {
+      const decoder = new OggOpusDecoder();
+      await decoder.ready;
+      return decoder;
+    })();
   }
 
   return decoderState.opus.decoderPromise;
@@ -147,14 +148,11 @@ const loadOpusDecoder = async () => {
 
 const loadVorbisDecoder = async () => {
   if (!decoderState.vorbis.decoderPromise) {
-    decoderState.vorbis.decoderPromise =
-      import("@wasm-audio-decoders/ogg-vorbis").then(
-        async ({ OggVorbisDecoder }) => {
-          const decoder = new OggVorbisDecoder();
-          await decoder.ready;
-          return decoder;
-        },
-      );
+    decoderState.vorbis.decoderPromise = (async () => {
+      const decoder = new OggVorbisDecoder();
+      await decoder.ready;
+      return decoder;
+    })();
   }
 
   return decoderState.vorbis.decoderPromise;

--- a/src/audio/oggDecoderFallback.js
+++ b/src/audio/oggDecoderFallback.js
@@ -1,0 +1,215 @@
+const OGG_AUDIO_TYPES = new Set(["audio/ogg", "application/ogg"]);
+
+const decoderState = {
+  opus: {
+    decoderPromise: null,
+    queue: Promise.resolve(),
+  },
+  vorbis: {
+    decoderPromise: null,
+    queue: Promise.resolve(),
+  },
+};
+
+const audioTypeSupport = new Map();
+
+const toBytes = (arrayBuffer) =>
+  arrayBuffer instanceof Uint8Array
+    ? arrayBuffer
+    : new Uint8Array(arrayBuffer ?? new ArrayBuffer(0));
+
+const includesAscii = (bytes, marker) => {
+  const markerCodes = Array.from(marker, (char) => char.charCodeAt(0));
+  const lastStart = bytes.length - markerCodes.length;
+
+  for (let index = 0; index <= lastStart; index += 1) {
+    let matched = true;
+    for (
+      let markerIndex = 0;
+      markerIndex < markerCodes.length;
+      markerIndex += 1
+    ) {
+      if (bytes[index + markerIndex] !== markerCodes[markerIndex]) {
+        matched = false;
+        break;
+      }
+    }
+
+    if (matched) return true;
+  }
+
+  return false;
+};
+
+const canPlayAudioType = (type) => {
+  if (audioTypeSupport.has(type)) {
+    return audioTypeSupport.get(type);
+  }
+
+  let supported = false;
+  try {
+    const audio = globalThis.document?.createElement?.("audio");
+    supported =
+      typeof audio?.canPlayType === "function" &&
+      audio.canPlayType(type) !== "";
+  } catch {
+    supported = false;
+  }
+
+  audioTypeSupport.set(type, supported);
+  return supported;
+};
+
+const getNormalizedType = (type) => {
+  if (typeof type !== "string") return "";
+  return type.split(";")[0].trim().toLowerCase();
+};
+
+export const isOggAudioType = (type) => {
+  return OGG_AUDIO_TYPES.has(getNormalizedType(type));
+};
+
+export const detectOggCodec = (arrayBuffer) => {
+  const bytes = toBytes(arrayBuffer);
+
+  if (includesAscii(bytes, "OpusHead")) return "opus";
+  if (includesAscii(bytes, "vorbis")) return "vorbis";
+
+  return "unknown";
+};
+
+const canNativeDecodeOggCodec = (codec) => {
+  if (codec === "opus") {
+    return (
+      canPlayAudioType('audio/ogg; codecs="opus"') ||
+      canPlayAudioType("audio/ogg")
+    );
+  }
+
+  if (codec === "vorbis") {
+    return (
+      canPlayAudioType('audio/ogg; codecs="vorbis"') ||
+      canPlayAudioType("audio/ogg")
+    );
+  }
+
+  return canPlayAudioType("audio/ogg");
+};
+
+const createAudioBuffer = ({
+  audioContext,
+  channelData,
+  sampleRate,
+  samplesDecoded,
+}) => {
+  const channelCount = channelData.length;
+  if (channelCount === 0) {
+    throw new Error("Ogg decoder returned no audio channels.");
+  }
+
+  const length = Math.max(
+    0,
+    samplesDecoded ?? Math.max(...channelData.map((channel) => channel.length)),
+  );
+
+  if (length === 0) {
+    throw new Error("Ogg decoder returned an empty audio buffer.");
+  }
+
+  const audioBuffer = audioContext.createBuffer(
+    channelCount,
+    length,
+    sampleRate,
+  );
+  for (let channelIndex = 0; channelIndex < channelCount; channelIndex += 1) {
+    const sourceChannel = channelData[channelIndex];
+    audioBuffer
+      .getChannelData(channelIndex)
+      .set(sourceChannel.subarray(0, length));
+  }
+
+  return audioBuffer;
+};
+
+const loadOpusDecoder = async () => {
+  if (!decoderState.opus.decoderPromise) {
+    decoderState.opus.decoderPromise = import("ogg-opus-decoder").then(
+      async ({ OggOpusDecoder }) => {
+        const decoder = new OggOpusDecoder();
+        await decoder.ready;
+        return decoder;
+      },
+    );
+  }
+
+  return decoderState.opus.decoderPromise;
+};
+
+const loadVorbisDecoder = async () => {
+  if (!decoderState.vorbis.decoderPromise) {
+    decoderState.vorbis.decoderPromise =
+      import("@wasm-audio-decoders/ogg-vorbis").then(
+        async ({ OggVorbisDecoder }) => {
+          const decoder = new OggVorbisDecoder();
+          await decoder.ready;
+          return decoder;
+        },
+      );
+  }
+
+  return decoderState.vorbis.decoderPromise;
+};
+
+const getDecoder = (codec) => {
+  if (codec === "opus") return loadOpusDecoder();
+  if (codec === "vorbis") return loadVorbisDecoder();
+
+  throw new Error(`Unsupported Ogg codec "${codec}".`);
+};
+
+const decodeWithQueuedDecoder = async ({ codec, bytes }) => {
+  const state = decoderState[codec];
+  const run = async () => {
+    const decoder = await getDecoder(codec);
+    const decoded = await decoder.decodeFile(bytes);
+    await decoder.reset?.();
+    return decoded;
+  };
+
+  const result = state.queue.then(run, run);
+  state.queue = result.catch(() => {});
+
+  return result;
+};
+
+export const prepareOggDecoders = async (assetMap = {}) => {
+  const codecsToPrepare = new Set();
+
+  for (const asset of Object.values(assetMap)) {
+    if (!isOggAudioType(asset?.type) || !asset?.buffer) {
+      continue;
+    }
+
+    const codec = detectOggCodec(asset.buffer);
+    if (codec === "unknown" || canNativeDecodeOggCodec(codec)) {
+      continue;
+    }
+
+    codecsToPrepare.add(codec);
+  }
+
+  await Promise.all([...codecsToPrepare].map((codec) => getDecoder(codec)));
+};
+
+export const decodeOggToAudioBuffer = async ({ arrayBuffer, audioContext }) => {
+  const codec = detectOggCodec(arrayBuffer);
+  const bytes = toBytes(arrayBuffer);
+  const decoded = await decodeWithQueuedDecoder({ codec, bytes });
+
+  return createAudioBuffer({
+    audioContext,
+    channelData: decoded.channelData ?? [],
+    sampleRate: decoded.sampleRate,
+    samplesDecoded: decoded.samplesDecoded,
+  });
+};

--- a/src/cli/routeGraphicsCli.js
+++ b/src/cli/routeGraphicsCli.js
@@ -404,33 +404,6 @@ const getServedAssetPath = (assetId, assetPath) => {
   return `${toBrowserPath(assetId)}${extension}`;
 };
 
-const getDistFilePath = (pathname) => {
-  if (!pathname.startsWith("/dist/")) return null;
-
-  let relativePath;
-  try {
-    relativePath = decodeURIComponent(pathname.slice("/dist/".length));
-  } catch {
-    return null;
-  }
-  const normalizedPath = path.normalize(relativePath);
-  if (
-    normalizedPath.startsWith("..") ||
-    path.isAbsolute(normalizedPath) ||
-    normalizedPath.length === 0
-  ) {
-    return null;
-  }
-
-  return path.join(path.dirname(bundlePath), normalizedPath);
-};
-
-const getJavaScriptContentType = (filePath) => {
-  return filePath.endsWith(".map")
-    ? "application/json; charset=utf-8"
-    : "text/javascript; charset=utf-8";
-};
-
 const createRequestHandler = ({ assetRoutes }) => {
   return async (request, response) => {
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
@@ -441,25 +414,11 @@ const createRequestHandler = ({ assetRoutes }) => {
       return;
     }
 
-    const distFilePath = getDistFilePath(url.pathname);
-    if (distFilePath) {
-      try {
-        const stat = await fsPromises.stat(distFilePath);
-        if (!stat.isFile()) {
-          response.writeHead(404);
-          response.end("Not Found");
-          return;
-        }
-
-        response.writeHead(200, {
-          "content-length": stat.size,
-          "content-type": getJavaScriptContentType(distFilePath),
-        });
-        fs.createReadStream(distFilePath).pipe(response);
-      } catch {
-        response.writeHead(404);
-        response.end("Not Found");
-      }
+    if (url.pathname === "/dist/RouteGraphics.js") {
+      response.writeHead(200, {
+        "content-type": "text/javascript; charset=utf-8",
+      });
+      fs.createReadStream(bundlePath).pipe(response);
       return;
     }
 

--- a/src/cli/routeGraphicsCli.js
+++ b/src/cli/routeGraphicsCli.js
@@ -404,6 +404,28 @@ const getServedAssetPath = (assetId, assetPath) => {
   return `${toBrowserPath(assetId)}${extension}`;
 };
 
+const getDistFilePath = (pathname) => {
+  if (!pathname.startsWith("/dist/")) return null;
+
+  const relativePath = decodeURIComponent(pathname.slice("/dist/".length));
+  const normalizedPath = path.normalize(relativePath);
+  if (
+    normalizedPath.startsWith("..") ||
+    path.isAbsolute(normalizedPath) ||
+    normalizedPath.length === 0
+  ) {
+    return null;
+  }
+
+  return path.join(path.dirname(bundlePath), normalizedPath);
+};
+
+const getJavaScriptContentType = (filePath) => {
+  return filePath.endsWith(".map")
+    ? "application/json; charset=utf-8"
+    : "text/javascript; charset=utf-8";
+};
+
 const createRequestHandler = ({ assetRoutes }) => {
   return async (request, response) => {
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
@@ -414,11 +436,25 @@ const createRequestHandler = ({ assetRoutes }) => {
       return;
     }
 
-    if (url.pathname === "/dist/RouteGraphics.js") {
-      response.writeHead(200, {
-        "content-type": "text/javascript; charset=utf-8",
-      });
-      fs.createReadStream(bundlePath).pipe(response);
+    const distFilePath = getDistFilePath(url.pathname);
+    if (distFilePath) {
+      try {
+        const stat = await fsPromises.stat(distFilePath);
+        if (!stat.isFile()) {
+          response.writeHead(404);
+          response.end("Not Found");
+          return;
+        }
+
+        response.writeHead(200, {
+          "content-length": stat.size,
+          "content-type": getJavaScriptContentType(distFilePath),
+        });
+        fs.createReadStream(distFilePath).pipe(response);
+      } catch {
+        response.writeHead(404);
+        response.end("Not Found");
+      }
       return;
     }
 


### PR DESCRIPTION
Summary
- Add Ogg Vorbis and Opus WASM decoder fallbacks when native AudioContext decoding fails; browsers with native Ogg support remain on the native path.
- Embed the standard decoders in the main RouteGraphics bundle and exclude the unused 3.91 MiB Opus ML enhancement model. No decoder chunks or chunk-serving routes are required.
- Preserve current main's shared asset lifecycle and structured decode errors while forwarding normalized Ogg MIME types.
- Add a manual macOS VT fixture backed by a real Vorbis Ogg file.

Conflict resolution and review
- Merge current main into the PR branch and resolve AudioAsset, RouteGraphics, and audio test conflicts.
- Keep decoder preparation behind registered audio load jobs so texture and video ownership timing is unchanged.
- Handle application/ogg codec parameters, unknown Ogg codecs, and decoder reset after failed decodes.

Verification
- bun run build
- bun run lint
- bun run test: 85 files, 626 tests passed
- Direct Vorbis fallback decode: non-silent stereo, 12 kHz
- Direct Opus fallback decode: non-silent stereo, 48 kHz