### PR TITLE
Fix resource swaps before update animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.17.4",
+  "version": "1.17.5",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/elements/animatedSpriteRendering.spec.js
+++ b/spec/elements/animatedSpriteRendering.spec.js
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const {
   textureFrom,
   dispatchLiveAnimations,
+  getLiveAnimations,
   MockAnimatedSprite,
   MockBlurFilter,
   MockSpritesheet,
@@ -57,6 +58,7 @@ const {
   return {
     textureFrom: vi.fn(),
     dispatchLiveAnimations: vi.fn(() => false),
+    getLiveAnimations: vi.fn(() => []),
     MockAnimatedSprite: HoistedMockAnimatedSprite,
     MockBlurFilter: HoistedMockBlurFilter,
     MockSpritesheet: HoistedMockSpritesheet,
@@ -74,6 +76,7 @@ vi.mock("pixi.js", () => ({
 
 vi.mock("../../src/plugins/animations/planAnimations.js", () => ({
   dispatchLiveAnimations,
+  getLiveAnimations,
 }));
 
 import { addAnimatedSprite } from "../../src/plugins/elements/animated-sprite/addAnimatedSprite.js";
@@ -120,6 +123,8 @@ describe("spritesheet animation rendering", () => {
     textureFrom.mockReturnValue({ alias: "fighter-spritesheet" });
     dispatchLiveAnimations.mockReset();
     dispatchLiveAnimations.mockReturnValue(false);
+    getLiveAnimations.mockReset();
+    getLiveAnimations.mockReturnValue([]);
   });
 
   afterEach(() => {
@@ -296,6 +301,294 @@ describe("spritesheet animation rendering", () => {
       { frameName: "frame-1.png" },
       { frameName: "frame-2.png" },
     ]);
+  });
+
+  it("reloads changed spritesheet resources before dispatching update animations", async () => {
+    const order = [];
+    textureFrom.mockImplementation((src) => {
+      order.push(`texture:${src}`);
+      return { alias: src };
+    });
+    dispatchLiveAnimations.mockImplementation(() => {
+      order.push("dispatch");
+      return true;
+    });
+    getLiveAnimations.mockReturnValue([
+      {
+        id: "animated-sprite-update",
+        targetId: "animated-sprite-1",
+        type: "update",
+      },
+    ]);
+
+    const app = {
+      debug: false,
+      render: vi.fn(() => {
+        order.push(
+          `render:${animatedSpriteElement.width}x${animatedSpriteElement.height}`,
+        );
+      }),
+    };
+    const animatedSpriteElement = new MockAnimatedSprite([
+      { frameName: "old" },
+    ]);
+    animatedSpriteElement.label = "animated-sprite-1";
+    animatedSpriteElement.x = 20;
+    animatedSpriteElement.y = 30;
+    animatedSpriteElement.width = 64;
+    animatedSpriteElement.height = 64;
+    const parent = {
+      children: [animatedSpriteElement],
+    };
+    const prevElement = createAnimatedSpriteElement({
+      x: 20,
+      y: 30,
+      width: 64,
+      height: 64,
+    });
+    const nextElement = createAnimatedSpriteElement({
+      src: "fighter-spritesheet-v2",
+      x: 240,
+      y: 160,
+      width: 128,
+      height: 128,
+    });
+
+    await updateAnimatedSprite({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations: [
+        {
+          id: "animated-sprite-update",
+          targetId: "animated-sprite-1",
+          type: "update",
+          tween: {
+            x: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+          },
+        },
+      ],
+      animationBus: {},
+      completionTracker: {
+        getVersion: vi.fn().mockReturnValue(1),
+        track: vi.fn(() => {
+          order.push("track");
+        }),
+        complete: vi.fn(() => {
+          order.push("complete");
+        }),
+      },
+      zIndex: 4,
+      signal: undefined,
+    });
+
+    expect(order).toEqual([
+      "track",
+      "texture:fighter-spritesheet-v2",
+      "render:128x128",
+      "dispatch",
+      "complete",
+    ]);
+    expect(animatedSpriteElement.textures).toEqual([
+      { frameName: "frame-0.png" },
+      { frameName: "frame-1.png" },
+      { frameName: "frame-2.png" },
+    ]);
+    expect(animatedSpriteElement.x).toBe(20);
+    expect(animatedSpriteElement.y).toBe(30);
+    expect(animatedSpriteElement.width).toBe(128);
+    expect(animatedSpriteElement.height).toBe(128);
+  });
+
+  it("keeps animated dimensions at their current values before dispatch", async () => {
+    const order = [];
+    textureFrom.mockImplementation((src) => {
+      order.push(`texture:${src}`);
+      return { alias: src };
+    });
+    dispatchLiveAnimations.mockImplementation(({ element }) => {
+      order.push(`dispatch:${element.width}x${element.height}`);
+      return true;
+    });
+    getLiveAnimations.mockReturnValue([
+      {
+        id: "animated-sprite-update",
+        targetId: "animated-sprite-1",
+        type: "update",
+        tween: {
+          width: {
+            auto: {
+              duration: 300,
+              easing: "linear",
+            },
+          },
+          height: {
+            auto: {
+              duration: 300,
+              easing: "linear",
+            },
+          },
+        },
+      },
+    ]);
+
+    const app = {
+      debug: false,
+      render: vi.fn(),
+    };
+    const animatedSpriteElement = new MockAnimatedSprite([
+      { frameName: "old" },
+    ]);
+    animatedSpriteElement.label = "animated-sprite-1";
+    animatedSpriteElement.x = 20;
+    animatedSpriteElement.y = 30;
+    animatedSpriteElement.width = 64;
+    animatedSpriteElement.height = 48;
+    const parent = {
+      children: [animatedSpriteElement],
+    };
+    const prevElement = createAnimatedSpriteElement({
+      x: 20,
+      y: 30,
+      width: 64,
+      height: 48,
+    });
+    const nextElement = createAnimatedSpriteElement({
+      src: "fighter-spritesheet-v2",
+      x: 20,
+      y: 30,
+      width: 128,
+      height: 96,
+    });
+
+    await updateAnimatedSprite({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations: [
+        {
+          id: "animated-sprite-update",
+          targetId: "animated-sprite-1",
+          type: "update",
+          tween: {
+            width: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+            height: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+          },
+        },
+      ],
+      animationBus: {},
+      completionTracker: {
+        getVersion: vi.fn().mockReturnValue(1),
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      zIndex: 4,
+      signal: undefined,
+    });
+
+    expect(order).toEqual(["texture:fighter-spritesheet-v2", "dispatch:64x48"]);
+    expect(animatedSpriteElement.textures).toEqual([
+      { frameName: "frame-0.png" },
+      { frameName: "frame-1.png" },
+      { frameName: "frame-2.png" },
+    ]);
+    expect(animatedSpriteElement.width).toBe(64);
+    expect(animatedSpriteElement.height).toBe(48);
+  });
+
+  it("does not reload frame textures before dispatch for playback-only updates", async () => {
+    const order = [];
+    dispatchLiveAnimations.mockImplementation(() => {
+      order.push("dispatch");
+      return true;
+    });
+    getLiveAnimations.mockReturnValue([
+      {
+        id: "animated-sprite-update",
+        targetId: "animated-sprite-1",
+        type: "update",
+        tween: {
+          x: {
+            auto: {
+              duration: 300,
+              easing: "linear",
+            },
+          },
+        },
+      },
+    ]);
+
+    const app = {
+      debug: false,
+      render: vi.fn(),
+    };
+    const animatedSpriteElement = new MockAnimatedSprite([
+      { frameName: "old" },
+    ]);
+    animatedSpriteElement.label = "animated-sprite-1";
+    const parent = {
+      children: [animatedSpriteElement],
+    };
+    const prevElement = createAnimatedSpriteElement();
+    const nextElement = createAnimatedSpriteElement({
+      playback: {
+        clip: "idle",
+        fps: 12,
+        loop: true,
+        autoplay: true,
+      },
+    });
+
+    await updateAnimatedSprite({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations: [
+        {
+          id: "animated-sprite-update",
+          targetId: "animated-sprite-1",
+          type: "update",
+          tween: {
+            x: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+          },
+        },
+      ],
+      animationBus: {},
+      completionTracker: {
+        getVersion: vi.fn().mockReturnValue(1),
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      zIndex: 4,
+      signal: undefined,
+    });
+
+    expect(order).toEqual(["dispatch"]);
+    expect(textureFrom).not.toHaveBeenCalled();
+    expect(animatedSpriteElement.animationSpeed).toBe(0);
   });
 
   it("re-renders when a debug snapshot frame event changes the current frame", () => {

--- a/spec/elements/updateSprite.spec.js
+++ b/spec/elements/updateSprite.spec.js
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { MockBlurFilter, textureFrom } = vi.hoisted(() => {
+  class HoistedMockBlurFilter {
+    constructor(options = {}) {
+      this.strengthX = options.strengthX ?? options.strength ?? 0;
+      this.strengthY = options.strengthY ?? options.strength ?? 0;
+      this.quality = options.quality ?? 4;
+      this.kernelSize = options.kernelSize ?? 5;
+      this.repeatEdgePixels = false;
+      this.destroy = vi.fn();
+    }
+  }
+
+  return {
+    MockBlurFilter: HoistedMockBlurFilter,
+    textureFrom: vi.fn(),
+  };
+});
+
+vi.mock("pixi.js", () => ({
+  BlurFilter: MockBlurFilter,
+  Texture: {
+    EMPTY: { src: "" },
+    from: textureFrom,
+  },
+}));
+
+import { updateSprite } from "../../src/plugins/elements/sprite/updateSprite.js";
+
+describe("updateSprite", () => {
+  beforeEach(() => {
+    textureFrom.mockReset();
+  });
+
+  it("swaps changed textures before dispatching update animations", () => {
+    const order = [];
+    const nextTexture = { src: "next-sprite" };
+    textureFrom.mockImplementation((src) => {
+      order.push(`texture:${src}`);
+      return nextTexture;
+    });
+
+    const spriteElement = {
+      label: "sprite-1",
+      texture: { src: "prev-sprite" },
+      x: 10,
+      y: 20,
+      width: 80,
+      height: 80,
+      alpha: 1,
+      zIndex: 0,
+      removeAllListeners: vi.fn(),
+      on: vi.fn(),
+    };
+    const animationBus = {
+      dispatch: vi.fn(() => {
+        order.push("dispatch");
+      }),
+    };
+
+    updateSprite({
+      app: {
+        audioStage: { add: vi.fn() },
+      },
+      parent: {
+        children: [spriteElement],
+      },
+      prevElement: {
+        id: "sprite-1",
+        type: "sprite",
+        src: "prev-sprite",
+        x: 10,
+        y: 20,
+        width: 80,
+        height: 80,
+        alpha: 1,
+      },
+      nextElement: {
+        id: "sprite-1",
+        type: "sprite",
+        src: "next-sprite",
+        x: 200,
+        y: 120,
+        width: 100,
+        height: 100,
+        alpha: 1,
+      },
+      animations: [
+        {
+          id: "sprite-update",
+          targetId: "sprite-1",
+          type: "update",
+          tween: {
+            x: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+          },
+        },
+      ],
+      animationBus,
+      completionTracker: {
+        getVersion: vi.fn().mockReturnValue(1),
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      eventHandler: vi.fn(),
+      zIndex: 4,
+    });
+
+    expect(order).toEqual(["texture:next-sprite", "dispatch"]);
+    expect(spriteElement.texture).toBe(nextTexture);
+    expect(spriteElement.x).toBe(10);
+    expect(spriteElement.y).toBe(20);
+    expect(spriteElement.width).toBe(100);
+    expect(spriteElement.height).toBe(100);
+  });
+
+  it("keeps animated dimensions at their current values before dispatch", () => {
+    const order = [];
+    const nextTexture = { src: "next-sprite" };
+    textureFrom.mockImplementation((src) => {
+      order.push(`texture:${src}`);
+      return nextTexture;
+    });
+
+    const spriteElement = {
+      label: "sprite-1",
+      texture: { src: "prev-sprite" },
+      x: 10,
+      y: 20,
+      width: 80,
+      height: 60,
+      alpha: 1,
+      zIndex: 0,
+      removeAllListeners: vi.fn(),
+      on: vi.fn(),
+    };
+    const animationBus = {
+      dispatch: vi.fn((command) => {
+        const { element } = command.payload;
+        order.push(`dispatch:${element.width}x${element.height}`);
+      }),
+    };
+
+    updateSprite({
+      app: {
+        audioStage: { add: vi.fn() },
+      },
+      parent: {
+        children: [spriteElement],
+      },
+      prevElement: {
+        id: "sprite-1",
+        type: "sprite",
+        src: "prev-sprite",
+        x: 10,
+        y: 20,
+        width: 80,
+        height: 60,
+        alpha: 1,
+      },
+      nextElement: {
+        id: "sprite-1",
+        type: "sprite",
+        src: "next-sprite",
+        x: 10,
+        y: 20,
+        width: 120,
+        height: 90,
+        alpha: 1,
+      },
+      animations: [
+        {
+          id: "sprite-update",
+          targetId: "sprite-1",
+          type: "update",
+          tween: {
+            width: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+            height: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+          },
+        },
+      ],
+      animationBus,
+      completionTracker: {
+        getVersion: vi.fn().mockReturnValue(1),
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      eventHandler: vi.fn(),
+      zIndex: 4,
+    });
+
+    expect(order).toEqual(["texture:next-sprite", "dispatch:80x60"]);
+    expect(spriteElement.texture).toBe(nextTexture);
+    expect(spriteElement.width).toBe(80);
+    expect(spriteElement.height).toBe(60);
+  });
+});

--- a/spec/elements/updateVideo.spec.js
+++ b/spec/elements/updateVideo.spec.js
@@ -120,4 +120,302 @@ describe("updateVideo", () => {
     );
     expect(currentVideo.loop).toBe(false);
   });
+
+  it("swaps changed video resources before dispatching update animations", () => {
+    const order = [];
+    const currentVideo = createMockVideo();
+    const nextVideo = createMockVideo();
+    textureFrom.mockImplementation((src) => {
+      order.push(`texture:${src}`);
+      return {
+        source: {
+          resource: nextVideo,
+        },
+      };
+    });
+
+    const videoElement = {
+      label: "video-1",
+      texture: {
+        source: {
+          resource: currentVideo,
+        },
+      },
+      zIndex: 0,
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 100,
+      alpha: 1,
+    };
+    const animationBus = {
+      dispatch: vi.fn(() => {
+        order.push("dispatch");
+      }),
+    };
+
+    updateVideo({
+      app: {},
+      parent: {
+        children: [videoElement],
+      },
+      prevElement: {
+        id: "video-1",
+        src: "old-video.mp4",
+        loop: true,
+        volume: 50,
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 100,
+        alpha: 1,
+      },
+      nextElement: {
+        id: "video-1",
+        src: "new-video.mp4",
+        loop: true,
+        volume: 50,
+        x: 200,
+        y: 120,
+        width: 160,
+        height: 90,
+        alpha: 1,
+      },
+      animations: [
+        {
+          id: "video-update",
+          targetId: "video-1",
+          type: "update",
+          tween: {
+            x: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+          },
+        },
+      ],
+      animationBus,
+      eventHandler: vi.fn(),
+      completionTracker: {
+        getVersion: vi.fn().mockReturnValue(1),
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      zIndex: 3,
+    });
+
+    expect(order).toEqual(["texture:new-video.mp4", "dispatch"]);
+    expect(videoElement.texture.source.resource).toBe(nextVideo);
+    expect(currentVideo.pause).toHaveBeenCalled();
+    expect(nextVideo.play).toHaveBeenCalled();
+    expect(videoElement.x).toBe(10);
+    expect(videoElement.y).toBe(20);
+    expect(videoElement.width).toBe(160);
+    expect(videoElement.height).toBe(90);
+  });
+
+  it("keeps animated dimensions at their current values before dispatch", () => {
+    const order = [];
+    const currentVideo = createMockVideo();
+    const nextVideo = createMockVideo();
+    textureFrom.mockImplementation((src) => {
+      order.push(`texture:${src}`);
+      return {
+        source: {
+          resource: nextVideo,
+        },
+      };
+    });
+
+    const videoElement = {
+      label: "video-1",
+      texture: {
+        source: {
+          resource: currentVideo,
+        },
+      },
+      zIndex: 0,
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 80,
+      alpha: 1,
+    };
+    const animationBus = {
+      dispatch: vi.fn((command) => {
+        const { element } = command.payload;
+        order.push(`dispatch:${element.width}x${element.height}`);
+      }),
+    };
+
+    updateVideo({
+      app: {},
+      parent: {
+        children: [videoElement],
+      },
+      prevElement: {
+        id: "video-1",
+        src: "old-video.mp4",
+        loop: true,
+        volume: 50,
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 80,
+        alpha: 1,
+      },
+      nextElement: {
+        id: "video-1",
+        src: "new-video.mp4",
+        loop: true,
+        volume: 50,
+        x: 10,
+        y: 20,
+        width: 160,
+        height: 90,
+        alpha: 1,
+      },
+      animations: [
+        {
+          id: "video-update",
+          targetId: "video-1",
+          type: "update",
+          tween: {
+            width: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+            height: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+          },
+        },
+      ],
+      animationBus,
+      eventHandler: vi.fn(),
+      completionTracker: {
+        getVersion: vi.fn().mockReturnValue(1),
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      zIndex: 3,
+    });
+
+    expect(order).toEqual(["texture:new-video.mp4", "dispatch:100x80"]);
+    expect(videoElement.texture.source.resource).toBe(nextVideo);
+    expect(videoElement.width).toBe(100);
+    expect(videoElement.height).toBe(80);
+  });
+
+  it("does not re-track pre-synced non-looping video playback on animation completion", () => {
+    const currentVideo = createMockVideo();
+    const nextVideo = createMockVideo();
+    let animationComplete;
+    let endedListener;
+    textureFrom.mockReturnValue({
+      source: {
+        resource: nextVideo,
+      },
+    });
+    nextVideo.addEventListener.mockImplementation((eventName, listener) => {
+      if (eventName === "ended") {
+        endedListener = listener;
+      }
+    });
+
+    const videoElement = {
+      label: "video-1",
+      texture: {
+        source: {
+          resource: currentVideo,
+        },
+      },
+      zIndex: 0,
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 80,
+      alpha: 1,
+    };
+    const animationBus = {
+      dispatch: vi.fn((command) => {
+        animationComplete = command.payload.onComplete;
+      }),
+    };
+    const completionTracker = {
+      getVersion: vi.fn().mockReturnValue(1),
+      track: vi.fn(),
+      complete: vi.fn(),
+    };
+
+    updateVideo({
+      app: {},
+      parent: {
+        children: [videoElement],
+      },
+      prevElement: {
+        id: "video-1",
+        src: "old-video.mp4",
+        loop: true,
+        volume: 50,
+        x: 10,
+        y: 20,
+        width: 100,
+        height: 80,
+        alpha: 1,
+      },
+      nextElement: {
+        id: "video-1",
+        src: "new-video.mp4",
+        loop: false,
+        volume: 50,
+        x: 160,
+        y: 90,
+        width: 120,
+        height: 90,
+        alpha: 1,
+      },
+      animations: [
+        {
+          id: "video-update",
+          targetId: "video-1",
+          type: "update",
+          tween: {
+            x: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+          },
+        },
+      ],
+      animationBus,
+      eventHandler: vi.fn(),
+      completionTracker,
+      zIndex: 3,
+    });
+
+    expect(completionTracker.track).toHaveBeenCalledTimes(2);
+    expect(nextVideo.addEventListener).toHaveBeenCalledWith(
+      "ended",
+      expect.any(Function),
+    );
+
+    animationComplete();
+
+    expect(nextVideo.removeEventListener).not.toHaveBeenCalled();
+    expect(completionTracker.track).toHaveBeenCalledTimes(2);
+
+    endedListener();
+
+    expect(completionTracker.complete).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/plugins/elements/animated-sprite/updateAnimatedSprite.js
+++ b/src/plugins/elements/animated-sprite/updateAnimatedSprite.js
@@ -1,7 +1,10 @@
 import { Spritesheet, Texture } from "pixi.js";
 import { setupDebugMode, cleanupDebugMode } from "./util/debugUtils.js";
 import { isDeepEqual } from "../../../util/isDeepEqual.js";
-import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import {
+  dispatchLiveAnimations,
+  getLiveAnimations,
+} from "../../animations/planAnimations.js";
 import {
   getBlurTargetState,
   hasBlurUpdateAnimation,
@@ -44,24 +47,123 @@ export const updateAnimatedSprite = async ({
     syncBlurEffect(animatedSpriteElement, prevElement.blur, { force: true });
   }
 
+  const prevAtlas = normalizeAnimatedSpriteAtlas(prevElement.atlas);
+  const prevClips = normalizeAnimatedSpriteClips(
+    prevElement.clips,
+    prevElement.atlas?.animations,
+    prevElement.atlas?.meta,
+    Object.keys(prevAtlas.frames ?? {}),
+  );
+  const prevPlayback = normalizeAnimatedSpritePlayback({
+    atlas: prevAtlas,
+    clips: prevClips,
+    playback: prevElement.playback,
+  });
+  const nextSrc = nextElement.src;
+  const nextAtlas = normalizeAnimatedSpriteAtlas(nextElement.atlas);
+  const nextClips = normalizeAnimatedSpriteClips(
+    nextElement.clips,
+    nextElement.atlas?.animations,
+    nextElement.atlas?.meta,
+    Object.keys(nextAtlas.frames ?? {}),
+  );
+  const nextPlayback = normalizeAnimatedSpritePlayback({
+    atlas: nextAtlas,
+    clips: nextClips,
+    playback: nextElement.playback,
+  });
+  const playbackChanged = !isDeepEqual(
+    prevElement.playback,
+    nextElement.playback,
+  );
+  const clipSetChanged = !isDeepEqual(prevElement.clips, nextElement.clips);
+  const atlasChanged =
+    prevElement.src !== nextSrc ||
+    !isDeepEqual(prevElement.atlas, nextElement.atlas);
+  const playbackFramesChanged = !isDeepEqual(
+    prevPlayback.frames,
+    nextPlayback.frames,
+  );
+  const frameResourceChanged =
+    atlasChanged || clipSetChanged || playbackFramesChanged;
+  const shouldSyncFrameResource =
+    playbackChanged || clipSetChanged || atlasChanged;
+  let didSyncFrameResource = false;
+
+  const syncFrameResource = async ({
+    completeOnFinish = true,
+    renderAfterSync = true,
+  } = {}) => {
+    if (signal?.aborted || animatedSpriteElement.destroyed) {
+      return { synced: false, completionVersion: undefined };
+    }
+
+    animatedSpriteElement.animationSpeed = playbackFpsToAnimationSpeed(
+      nextPlayback.fps,
+    );
+    animatedSpriteElement.loop = nextPlayback.loop;
+
+    if (!shouldSyncFrameResource || didSyncFrameResource) {
+      return { synced: true, completionVersion: undefined };
+    }
+
+    const completionVersion = completionTracker?.getVersion?.();
+    completionTracker?.track?.(completionVersion);
+
+    try {
+      const spriteSheet = new Spritesheet(Texture.from(nextSrc), nextAtlas);
+      await spriteSheet.parse();
+      if (signal?.aborted || animatedSpriteElement.destroyed) {
+        return { synced: false, completionVersion };
+      }
+
+      const { frameTextures } = resolveAnimatedSpriteFrameTextures({
+        spritesheet: spriteSheet,
+        atlas: nextAtlas,
+        clips: nextClips,
+        playback: nextPlayback,
+      });
+      animatedSpriteElement.textures = frameTextures;
+      didSyncFrameResource = true;
+
+      if (renderAfterSync && typeof app.render === "function") {
+        app.render();
+      }
+
+      if (!app.debug && nextPlayback.autoplay) {
+        animatedSpriteElement.play();
+      } else {
+        if (!app.debug) {
+          animatedSpriteElement.stop?.();
+        }
+
+        if (prevElement.id !== nextElement.id) {
+          cleanupDebugMode(animatedSpriteElement);
+          setupDebugMode(
+            animatedSpriteElement,
+            nextElement.id,
+            app.debug,
+            () => {
+              if (typeof app.render === "function") {
+                app.render();
+              }
+            },
+          );
+        }
+      }
+    } finally {
+      if (completeOnFinish) {
+        completionTracker?.complete?.(completionVersion);
+      }
+    }
+
+    return { synced: true, completionVersion };
+  };
+
   const updateElement = async () => {
     if (signal?.aborted || animatedSpriteElement.destroyed) return;
 
     if (!isDeepEqual(prevElement, nextElement)) {
-      const nextSrc = nextElement.src;
-      const nextAtlas = normalizeAnimatedSpriteAtlas(nextElement.atlas);
-      const nextClips = normalizeAnimatedSpriteClips(
-        nextElement.clips,
-        nextElement.atlas?.animations,
-        nextElement.atlas?.meta,
-        Object.keys(nextAtlas.frames ?? {}),
-      );
-      const nextPlayback = normalizeAnimatedSpritePlayback({
-        atlas: nextAtlas,
-        clips: nextClips,
-        playback: nextElement.playback,
-      });
-
       animatedSpriteElement.x = Math.round(nextElement.x);
       animatedSpriteElement.y = Math.round(nextElement.y);
       animatedSpriteElement.width = Math.round(nextElement.width);
@@ -71,69 +173,44 @@ export const updateAnimatedSprite = async ({
         force: shouldForceBlur,
       });
 
-      const playbackChanged = !isDeepEqual(
-        prevElement.playback,
-        nextElement.playback,
-      );
-      const clipSetChanged = !isDeepEqual(prevElement.clips, nextElement.clips);
-      const atlasChanged =
-        prevElement.src !== nextSrc ||
-        !isDeepEqual(prevElement.atlas, nextElement.atlas);
-
-      animatedSpriteElement.animationSpeed = playbackFpsToAnimationSpeed(
-        nextPlayback.fps,
-      );
-      animatedSpriteElement.loop = nextPlayback.loop;
-
-      if (playbackChanged || clipSetChanged || atlasChanged) {
-        const completionVersion = completionTracker?.getVersion?.();
-        completionTracker?.track?.(completionVersion);
-
-        try {
-          const spriteSheet = new Spritesheet(Texture.from(nextSrc), nextAtlas);
-          await spriteSheet.parse();
-          if (signal?.aborted || animatedSpriteElement.destroyed) return;
-
-          const { frameTextures } = resolveAnimatedSpriteFrameTextures({
-            spritesheet: spriteSheet,
-            atlas: nextAtlas,
-            clips: nextClips,
-            playback: nextPlayback,
-          });
-          animatedSpriteElement.textures = frameTextures;
-          if (typeof app.render === "function") {
-            app.render();
-          }
-
-          if (!app.debug && nextPlayback.autoplay) {
-            animatedSpriteElement.play();
-          } else {
-            if (!app.debug) {
-              animatedSpriteElement.stop?.();
-            }
-
-            if (prevElement.id !== nextElement.id) {
-              cleanupDebugMode(animatedSpriteElement);
-              setupDebugMode(
-                animatedSpriteElement,
-                nextElement.id,
-                app.debug,
-                () => {
-                  if (typeof app.render === "function") {
-                    app.render();
-                  }
-                },
-              );
-            }
-          }
-        } finally {
-          completionTracker?.complete?.(completionVersion);
-        }
-      }
+      await syncFrameResource();
     }
   };
 
   const { x, y, width, height, alpha } = nextElement;
+  const liveAnimations = getLiveAnimations(animations, prevElement.id);
+  const hasLiveAnimation = liveAnimations.length > 0;
+  const hasLiveAnimationTween = (property) =>
+    liveAnimations.some((animation) =>
+      Object.prototype.hasOwnProperty.call(animation.tween ?? {}, property),
+    );
+  let preDispatchFrameResourceCompletionVersion;
+
+  if (frameResourceChanged && hasLiveAnimation) {
+    const currentWidth = animatedSpriteElement.width;
+    const currentHeight = animatedSpriteElement.height;
+    const result = await syncFrameResource({
+      completeOnFinish: false,
+      renderAfterSync: false,
+    });
+    if (!result?.synced) {
+      completionTracker?.complete?.(result?.completionVersion);
+      return;
+    }
+
+    animatedSpriteElement.width = Math.round(
+      hasLiveAnimationTween("width") ? currentWidth : width,
+    );
+    animatedSpriteElement.height = Math.round(
+      hasLiveAnimationTween("height") ? currentHeight : height,
+    );
+
+    if (typeof app.render === "function") {
+      app.render();
+    }
+
+    preDispatchFrameResourceCompletionVersion = result.completionVersion;
+  }
 
   const dispatched = dispatchLiveAnimations({
     animations,
@@ -155,6 +232,10 @@ export const updateAnimatedSprite = async ({
       void updateElement();
     },
   });
+
+  if (preDispatchFrameResourceCompletionVersion !== undefined) {
+    completionTracker?.complete?.(preDispatchFrameResourceCompletionVersion);
+  }
 
   if (!dispatched) {
     // No animations, update immediately

--- a/src/plugins/elements/sprite/updateSprite.js
+++ b/src/plugins/elements/sprite/updateSprite.js
@@ -1,7 +1,10 @@
 import { Texture } from "pixi.js";
 import { isDeepEqual } from "../../../util/isDeepEqual.js";
 import { normalizeVolume } from "../../../util/normalizeVolume.js";
-import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import {
+  dispatchLiveAnimations,
+  getLiveAnimations,
+} from "../../animations/planAnimations.js";
 import { isPrimaryPointerEvent } from "../util/isPrimaryPointerEvent.js";
 import {
   getBlurTargetState,
@@ -47,11 +50,217 @@ export const updateSprite = ({
     syncBlurEffect(spriteElement, prevElement.blur, { force: true });
   }
 
+  let didSyncResourceBeforeAnimation = false;
+  const liveAnimations = getLiveAnimations(animations, prevElement.id);
+  const hasLiveAnimation = liveAnimations.length > 0;
+  const hasLiveAnimationTween = (property) =>
+    liveAnimations.some((animation) =>
+      Object.prototype.hasOwnProperty.call(animation.tween ?? {}, property),
+    );
+
+  const bindSpriteInteractions = (texture) => {
+    spriteElement._cleanupScrollInteraction?.();
+    spriteElement.removeAllListeners("pointerover");
+    spriteElement.removeAllListeners("pointerout");
+    spriteElement.removeAllListeners("pointerdown");
+    spriteElement.removeAllListeners("pointerupoutside");
+    spriteElement.removeAllListeners("pointerup");
+    spriteElement.removeAllListeners("rightdown");
+    spriteElement.removeAllListeners("rightclick");
+    spriteElement.removeAllListeners("rightup");
+    spriteElement.removeAllListeners("rightupoutside");
+    spriteElement.removeAllListeners("wheel");
+    clearInheritedHoverTarget(spriteElement);
+    clearInheritedPressTarget(spriteElement);
+    clearInheritedRightPressTarget(spriteElement);
+
+    const hoverEvents = nextElement?.hover;
+    const clickEvents = nextElement?.click;
+    const rightClickEvents = nextElement?.rightClick;
+    const scrollUpEvent = nextElement?.scrollUp;
+    const scrollDownEvent = nextElement?.scrollDown;
+
+    let hoverController = null;
+    let pressController = null;
+    let rightPressController = null;
+
+    const updateTexture = () => {
+      const isHovering = hoverController?.isHovering() ?? false;
+      const isPressed = pressController?.isPressed() ?? false;
+      const isRightPressed = rightPressController?.isPressed() ?? false;
+
+      if (isRightPressed && rightClickEvents?.src) {
+        const rightClickTexture = Texture.from(rightClickEvents.src);
+        spriteElement.texture = rightClickTexture;
+      } else if (isPressed && clickEvents?.src) {
+        const clickTexture = Texture.from(clickEvents.src);
+        spriteElement.texture = clickTexture;
+      } else if (isHovering && hoverEvents?.src) {
+        const hoverTexture = Texture.from(hoverEvents.src);
+        spriteElement.texture = hoverTexture;
+      } else {
+        spriteElement.texture = texture;
+      }
+    };
+
+    if (hoverEvents) {
+      const { cursor, soundSrc, payload } = hoverEvents;
+      spriteElement.eventMode = "static";
+      hoverController = createHoverStateController({
+        displayObject: spriteElement,
+        onHoverChange: updateTexture,
+      });
+
+      const overListener = () => {
+        hoverController.setDirectHover(true);
+        if (payload && eventHandler)
+          eventHandler(`hover`, {
+            _event: {
+              id: spriteElement.label,
+            },
+            ...payload,
+          });
+        if (cursor) spriteElement.cursor = cursor;
+        if (soundSrc)
+          app.audioStage.add({
+            id: `hover-${Date.now()}`,
+            url: soundSrc,
+            loop: false,
+          });
+      };
+
+      const outListener = () => {
+        hoverController.setDirectHover(false);
+        spriteElement.cursor = "auto";
+      };
+
+      spriteElement.on("pointerover", overListener);
+      spriteElement.on("pointerout", outListener);
+    }
+
+    if (clickEvents) {
+      const { soundSrc, soundVolume, payload } = clickEvents;
+      spriteElement.eventMode = "static";
+      pressController = createPressStateController({
+        displayObject: spriteElement,
+        onPressChange: updateTexture,
+      });
+
+      const clickListener = (event) => {
+        if (!isPrimaryPointerEvent(event)) {
+          return;
+        }
+
+        pressController.setDirectPress(true);
+      };
+
+      const releaseListener = (event) => {
+        if (!isPrimaryPointerEvent(event)) {
+          return;
+        }
+
+        pressController.setDirectPress(false);
+
+        if (payload && eventHandler)
+          eventHandler(`click`, {
+            _event: {
+              id: spriteElement.label,
+            },
+            ...payload,
+          });
+        if (soundSrc)
+          app.audioStage.add({
+            id: `click-${Date.now()}`,
+            url: soundSrc,
+            loop: false,
+            volume: normalizeVolume(soundVolume),
+          });
+      };
+
+      const outListener = () => {
+        pressController.setDirectPress(false);
+      };
+
+      spriteElement.on("pointerdown", clickListener);
+      spriteElement.on("pointerup", releaseListener);
+      spriteElement.on("pointerupoutside", outListener);
+    }
+
+    if (rightClickEvents) {
+      const { soundSrc, payload } = rightClickEvents;
+      spriteElement.eventMode = "static";
+      rightPressController = createRightPressStateController({
+        displayObject: spriteElement,
+        onPressChange: updateTexture,
+      });
+
+      const rightPressListener = () => {
+        rightPressController.setDirectPress(true);
+      };
+
+      const rightReleaseListener = () => {
+        rightPressController.setDirectPress(false);
+      };
+
+      const rightClickListener = () => {
+        rightPressController.setDirectPress(false);
+
+        if (payload && eventHandler) {
+          eventHandler(`rightClick`, {
+            _event: {
+              id: spriteElement.label,
+            },
+            ...payload,
+          });
+        }
+        if (soundSrc) {
+          app.audioStage.add({
+            id: `rightClick-${Date.now()}`,
+            url: soundSrc,
+            loop: false,
+          });
+        }
+      };
+
+      const rightOutListener = () => {
+        rightPressController.setDirectPress(false);
+      };
+
+      spriteElement.on("rightdown", rightPressListener);
+      spriteElement.on("rightup", rightReleaseListener);
+      spriteElement.on("rightclick", rightClickListener);
+      spriteElement.on("rightupoutside", rightOutListener);
+    }
+
+    if (scrollUpEvent || scrollDownEvent) {
+      setupScrollInteraction({
+        canvas: app.canvas,
+        displayObject: spriteElement,
+        scrollUpEvent,
+        scrollDownEvent,
+        eventHandler,
+      });
+    }
+  };
+
+  const syncSpriteResource = ({
+    preserveWidth = false,
+    preserveHeight = false,
+  } = {}) => {
+    const currentWidth = spriteElement.width;
+    const currentHeight = spriteElement.height;
+    const texture = src ? Texture.from(src) : Texture.EMPTY;
+    spriteElement.texture = texture;
+    spriteElement.width = Math.round(preserveWidth ? currentWidth : width);
+    spriteElement.height = Math.round(preserveHeight ? currentHeight : height);
+    bindSpriteInteractions(texture);
+  };
+
   const updateElement = () => {
     if (!isDeepEqual(prevElement, nextElement)) {
-      spriteElement._cleanupScrollInteraction?.();
-      const texture = src ? Texture.from(src) : Texture.EMPTY;
-      spriteElement.texture = texture;
+      if (!didSyncResourceBeforeAnimation) {
+        syncSpriteResource();
+      }
 
       spriteElement.x = Math.round(x);
       spriteElement.y = Math.round(y);
@@ -61,190 +270,16 @@ export const updateSprite = ({
       syncBlurEffect(spriteElement, nextElement.blur, {
         force: shouldForceBlur,
       });
-
-      spriteElement.removeAllListeners("pointerover");
-      spriteElement.removeAllListeners("pointerout");
-      spriteElement.removeAllListeners("pointerdown");
-      spriteElement.removeAllListeners("pointerupoutside");
-      spriteElement.removeAllListeners("pointerup");
-      spriteElement.removeAllListeners("rightdown");
-      spriteElement.removeAllListeners("rightclick");
-      spriteElement.removeAllListeners("rightup");
-      spriteElement.removeAllListeners("rightupoutside");
-      spriteElement.removeAllListeners("wheel");
-      clearInheritedHoverTarget(spriteElement);
-      clearInheritedPressTarget(spriteElement);
-      clearInheritedRightPressTarget(spriteElement);
-
-      const hoverEvents = nextElement?.hover;
-      const clickEvents = nextElement?.click;
-      const rightClickEvents = nextElement?.rightClick;
-      const scrollUpEvent = nextElement?.scrollUp;
-      const scrollDownEvent = nextElement?.scrollDown;
-
-      let hoverController = null;
-      let pressController = null;
-      let rightPressController = null;
-
-      const updateTexture = () => {
-        const isHovering = hoverController?.isHovering() ?? false;
-        const isPressed = pressController?.isPressed() ?? false;
-        const isRightPressed = rightPressController?.isPressed() ?? false;
-
-        if (isRightPressed && rightClickEvents?.src) {
-          const rightClickTexture = Texture.from(rightClickEvents.src);
-          spriteElement.texture = rightClickTexture;
-        } else if (isPressed && clickEvents?.src) {
-          const clickTexture = Texture.from(clickEvents.src);
-          spriteElement.texture = clickTexture;
-        } else if (isHovering && hoverEvents?.src) {
-          const hoverTexture = Texture.from(hoverEvents.src);
-          spriteElement.texture = hoverTexture;
-        } else {
-          spriteElement.texture = texture;
-        }
-      };
-
-      if (hoverEvents) {
-        const { cursor, soundSrc, payload } = hoverEvents;
-        spriteElement.eventMode = "static";
-        hoverController = createHoverStateController({
-          displayObject: spriteElement,
-          onHoverChange: updateTexture,
-        });
-
-        const overListener = () => {
-          hoverController.setDirectHover(true);
-          if (payload && eventHandler)
-            eventHandler(`hover`, {
-              _event: {
-                id: spriteElement.label,
-              },
-              ...payload,
-            });
-          if (cursor) spriteElement.cursor = cursor;
-          if (soundSrc)
-            app.audioStage.add({
-              id: `hover-${Date.now()}`,
-              url: soundSrc,
-              loop: false,
-            });
-        };
-
-        const outListener = () => {
-          hoverController.setDirectHover(false);
-          spriteElement.cursor = "auto";
-        };
-
-        spriteElement.on("pointerover", overListener);
-        spriteElement.on("pointerout", outListener);
-      }
-
-      if (clickEvents) {
-        const { soundSrc, soundVolume, payload } = clickEvents;
-        spriteElement.eventMode = "static";
-        pressController = createPressStateController({
-          displayObject: spriteElement,
-          onPressChange: updateTexture,
-        });
-
-        const clickListener = (event) => {
-          if (!isPrimaryPointerEvent(event)) {
-            return;
-          }
-
-          pressController.setDirectPress(true);
-        };
-
-        const releaseListener = (event) => {
-          if (!isPrimaryPointerEvent(event)) {
-            return;
-          }
-
-          pressController.setDirectPress(false);
-
-          if (payload && eventHandler)
-            eventHandler(`click`, {
-              _event: {
-                id: spriteElement.label,
-              },
-              ...payload,
-            });
-          if (soundSrc)
-            app.audioStage.add({
-              id: `click-${Date.now()}`,
-              url: soundSrc,
-              loop: false,
-              volume: normalizeVolume(soundVolume),
-            });
-        };
-
-        const outListener = () => {
-          pressController.setDirectPress(false);
-        };
-
-        spriteElement.on("pointerdown", clickListener);
-        spriteElement.on("pointerup", releaseListener);
-        spriteElement.on("pointerupoutside", outListener);
-      }
-
-      if (rightClickEvents) {
-        const { soundSrc, payload } = rightClickEvents;
-        spriteElement.eventMode = "static";
-        rightPressController = createRightPressStateController({
-          displayObject: spriteElement,
-          onPressChange: updateTexture,
-        });
-
-        const rightPressListener = () => {
-          rightPressController.setDirectPress(true);
-        };
-
-        const rightReleaseListener = () => {
-          rightPressController.setDirectPress(false);
-        };
-
-        const rightClickListener = () => {
-          rightPressController.setDirectPress(false);
-
-          if (payload && eventHandler) {
-            eventHandler(`rightClick`, {
-              _event: {
-                id: spriteElement.label,
-              },
-              ...payload,
-            });
-          }
-          if (soundSrc) {
-            app.audioStage.add({
-              id: `rightClick-${Date.now()}`,
-              url: soundSrc,
-              loop: false,
-            });
-          }
-        };
-
-        const rightOutListener = () => {
-          rightPressController.setDirectPress(false);
-        };
-
-        spriteElement.on("rightdown", rightPressListener);
-        spriteElement.on("rightup", rightReleaseListener);
-        spriteElement.on("rightclick", rightClickListener);
-        spriteElement.on("rightupoutside", rightOutListener);
-      }
-
-      if (scrollUpEvent || scrollDownEvent) {
-        setupScrollInteraction({
-          canvas: app.canvas,
-          displayObject: spriteElement,
-          scrollUpEvent,
-          scrollDownEvent,
-          eventHandler,
-        });
-      }
     }
   };
+
+  if (prevElement.src !== nextElement.src && hasLiveAnimation) {
+    syncSpriteResource({
+      preserveWidth: hasLiveAnimationTween("width"),
+      preserveHeight: hasLiveAnimationTween("height"),
+    });
+    didSyncResourceBeforeAnimation = true;
+  }
 
   const dispatched = dispatchLiveAnimations({
     animations,

--- a/src/plugins/elements/video/updateVideo.js
+++ b/src/plugins/elements/video/updateVideo.js
@@ -4,7 +4,10 @@ import {
   clearVideoPlaybackTracking,
   syncVideoPlaybackTracking,
 } from "./playbackTracking.js";
-import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import {
+  dispatchLiveAnimations,
+  getLiveAnimations,
+} from "../../animations/planAnimations.js";
 import { normalizeVolume } from "../../../util/normalizeVolume.js";
 import {
   getBlurTargetState,
@@ -40,6 +43,55 @@ export const updateVideo = ({
     syncBlurEffect(videoElement, prevElement.blur, { force: true });
   }
 
+  let currentSrc = prevElement.src;
+  let didSyncResourceBeforeAnimation = false;
+  const liveAnimations = getLiveAnimations(animations, prevElement.id);
+  const hasLiveAnimation = liveAnimations.length > 0;
+  const hasLiveAnimationTween = (property) =>
+    liveAnimations.some((animation) =>
+      Object.prototype.hasOwnProperty.call(animation.tween ?? {}, property),
+    );
+
+  const syncVideoResource = () => {
+    let activeVideo = videoElement.texture.source.resource;
+    const srcChanged = currentSrc !== nextElement.src;
+
+    if (srcChanged) {
+      const oldVideo = activeVideo;
+      clearVideoPlaybackTracking({
+        videoElement,
+        video: oldVideo,
+      });
+
+      if (oldVideo) {
+        oldVideo.pause();
+      }
+
+      const newTexture = Texture.from(nextElement.src);
+      videoElement.texture = newTexture;
+      activeVideo = newTexture.source.resource;
+
+      activeVideo.muted = false;
+      activeVideo.pause();
+      activeVideo.currentTime = 0;
+      currentSrc = nextElement.src;
+    }
+
+    syncVideoPlaybackTracking({
+      videoElement,
+      video: activeVideo,
+      loop: nextElement.loop,
+      completionTracker,
+    });
+
+    activeVideo.volume = normalizeVolume(nextElement.volume);
+    activeVideo.loop = nextElement.loop ?? false;
+
+    if (srcChanged) {
+      activeVideo.play();
+    }
+  };
+
   const updateElement = () => {
     if (!isDeepEqual(prevElement, nextElement)) {
       videoElement.x = Math.round(x);
@@ -51,43 +103,24 @@ export const updateVideo = ({
         force: shouldForceBlur,
       });
 
-      let activeVideo = videoElement.texture.source.resource;
-
-      if (prevElement.src !== nextElement.src) {
-        const oldVideo = activeVideo;
-        clearVideoPlaybackTracking({
-          videoElement,
-          video: oldVideo,
-        });
-
-        if (oldVideo) {
-          oldVideo.pause();
-        }
-
-        const newTexture = Texture.from(nextElement.src);
-        videoElement.texture = newTexture;
-        activeVideo = newTexture.source.resource;
-
-        activeVideo.muted = false;
-        activeVideo.pause();
-        activeVideo.currentTime = 0;
-      }
-
-      syncVideoPlaybackTracking({
-        videoElement,
-        video: activeVideo,
-        loop: nextElement.loop,
-        completionTracker,
-      });
-
-      activeVideo.volume = normalizeVolume(nextElement.volume);
-      activeVideo.loop = nextElement.loop ?? false;
-
-      if (prevElement.src !== nextElement.src) {
-        activeVideo.play();
+      if (!didSyncResourceBeforeAnimation) {
+        syncVideoResource();
       }
     }
   };
+
+  if (prevElement.src !== nextElement.src && hasLiveAnimation) {
+    const currentWidth = videoElement.width;
+    const currentHeight = videoElement.height;
+    syncVideoResource();
+    videoElement.width = Math.round(
+      hasLiveAnimationTween("width") ? currentWidth : width,
+    );
+    videoElement.height = Math.round(
+      hasLiveAnimationTween("height") ? currentHeight : height,
+    );
+    didSyncResourceBeforeAnimation = true;
+  }
 
   const dispatched = dispatchLiveAnimations({
     animations,

--- a/vt/reference/animatedspritetransition/animated-sprite-update-src-animation-01.webp
+++ b/vt/reference/animatedspritetransition/animated-sprite-update-src-animation-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:183bf94b24cdcca4e835ab203bddcab519df645b1d42ffd0fde7a63f1caf9c50
+size 6626

--- a/vt/reference/animatedspritetransition/animated-sprite-update-src-animation-02.webp
+++ b/vt/reference/animatedspritetransition/animated-sprite-update-src-animation-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00bf07057e9e7e986de42b6f22572ea8ff238d0d9ed4dcc9a56712f38a2ee945
+size 2038

--- a/vt/reference/animatedspritetransition/animated-sprite-update-src-animation-03.webp
+++ b/vt/reference/animatedspritetransition/animated-sprite-update-src-animation-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7eda6089c8682534f7ab9ac1e71d34aa4b0e22bb951ce2fe71576aeaeffd22ae
+size 1996

--- a/vt/reference/spritetransition/render-abortion-test-03.webp
+++ b/vt/reference/spritetransition/render-abortion-test-03.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:51dcf5476a45bbe267e79be3ac0b2a1b678222a706a847f36ba980b10d066515
-size 2432
+oid sha256:c10217d9398fefa6c62c3e3a0153dc8de05df641e4ba39d125eacffcd8c7c683
+size 2070

--- a/vt/reference/spritetransition/render-abortion-test-04.webp
+++ b/vt/reference/spritetransition/render-abortion-test-04.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f4e9aede607c09b4d2ee843fff3c1032594500e6750cfec0402c67ef0ebc4d1f
-size 3046
+oid sha256:e23e2042a3274f0bf79575c76d7a6a87f46115b6144414fba41707a14709bc32
+size 2488

--- a/vt/reference/spritetransition/render-abortion-test-05.webp
+++ b/vt/reference/spritetransition/render-abortion-test-05.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b523a1bcf446cd8e6d0330cf92f32b71cf7b74999227f022d62625fb627a1bcc
-size 3594
+oid sha256:253a0b3a5c578d6c8a87e5eb993054a510c807b28a3e00a2d6d0d1b8677e3686
+size 2622

--- a/vt/reference/spritetransition/sprite-update-src-animation-01.webp
+++ b/vt/reference/spritetransition/sprite-update-src-animation-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b626982d132ce4640d996243b95cef65c8239f937ffeabe5de27465578c2a92
+size 3212

--- a/vt/reference/spritetransition/sprite-update-src-animation-02.webp
+++ b/vt/reference/spritetransition/sprite-update-src-animation-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc29064823b899d098e759a2178f7c2e97eb9a2fd6ca85f96f1fafa4e648b6ef
+size 3020

--- a/vt/reference/spritetransition/sprite-update-src-animation-03.webp
+++ b/vt/reference/spritetransition/sprite-update-src-animation-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df59efc5ce6603ceac0ce85c136612fcf00e947de46b933c18e5464b1c317352
+size 3042

--- a/vt/specs/animatedspritetransition/animated-sprite-update-src-animation.yaml
+++ b/vt/specs/animatedspritetransition/animated-sprite-update-src-animation.yaml
@@ -1,0 +1,116 @@
+---
+title: Animated Sprite Update Src Animation
+description: A same-id spritesheet-animation changes atlas source while running an update animation.
+specs:
+  - spritesheet animation should swap to the next source before the update animation starts
+  - the mid-animation checkpoint should show the incoming slider atlas frame, not the previous fighter frame
+  - final state should keep the incoming atlas frame at the target position
+steps:
+  - action: customEvent
+    name: "snapShotAnimatedSpriteFrame"
+    detail:
+      frameIndex: 0
+      elementId: "animated-sprite1"
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotAnimatedSpriteFrame"
+    detail:
+      frameIndex: 0
+      elementId: "animated-sprite1"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - elements:
+      - id: animated-sprite1
+        type: spritesheet-animation
+        x: 180
+        "y": 160
+        width: 150
+        height: 150
+        src: fighter-spritesheet
+        atlas:
+          frames:
+            rollSequence0000.png:
+              frame:
+                x: 483
+                "y": 692
+                w: 169
+                h: 226
+              rotated: false
+              trimmed: true
+              spriteSourceSize:
+                x: 3
+                "y": 4
+                w: 169
+                h: 226
+              sourceSize:
+                w: 175
+                h: 240
+          meta:
+            format: RGBA8888
+            size:
+              w: 1024
+              h: 1024
+            scale: "1"
+        clips:
+          idle:
+            - rollSequence0000.png
+        playback:
+          clip: idle
+          fps: 1
+          loop: true
+        alpha: 1
+  - elements:
+      - id: animated-sprite1
+        type: spritesheet-animation
+        x: 520
+        "y": 330
+        width: 360
+        height: 64
+        src: slider
+        atlas:
+          frames:
+            frame-0.png:
+              x: 0
+              "y": 0
+              width: 218
+              height: 16
+            frame-1.png:
+              x: 218
+              "y": 0
+              width: 218
+              height: 16
+          width: 436
+          height: 16
+        clips:
+          pulse:
+            - frame-0.png
+            - frame-1.png
+        playback:
+          clip: pulse
+          fps: 1
+          loop: true
+        alpha: 1
+    animations:
+      - id: animated-sprite-src-update
+        targetId: animated-sprite1
+        type: update
+        tween:
+          x:
+            auto:
+              duration: 1000
+              easing: linear
+          "y":
+            auto:
+              duration: 1000
+              easing: linear

--- a/vt/specs/spritetransition/sprite-update-src-animation.yaml
+++ b/vt/specs/spritetransition/sprite-update-src-animation.yaml
@@ -1,0 +1,53 @@
+---
+title: Sprite Update Src Animation
+description: A same-id sprite changes source while running an update animation; colored sprite assets intentionally make the resource handoff visible.
+specs:
+  - sprite should swap to the next source before the update animation starts
+  - the mid-animation checkpoint should show the red sprite, not the previous blue sprite
+  - final state should keep the red sprite at the target position
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - elements:
+      - id: sprite1
+        type: sprite
+        src: circle-blue
+        x: 120
+        "y": 120
+        width: 140
+        height: 140
+        alpha: 1
+  - elements:
+      - id: sprite1
+        type: sprite
+        src: circle-red
+        x: 520
+        "y": 340
+        width: 140
+        height: 140
+        alpha: 1
+    animations:
+      - id: sprite-src-update
+        targetId: sprite1
+        type: update
+        tween:
+          x:
+            auto:
+              duration: 1000
+              easing: linear
+          "y":
+            auto:
+              duration: 1000
+              easing: linear


### PR DESCRIPTION
## Summary
- Swap sprite, video, and spritesheet resources before update animations dispatch when the resource changes
- Preserve current width/height when those dimensions are animated so dimension tweens still start correctly
- Add unit and VT coverage for update-animation resource handoff behavior

## Tests
- bunx vitest run
- bun run vt:report