### PR TITLE
Fix animation position tween semantics

### DIFF
--- a/docs/animation-implementation-plan.md
+++ b/docs/animation-implementation-plan.md
@@ -93,6 +93,9 @@ animations:
 Key rules:
 
 - `update` uses `tween`
+- `update` and `transition` both support absolute `x` / `y` and subject-relative
+  `translateX` / `translateY`
+- a single tween cannot combine `x` with `translateX`, or `y` with `translateY`
 - `update` and `transition` support optional `playback.continuity: persistent`
 - `transition` uses `prev`, `next`, and optional `mask`
 - `transition` may define:

--- a/docs/animation-model.md
+++ b/docs/animation-model.md
@@ -182,6 +182,17 @@ The same payload is reused in two places:
 - manual `update.tween`
 - `prev.tween` / `next.tween`
 
+Position tweens support two addressing modes in both `update` and `transition`:
+
+- `x` / `y` are absolute pixel positions in the parent coordinate space
+- `translateX` / `translateY` are relative offsets in units of the animated
+  subject's own width or height
+
+For example, `translateX: -1` moves the subject left by one subject width, and
+`translateY: 0.5` moves it down by half its height. A single tween cannot define
+both `x` and `translateX`, or both `y` and `translateY`, because that would make
+the final position ambiguous.
+
 `update` also supports a shorthand for the common "animate this property from
 its current live value to the next state's value" case:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.17.5",
+  "version": "1.17.6",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/animations/animationBus.spec.js
+++ b/spec/animations/animationBus.spec.js
@@ -216,6 +216,50 @@ describe("animationBus auto tween shorthand", () => {
     expect(element._routeGraphicsBlur.y).toBeCloseTo(4);
   });
 
+  it("applies translate tweens relative to the subject dimensions", () => {
+    const animationBus = createAnimationBus();
+    const element = {
+      x: 10,
+      y: 20,
+      width: 120,
+      height: 80,
+      scale: { x: 1, y: 1 },
+    };
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "manual-translate",
+        element,
+        properties: {
+          translateX: {
+            initialValue: 0,
+            keyframes: [{ duration: 200, value: 1, easing: "linear" }],
+          },
+          translateY: {
+            initialValue: -0.5,
+            keyframes: [{ duration: 200, value: 0.5, easing: "linear" }],
+          },
+        },
+      },
+    });
+
+    animationBus.flush();
+
+    expect(element.x).toBeCloseTo(10);
+    expect(element.y).toBeCloseTo(-20);
+
+    animationBus.tick(100);
+
+    expect(element.x).toBeCloseTo(70);
+    expect(element.y).toBeCloseTo(20);
+
+    animationBus.tick(100);
+
+    expect(element.x).toBeCloseTo(130);
+    expect(element.y).toBeCloseTo(60);
+  });
+
   it("samples property animations at an exact time without completing them", () => {
     const animationBus = createAnimationBus();
     const onComplete = vi.fn();

--- a/spec/animations/runReplaceAnimation.spec.js
+++ b/spec/animations/runReplaceAnimation.spec.js
@@ -833,7 +833,7 @@ describe("runReplaceAnimation", () => {
 
     expect(overlay.children).toHaveLength(1);
     dispatched.payload.applyFrame(500);
-    expect(overlay.children[0].x).toBeLessThan(0);
+    expect(overlay.children[0].x).toBeCloseTo(-50);
     expect(nextDisplayObject.visible).toBe(false);
   });
 
@@ -909,8 +909,174 @@ describe("runReplaceAnimation", () => {
 
     expect(overlay.children).toHaveLength(1);
     dispatched.payload.applyFrame(500);
-    expect(overlay.children[0].x).toBeGreaterThan(0);
+    expect(overlay.children[0].x).toBeCloseTo(50);
     expect(nextDisplayObject.visible).toBe(false);
+  });
+
+  it("applies absolute x and y tweens to transition snapshots", () => {
+    const nextDisplayObject = createDisplayObject("scene-root");
+    const parent = createParent();
+
+    const plugin = {
+      add: vi.fn(({ parent: targetParent, element }) => {
+        nextDisplayObject.label = element.id;
+        targetParent.addChild(nextDisplayObject);
+      }),
+      delete: vi.fn(),
+    };
+
+    const animationBus = {
+      dispatch: vi.fn(),
+    };
+
+    const app = {
+      renderer: {
+        width: 1280,
+        height: 720,
+        generateTexture: vi.fn(() => Texture.EMPTY),
+      },
+    };
+
+    runReplaceAnimation({
+      app,
+      parent,
+      prevElement: null,
+      nextElement: { id: "scene-root", type: "container", children: [] },
+      animation: {
+        id: "scene-absolute-in",
+        targetId: "scene-root",
+        type: "transition",
+        next: {
+          tween: {
+            x: {
+              initialValue: 20,
+              keyframes: [{ duration: 1000, value: 120, easing: "linear" }],
+            },
+            y: {
+              initialValue: 10,
+              keyframes: [{ duration: 1000, value: 60, easing: "linear" }],
+            },
+          },
+        },
+      },
+      animations: new Map(),
+      animationBus,
+      completionTracker: {
+        getVersion: () => 11,
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      eventHandler: vi.fn(),
+      elementPlugins: [],
+      plugin,
+      zIndex: 0,
+      signal: new AbortController().signal,
+    });
+
+    const dispatched = animationBus.dispatch.mock.calls[0][0];
+    const overlay = parent.children.find(
+      (child) => child !== nextDisplayObject,
+    );
+
+    dispatched.payload.applyFrame(500);
+    expect(overlay.children[0].x).toBeCloseTo(70);
+    expect(overlay.children[0].y).toBeCloseTo(35);
+  });
+
+  it("expands masked transition bounds for absolute position tweens", () => {
+    const prevDisplayObject = createDisplayObject("scene-root");
+    const nextDisplayObject = createDisplayObject("scene-root");
+    const parent = createParent(prevDisplayObject);
+    prevDisplayObject.parent = parent;
+    const maskTexture = document.createElement("canvas");
+    maskTexture.width = 1;
+    maskTexture.height = 1;
+
+    const plugin = {
+      add: vi.fn(({ parent: targetParent, element }) => {
+        nextDisplayObject.label = element.id;
+        targetParent.addChild(nextDisplayObject);
+      }),
+      delete: vi.fn(({ parent: targetParent, element }) => {
+        const child = targetParent.children.find(
+          (item) => item.label === element.id,
+        );
+        if (child) {
+          targetParent.removeChild(child);
+        }
+      }),
+    };
+
+    const animationBus = {
+      dispatch: vi.fn(),
+    };
+
+    const app = {
+      renderer: {
+        width: 1280,
+        height: 720,
+        generateTexture: vi.fn(() => Texture.EMPTY),
+        render: vi.fn(),
+      },
+    };
+
+    runReplaceAnimation({
+      app,
+      parent,
+      prevElement: { id: "scene-root", type: "container" },
+      nextElement: { id: "scene-root", type: "container", children: [] },
+      animation: {
+        id: "scene-mask-position",
+        targetId: "scene-root",
+        type: "transition",
+        prev: {
+          tween: {
+            alpha: {
+              initialValue: 1,
+              keyframes: [{ duration: 1000, value: 0, easing: "linear" }],
+            },
+          },
+        },
+        next: {
+          tween: {
+            x: {
+              initialValue: 200,
+              keyframes: [{ duration: 1000, value: 400, easing: "linear" }],
+            },
+          },
+        },
+        mask: {
+          kind: "single",
+          texture: maskTexture,
+          channel: "red",
+          progress: {
+            initialValue: 0,
+            keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+          },
+        },
+      },
+      animations: new Map(),
+      animationBus,
+      completionTracker: {
+        getVersion: () => 11,
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      eventHandler: vi.fn(),
+      elementPlugins: [],
+      plugin,
+      zIndex: 0,
+      signal: new AbortController().signal,
+    });
+
+    const overlay = parent.children.find(
+      (child) => child !== nextDisplayObject,
+    );
+    const sprite = overlay.children[0];
+
+    expect(sprite.x).toBe(0);
+    expect(sprite.filterArea.width).toBe(401);
+    expect(sprite.filterArea.height).toBe(1);
   });
 
   it("does not preprocess single masks through CPU extraction", () => {

--- a/spec/parser/normalizeRenderState.test.yaml
+++ b/spec/parser/normalizeRenderState.test.yaml
@@ -199,6 +199,49 @@ out:
   audio: []
   audioEffects: []
 ---
+case: Normalize transition animation with absolute position tween
+in:
+  - id: state-2-next-transition-position
+    animations:
+      - id: anim-next-transition-position
+        targetId: scene-root
+        type: transition
+        next:
+          tween:
+            x:
+              initialValue: 100
+              keyframes:
+                - duration: 200
+                  value: 240
+            y:
+              initialValue: 80
+              keyframes:
+                - duration: 200
+                  value: 180
+out:
+  id: state-2-next-transition-position
+  elements: []
+  animations:
+    - id: anim-next-transition-position
+      targetId: scene-root
+      type: transition
+      next:
+        tween:
+          x:
+            initialValue: 100
+            keyframes:
+              - duration: 200
+                value: 240
+                easing: linear
+          y:
+            initialValue: 80
+            keyframes:
+              - duration: 200
+                value: 180
+                easing: linear
+  audio: []
+  audioEffects: []
+---
 case: Preserve advanced easing names
 in:
   - id: state-2-easing
@@ -259,6 +302,48 @@ out:
           auto:
             duration: 220
             easing: easeOutQuad
+  audio: []
+  audioEffects: []
+---
+case: Normalize update translate tween
+in:
+  - id: state-2-translate
+    animations:
+      - id: anim-translate
+        targetId: portrait
+        type: update
+        tween:
+          translateX:
+            initialValue: -1
+            keyframes:
+              - duration: 180
+                value: 0
+          translateY:
+            initialValue: 0.5
+            keyframes:
+              - duration: 220
+                value: 0
+                easing: easeOutQuad
+out:
+  id: state-2-translate
+  elements: []
+  animations:
+    - id: anim-translate
+      targetId: portrait
+      type: update
+      tween:
+        translateX:
+          initialValue: -1
+          keyframes:
+            - duration: 180
+              value: 0
+              easing: linear
+        translateY:
+          initialValue: 0.5
+          keyframes:
+            - duration: 220
+              value: 0
+              easing: easeOutQuad
   audio: []
   audioEffects: []
 ---
@@ -498,6 +583,43 @@ in:
               - duration: 100
                 value: 1
 throws: animations[0].tween is not valid for transition animations.
+---
+case: Throw when update tween mixes x and translateX
+in:
+  - id: state-3b-update-mixed-x
+    animations:
+      - id: anim-1
+        targetId: text-1
+        type: update
+        tween:
+          x:
+            keyframes:
+              - duration: 100
+                value: 20
+          translateX:
+            keyframes:
+              - duration: 100
+                value: 1
+throws: animations[0].tween cannot define both x and translateX.
+---
+case: Throw when transition tween mixes y and translateY
+in:
+  - id: state-3b-transition-mixed-y
+    animations:
+      - id: anim-1
+        targetId: scene-root
+        type: transition
+        next:
+          tween:
+            y:
+              keyframes:
+                - duration: 100
+                  value: 20
+            translateY:
+              keyframes:
+                - duration: 100
+                  value: 1
+throws: animations[0].next.tween cannot define both y and translateY.
 ---
 case: Throw when easing is unsupported
 in:

--- a/src/plugins/animations/animationBus.js
+++ b/src/plugins/animations/animationBus.js
@@ -3,58 +3,19 @@ import {
   WhiteListAnimationProps,
 } from "../../types.js";
 import {
+  applyAnimationProperty,
+  createAnimationSubjectState,
+  getTimelineInitialValue,
+  isTranslateAnimationProperty,
+} from "./animationPropertyUtils.js";
+import {
   buildTimeline,
   calculateMaxDuration,
   getValueAtTime,
 } from "../../util/animationTimeline.js";
 
-const getMappedPath = (propertyPathMap, path) => {
-  if (typeof path !== "string") {
-    return path;
-  }
-
-  return propertyPathMap[path] ?? path;
-};
-
-const getAnimationProperty = (object, path, propertyPathMap, defaultValue) => {
-  const mappedPath = getMappedPath(propertyPathMap, path);
-
-  if (typeof mappedPath === "string") {
-    const result = object[mappedPath];
-    return result === undefined ? defaultValue : result;
-  }
-
-  let result = object;
-  for (const key of mappedPath) {
-    if (result == null) {
-      return defaultValue;
-    }
-    result = result[key];
-  }
-
-  return result === undefined ? defaultValue : result;
-};
-
-const setAnimationProperty = (object, path, propertyPathMap, value) => {
-  const mappedPath = getMappedPath(propertyPathMap, path);
-
-  if (typeof mappedPath === "string") {
-    object[mappedPath] = value;
-    return object;
-  }
-
-  let current = object;
-  for (let i = 0; i < mappedPath.length - 1; i++) {
-    const key = mappedPath[i];
-    if (!(key in current)) {
-      current[key] = {};
-    }
-    current = current[key];
-  }
-
-  current[mappedPath[mappedPath.length - 1]] = value;
-  return object;
-};
+const hasTranslateProperties = (properties = {}) =>
+  Object.keys(properties).some(isTranslateAnimationProperty);
 
 const resolveAutoTargetValue = (targetState, property, animationId) => {
   if (
@@ -75,6 +36,7 @@ const buildPropertyTimelines = (
   propertyPathMap,
   targetState,
   animationId,
+  subjectState,
 ) =>
   Object.entries(properties)
     .map(([property, config]) => {
@@ -84,12 +46,13 @@ const buildPropertyTimelines = (
         );
       }
 
-      const currentValue = getAnimationProperty(
-        element,
+      const currentValue = getTimelineInitialValue({
+        object: element,
         property,
         propertyPathMap,
-        0,
-      );
+        subjectState,
+        defaultValue: 0,
+      });
 
       if (config.auto) {
         const targetValue = resolveAutoTargetValue(
@@ -215,7 +178,21 @@ export const createAnimationBus = () => {
       onComplete,
       onCancel,
       propertyPathMap = TRANSITION_PROPERTY_PATH_MAP,
+      animationBaseState,
     } = payload;
+    let subjectState =
+      animationBaseState ??
+      (hasTranslateProperties(properties)
+        ? createAnimationSubjectState(element)
+        : null);
+
+    const getSubjectState = () => {
+      if (!subjectState) {
+        subjectState = createAnimationSubjectState(element);
+      }
+
+      return subjectState;
+    };
 
     const timelines = buildPropertyTimelines(
       element,
@@ -223,6 +200,7 @@ export const createAnimationBus = () => {
       propertyPathMap,
       targetState,
       id,
+      subjectState,
     );
 
     if (timelines.length === 0) {
@@ -245,7 +223,15 @@ export const createAnimationBus = () => {
         for (const { property, timeline } of timelines) {
           const value = getValueAtTime(timeline, time);
           try {
-            setAnimationProperty(element, property, propertyPathMap, value);
+            applyAnimationProperty({
+              object: element,
+              property,
+              propertyPathMap,
+              subjectState: isTranslateAnimationProperty(property)
+                ? getSubjectState()
+                : subjectState,
+              value,
+            });
           } catch (_error) {
             // Element might be mid-destroy or otherwise invalid.
           }
@@ -263,7 +249,15 @@ export const createAnimationBus = () => {
 
         for (const [property, value] of Object.entries(targetState)) {
           try {
-            setAnimationProperty(element, property, propertyPathMap, value);
+            applyAnimationProperty({
+              object: element,
+              property,
+              propertyPathMap,
+              subjectState: isTranslateAnimationProperty(property)
+                ? getSubjectState()
+                : subjectState,
+              value,
+            });
           } catch (_error) {
             // Skip properties that fail to apply.
           }

--- a/src/plugins/animations/animationPropertyUtils.js
+++ b/src/plugins/animations/animationPropertyUtils.js
@@ -1,0 +1,123 @@
+export const isTranslateAnimationProperty = (property) =>
+  property === "translateX" || property === "translateY";
+
+const getMappedPath = (propertyPathMap, path) => {
+  if (typeof path !== "string") {
+    return path;
+  }
+
+  return propertyPathMap[path] ?? path;
+};
+
+export const getAnimationProperty = (
+  object,
+  path,
+  propertyPathMap,
+  defaultValue,
+) => {
+  const mappedPath = getMappedPath(propertyPathMap, path);
+
+  if (typeof mappedPath === "string") {
+    const result = object[mappedPath];
+    return result === undefined ? defaultValue : result;
+  }
+
+  let result = object;
+  for (const key of mappedPath) {
+    if (result == null) {
+      return defaultValue;
+    }
+    result = result[key];
+  }
+
+  return result === undefined ? defaultValue : result;
+};
+
+export const setAnimationProperty = (object, path, propertyPathMap, value) => {
+  const mappedPath = getMappedPath(propertyPathMap, path);
+
+  if (typeof mappedPath === "string") {
+    object[mappedPath] = value;
+    return object;
+  }
+
+  let current = object;
+  for (let index = 0; index < mappedPath.length - 1; index++) {
+    const key = mappedPath[index];
+    if (!(key in current)) {
+      current[key] = {};
+    }
+    current = current[key];
+  }
+
+  current[mappedPath[mappedPath.length - 1]] = value;
+  return object;
+};
+
+const isFiniteNumber = (value) =>
+  typeof value === "number" && Number.isFinite(value);
+
+const getBoundsRectangle = (displayObject) => {
+  const bounds = displayObject?.getLocalBounds?.();
+  return bounds?.rectangle ?? bounds ?? null;
+};
+
+const getSubjectDimension = (displayObject, axis) => {
+  const directValue =
+    axis === "x" ? displayObject?.width : displayObject?.height;
+  if (isFiniteNumber(directValue) && directValue > 0) {
+    return directValue;
+  }
+
+  const rectangle = getBoundsRectangle(displayObject);
+  const boundsValue = axis === "x" ? rectangle?.width : rectangle?.height;
+  const scaleValue =
+    axis === "x" ? displayObject?.scale?.x : displayObject?.scale?.y;
+
+  if (isFiniteNumber(boundsValue) && boundsValue > 0) {
+    return Math.abs(boundsValue * (scaleValue ?? 1));
+  }
+
+  return 0;
+};
+
+export const createAnimationSubjectState = (displayObject) => ({
+  x: displayObject?.x ?? 0,
+  y: displayObject?.y ?? 0,
+  width: getSubjectDimension(displayObject, "x"),
+  height: getSubjectDimension(displayObject, "y"),
+});
+
+export const getTimelineInitialValue = ({
+  object,
+  property,
+  propertyPathMap,
+  subjectState,
+  defaultValue = 0,
+}) => {
+  if (property === "translateX" || property === "translateY") {
+    return defaultValue;
+  }
+
+  return getAnimationProperty(object, property, propertyPathMap, defaultValue);
+};
+
+export const applyAnimationProperty = ({
+  object,
+  property,
+  propertyPathMap,
+  subjectState,
+  value,
+}) => {
+  if (property === "translateX") {
+    object.x = subjectState.x + value * subjectState.width;
+    return object;
+  }
+
+  if (property === "translateY") {
+    object.y = subjectState.y + value * subjectState.height;
+    return object;
+  }
+
+  return setAnimationProperty(object, property, propertyPathMap, value);
+};

--- a/src/plugins/animations/planAnimations.js
+++ b/src/plugins/animations/planAnimations.js
@@ -3,6 +3,10 @@ import {
   dispatchUpdateAnimationsNow,
 } from "./updateAnimationDispatch.js";
 import { queueDeferredUpdateAnimationStart } from "../elements/renderContext.js";
+import {
+  createAnimationSubjectState,
+  isTranslateAnimationProperty,
+} from "./animationPropertyUtils.js";
 import { isDeepEqual } from "../../util/isDeepEqual.js";
 import { collectAllElementIds } from "../../util/collectElementIds.js";
 
@@ -45,6 +49,11 @@ export const getTransitionAnimation = (animationsOrMap, targetId) =>
   getTargetAnimations(animationsOrMap, targetId).find(
     (animation) => animation.type === "transition",
   ) ?? null;
+
+const animationsUseTranslate = (animations = []) =>
+  animations.some((animation) =>
+    Object.keys(animation.tween ?? {}).some(isTranslateAnimationProperty),
+  );
 
 const findElementMatchById = (elements = [], targetId, ancestorIds = []) => {
   for (const element of elements) {
@@ -259,7 +268,16 @@ export const dispatchUpdateAnimations = ({
       );
     }
 
-    applyInitialUpdateAnimationState(element, animationsToStart);
+    const animationBaseState = animationsUseTranslate(animationsToStart)
+      ? createAnimationSubjectState(element)
+      : undefined;
+
+    applyInitialUpdateAnimationState(
+      element,
+      animationsToStart,
+      undefined,
+      animationBaseState,
+    );
 
     queueDeferredUpdateAnimationStart(renderContext, {
       animations: animationsToStart,
@@ -267,6 +285,7 @@ export const dispatchUpdateAnimations = ({
       completionTracker,
       element,
       targetState,
+      animationBaseState,
     });
 
     return true;
@@ -279,6 +298,9 @@ export const dispatchUpdateAnimations = ({
     element,
     targetState,
     onComplete,
+    animationBaseState: animationsUseTranslate(animationsToStart)
+      ? createAnimationSubjectState(element)
+      : undefined,
   });
 
   return true;

--- a/src/plugins/animations/replace/runReplaceAnimation.js
+++ b/src/plugins/animations/replace/runReplaceAnimation.js
@@ -79,29 +79,43 @@ const createSnapshotSubject = (app, displayObject) => {
   return {
     wrapper,
     texture,
+    width: frame.width * Math.abs(wrapper.scale.x),
+    height: frame.height * Math.abs(wrapper.scale.y),
   };
 };
 
-const buildSubjectTimelines = (tween = {}) =>
+const getSubjectDefaultValue = (property, base) => {
+  switch (property) {
+    case "x":
+      return base.x;
+    case "y":
+      return base.y;
+    default:
+      return DEFAULT_SUBJECT_VALUES[property] ?? 0;
+  }
+};
+
+const buildSubjectTimelines = (tween = {}, base) =>
   Object.entries(tween).map(([property, config]) => ({
     property,
     timeline: buildTimeline([
       {
-        value: config.initialValue ?? DEFAULT_SUBJECT_VALUES[property] ?? 0,
+        value: config.initialValue ?? getSubjectDefaultValue(property, base),
       },
       ...config.keyframes,
     ]),
   }));
 
-const createSubjectController = (wrapper, tween, app) => {
-  if (!wrapper || !tween) {
+const createSubjectController = (subject, tween) => {
+  if (!subject?.wrapper || !tween) {
     return {
       duration: 0,
+      timelines: [],
       apply: () => {},
     };
   }
 
-  const timelines = buildSubjectTimelines(tween);
+  const wrapper = subject.wrapper;
   const base = {
     x: wrapper.x,
     y: wrapper.y,
@@ -109,10 +123,14 @@ const createSubjectController = (wrapper, tween, app) => {
     scaleX: wrapper.scale.x,
     scaleY: wrapper.scale.y,
     rotation: wrapper.rotation,
+    width: subject.width,
+    height: subject.height,
   };
+  const timelines = buildSubjectTimelines(tween, base);
 
   return {
     duration: calculateMaxDuration(timelines),
+    timelines,
     apply: (time) => {
       wrapper.x = base.x;
       wrapper.y = base.y;
@@ -125,11 +143,17 @@ const createSubjectController = (wrapper, tween, app) => {
         const value = getValueAtTime(timeline, time);
 
         switch (property) {
+          case "x":
+            wrapper.x = value;
+            break;
+          case "y":
+            wrapper.y = value;
+            break;
           case "translateX":
-            wrapper.x = base.x + value * app.renderer.width;
+            wrapper.x = base.x + value * base.width;
             break;
           case "translateY":
-            wrapper.y = base.y + value * app.renderer.height;
+            wrapper.y = base.y + value * base.height;
             break;
           case "alpha":
             wrapper.alpha = base.alpha * value;
@@ -147,6 +171,57 @@ const createSubjectController = (wrapper, tween, app) => {
       }
     },
   };
+};
+
+const collectControllerSampleTimes = (controllers) => {
+  const sampleTimes = new Set([0]);
+
+  for (const controller of controllers) {
+    sampleTimes.add(controller.duration);
+
+    for (const { timeline } of controller.timelines ?? []) {
+      for (let index = 0; index < timeline.length; index++) {
+        const currentTime = timeline[index].time;
+        sampleTimes.add(currentTime);
+
+        if (index === 0) {
+          continue;
+        }
+
+        const previousTime = timeline[index - 1].time;
+        const span = currentTime - previousTime;
+        if (span <= 0) {
+          continue;
+        }
+
+        sampleTimes.add(previousTime + span * 0.25);
+        sampleTimes.add(previousTime + span * 0.5);
+        sampleTimes.add(previousTime + span * 0.75);
+      }
+    }
+  }
+
+  return [...sampleTimes].sort((a, b) => a - b);
+};
+
+const unionRectangles = (rectangles) => {
+  if (rectangles.length === 0) {
+    return new Rectangle(0, 0, 1, 1);
+  }
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const rectangle of rectangles) {
+    minX = Math.min(minX, rectangle.x);
+    minY = Math.min(minY, rectangle.y);
+    maxX = Math.max(maxX, rectangle.x + rectangle.width);
+    maxY = Math.max(maxY, rectangle.y + rectangle.height);
+  }
+
+  return new Rectangle(minX, minY, maxX - minX, maxY - minY);
 };
 
 const createMaskProgressTimeline = (mask) =>
@@ -822,6 +897,41 @@ const getUnionBounds = (subjects) => {
   return normalizeFrame(getLocalBoundsRectangle(boundsContainer));
 };
 
+const getAnimatedUnionBounds = (subjects, controllers) => {
+  const activeSubjects = subjects.filter((subject) => subject?.wrapper);
+
+  if (activeSubjects.length === 0) {
+    return getUnionBounds(subjects);
+  }
+
+  const boundsContainer = new Container();
+  for (const subject of activeSubjects) {
+    boundsContainer.addChild(subject.wrapper);
+  }
+
+  const rectangles = [];
+  for (const time of collectControllerSampleTimes(controllers)) {
+    for (const controller of controllers) {
+      controller.apply(time);
+    }
+
+    rectangles.push(getLocalBoundsRectangle(boundsContainer));
+  }
+
+  for (const controller of controllers) {
+    controller.apply(0);
+  }
+
+  for (const subject of activeSubjects) {
+    if (subject.wrapper.parent === boundsContainer) {
+      boundsContainer.removeChild(subject.wrapper);
+    }
+  }
+  boundsContainer.destroy();
+
+  return normalizeFrame(unionRectangles(rectangles));
+};
+
 const renderOffscreenContainer = ({ app, container, target, frame }) => {
   app.renderer.render({
     container,
@@ -906,14 +1016,12 @@ const createPlainOverlay = ({
   }
 
   const prevController = createSubjectController(
-    prevSubject?.wrapper ?? null,
+    prevSubject,
     animation.prev?.tween,
-    app,
   );
   const nextController = createSubjectController(
-    nextSubject?.wrapper ?? null,
+    nextSubject,
     animation.next?.tween,
-    app,
   );
 
   return {
@@ -940,7 +1048,18 @@ const createMaskedOverlay = ({
   nextSubject,
   zIndex,
 }) => {
-  const unionBounds = getUnionBounds([prevSubject, nextSubject]);
+  const prevController = createSubjectController(
+    prevSubject,
+    animation.prev?.tween,
+  );
+  const nextController = createSubjectController(
+    nextSubject,
+    animation.next?.tween,
+  );
+  const unionBounds = getAnimatedUnionBounds(
+    [prevSubject, nextSubject],
+    [prevController, nextController],
+  );
   const prevRoot = new Container();
   const nextRoot = new Container();
 
@@ -1005,16 +1124,6 @@ const createMaskedOverlay = ({
     unionBounds.width,
     unionBounds.height,
     maskFilter,
-  );
-  const prevController = createSubjectController(
-    prevSubject?.wrapper ?? null,
-    animation.prev?.tween,
-    app,
-  );
-  const nextController = createSubjectController(
-    nextSubject?.wrapper ?? null,
-    animation.next?.tween,
-    app,
   );
   let prevStaticRendered = false;
   let nextStaticRendered = false;

--- a/src/plugins/animations/tween/docs/README.md
+++ b/src/plugins/animations/tween/docs/README.md
@@ -29,6 +29,12 @@ Each `tween` property can use either:
 
 `keyframes` and `auto` are mutually exclusive on the same property.
 
+Position tweens support `x` / `y` and `translateX` / `translateY` in both
+`update` and `transition`. `x` / `y` are absolute parent-space pixels.
+`translateX` / `translateY` are subject-size multipliers, so `translateX: -1`
+moves left by one subject width. A tween cannot define both `x` and
+`translateX`, or both `y` and `translateY`.
+
 Each keyframe's `easing` applies to the segment that reaches that keyframe
 from the previous value. The first authored keyframe controls the segment from
 the current value to that keyframe. `auto.easing` controls the single segment

--- a/src/plugins/animations/updateAnimationDispatch.js
+++ b/src/plugins/animations/updateAnimationDispatch.js
@@ -2,41 +2,20 @@ import {
   TRANSITION_PROPERTY_PATH_MAP,
   WhiteListAnimationProps,
 } from "../../types.js";
-
-const getMappedPath = (propertyPathMap, path) => {
-  if (typeof path !== "string") {
-    return path;
-  }
-
-  return propertyPathMap[path] ?? path;
-};
-
-const setAnimationProperty = (object, path, propertyPathMap, value) => {
-  const mappedPath = getMappedPath(propertyPathMap, path);
-
-  if (typeof mappedPath === "string") {
-    object[mappedPath] = value;
-    return object;
-  }
-
-  let current = object;
-  for (let index = 0; index < mappedPath.length - 1; index++) {
-    const key = mappedPath[index];
-    if (!(key in current)) {
-      current[key] = {};
-    }
-    current = current[key];
-  }
-
-  current[mappedPath[mappedPath.length - 1]] = value;
-  return object;
-};
+import {
+  applyAnimationProperty,
+  createAnimationSubjectState,
+  isTranslateAnimationProperty,
+} from "./animationPropertyUtils.js";
 
 export const applyInitialUpdateAnimationState = (
   element,
   animations,
   propertyPathMap = TRANSITION_PROPERTY_PATH_MAP,
+  animationBaseState,
 ) => {
+  let subjectState = animationBaseState;
+
   for (const animation of animations) {
     for (const [property, config] of Object.entries(animation.tween)) {
       if (!WhiteListAnimationProps[property]) {
@@ -49,12 +28,17 @@ export const applyInitialUpdateAnimationState = (
         continue;
       }
 
-      setAnimationProperty(
-        element,
+      if (!subjectState && isTranslateAnimationProperty(property)) {
+        subjectState = createAnimationSubjectState(element);
+      }
+
+      applyAnimationProperty({
+        object: element,
         property,
         propertyPathMap,
-        config.initialValue,
-      );
+        subjectState,
+        value: config.initialValue,
+      });
     }
   }
 };
@@ -66,6 +50,7 @@ export const dispatchUpdateAnimationsNow = ({
   element,
   targetState,
   onComplete,
+  animationBaseState,
 }) => {
   for (const animation of animations) {
     if (
@@ -113,6 +98,7 @@ export const dispatchUpdateAnimationsNow = ({
         element,
         properties: animation.tween,
         targetState,
+        animationBaseState,
         onComplete: () => {
           if (trackCompletion) {
             completionTracker.complete(stateVersion);

--- a/src/plugins/elements/renderContext.js
+++ b/src/plugins/elements/renderContext.js
@@ -62,6 +62,7 @@ const executeDeferredMountOperation = (operation) => {
         completionTracker: operation.completionTracker,
         element: operation.element,
         targetState: operation.targetState,
+        animationBaseState: operation.animationBaseState,
       });
       return;
   }
@@ -131,7 +132,14 @@ export const queueDeferredTextRevealAutoplay = (
 
 export const queueDeferredUpdateAnimationStart = (
   renderContext,
-  { animations, animationBus, completionTracker, element, targetState },
+  {
+    animations,
+    animationBus,
+    completionTracker,
+    element,
+    targetState,
+    animationBaseState,
+  },
 ) =>
   queueDeferredMountOperation(renderContext, {
     type: "start-update-animations",
@@ -140,6 +148,7 @@ export const queueDeferredUpdateAnimationStart = (
     completionTracker,
     element,
     targetState,
+    animationBaseState,
   });
 
 export const flushDeferredMountOperations = (renderContext) => {

--- a/src/schemas/animations/animation.yaml
+++ b/src/schemas/animations/animation.yaml
@@ -138,6 +138,10 @@ $defs:
         $ref: "#/$defs/tweenProperty"
       y:
         $ref: "#/$defs/tweenProperty"
+      translateX:
+        $ref: "#/$defs/tweenProperty"
+      translateY:
+        $ref: "#/$defs/tweenProperty"
       scaleX:
         $ref: "#/$defs/tweenProperty"
       scaleY:
@@ -148,11 +152,24 @@ $defs:
         $ref: "#/$defs/tweenProperty"
       blurY:
         $ref: "#/$defs/tweenProperty"
+    allOf:
+      - not:
+          required:
+            - x
+            - translateX
+      - not:
+          required:
+            - y
+            - translateY
     additionalProperties: false
     minProperties: 1
   transitionTween:
     type: object
     properties:
+      x:
+        $ref: "#/$defs/tweenProperty"
+      y:
+        $ref: "#/$defs/tweenProperty"
       translateX:
         $ref: "#/$defs/tweenProperty"
       translateY:
@@ -165,6 +182,15 @@ $defs:
         $ref: "#/$defs/tweenProperty"
       rotation:
         $ref: "#/$defs/tweenProperty"
+    allOf:
+      - not:
+          required:
+            - x
+            - translateX
+      - not:
+          required:
+            - y
+            - translateY
     additionalProperties: false
     minProperties: 1
   transitionSide:

--- a/src/types.js
+++ b/src/types.js
@@ -616,6 +616,8 @@ export const WhiteListAnimationProps = {
   alpha: "alpha",
   x: "x",
   y: "y",
+  translateX: "translateX",
+  translateY: "translateY",
   scaleX: "scaleX",
   scaleY: "scaleY",
   rotation: "rotation",
@@ -641,6 +643,8 @@ export const TRANSITION_PROPERTY_PATH_MAP = {
 };
 
 export const REPLACE_SUBJECT_PROPERTY_PATH_MAP = {
+  x: ["x"],
+  y: ["y"],
   translateX: ["x"],
   translateY: ["y"],
   scaleX: ["scale", "x"],
@@ -650,6 +654,8 @@ export const REPLACE_SUBJECT_PROPERTY_PATH_MAP = {
 };
 
 export const WhiteListReplaceSubjectProps = {
+  x: "x",
+  y: "y",
   translateX: "translateX",
   translateY: "translateY",
   alpha: "alpha",

--- a/src/util/normalizeAnimations.js
+++ b/src/util/normalizeAnimations.js
@@ -6,6 +6,8 @@ const UPDATE_TWEEN_PROPERTIES = new Set([
   "alpha",
   "x",
   "y",
+  "translateX",
+  "translateY",
   "scaleX",
   "scaleY",
   "rotation",
@@ -13,6 +15,8 @@ const UPDATE_TWEEN_PROPERTIES = new Set([
   "blurY",
 ]);
 const TRANSITION_TWEEN_PROPERTIES = new Set([
+  "x",
+  "y",
   "translateX",
   "translateY",
   "alpha",
@@ -175,6 +179,14 @@ const normalizeTweenMap = (
   propertyNormalizer = normalizeKeyframes,
 ) => {
   assertPlainObject(tween, path);
+
+  if (tween.x !== undefined && tween.translateX !== undefined) {
+    throw new Error(`${path} cannot define both x and translateX.`);
+  }
+
+  if (tween.y !== undefined && tween.translateY !== undefined) {
+    throw new Error(`${path} cannot define both y and translateY.`);
+  }
 
   const normalizedEntries = Object.entries(tween).map(([property, config]) => {
     if (!allowedProperties.has(property)) {

--- a/vt/reference/containertransition/render-abortion-test-02.webp
+++ b/vt/reference/containertransition/render-abortion-test-02.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2743856eaba934c547ea8ffac123cc46398f5ba5371d1588559312a0c950736b
-size 1772
+oid sha256:ab29688265b929f3dd5aa65566101e11ceb837f207760da36a36c4176def2f35
+size 1788

--- a/vt/reference/replacetransition/rect-mask-absolute-position-01.webp
+++ b/vt/reference/replacetransition/rect-mask-absolute-position-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6af9afed0e8d50d4086443c0426db63fe994f70bce55ff4c642b9b071c9bd69
+size 1754

--- a/vt/reference/replacetransition/rect-mask-absolute-position-02.webp
+++ b/vt/reference/replacetransition/rect-mask-absolute-position-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:237f10a529638bf4c09daf2f64e24c4413470b42e1f6a4e240dbc055735ad896
+size 1752

--- a/vt/reference/replacetransition/rect-mask-absolute-position-03.webp
+++ b/vt/reference/replacetransition/rect-mask-absolute-position-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:577b29299bae2e9806e4037207b108ebb5bff2954bfb97570901d75f35f7d246
+size 1750

--- a/vt/reference/replacetransition/rect-push-left-02.webp
+++ b/vt/reference/replacetransition/rect-push-left-02.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45fe355fc4af185d63228881b5c2a86c47995d19ed6754f5554bf75bcbb34144
-size 1852
+oid sha256:5d89fa2ef550decf458c7c204f7aebefc4450111d3b5bdfedb09e34ac1dea76f
+size 1878

--- a/vt/reference/replacetransition/rect-push-left-03.webp
+++ b/vt/reference/replacetransition/rect-push-left-03.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71356cf21d1adf84c50ee4b4b18216a75a697021ef0eec96fb0a7083be0a4c33
-size 1864
+oid sha256:df4a488eb05dd18319de3929777ca9c90092dbd011437385034fbaf25c7c3cb3
+size 1872

--- a/vt/reference/replacetransition/rect-push-mask-dissolve-02.webp
+++ b/vt/reference/replacetransition/rect-push-mask-dissolve-02.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63fcb2773a0090125ccb2eae5fb6519f09e6b214a7cce3a5a1258e99c8786113
-size 5744
+oid sha256:9bf95dc1764f135a1b0e26426025929ce53b7b77ddb616bd6eee900500dd90f7
+size 6254

--- a/vt/reference/replacetransition/rect-same-id-transition-handoff-02.webp
+++ b/vt/reference/replacetransition/rect-same-id-transition-handoff-02.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01b79345c694f720c14c2fd3fbb7b597751fcd98eb9a202dd086413f07495fe0
-size 1844
+oid sha256:21f7d6aa9d0c7c2e513a5318141010b37fc438a70d447cb263e52d2d2df1d5ea
+size 1848

--- a/vt/reference/replacetransition/rect-tween-enter-02.webp
+++ b/vt/reference/replacetransition/rect-tween-enter-02.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9c2201190772167caa77f8d3200a0bfdc7cadcd8c4f507e64b700a08f3e2cdf4
-size 1792
+oid sha256:d03f0e7b909ca3ae6a79020f00aafb6b7887a71659d224503d8a12096ed59fed
+size 1812

--- a/vt/reference/replacetransition/rect-tween-exit-02.webp
+++ b/vt/reference/replacetransition/rect-tween-exit-02.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b88a486b6425007a95a209d4df76e55e3c68ecb9006dedcb416d6efc091c1591
-size 1804
+oid sha256:4863e26fb8e6cac92f3a1de404df40864e065cbb430cc20a10a74a190baf71bc
+size 1818

--- a/vt/specs/containertransition/render-abortion-test.yaml
+++ b/vt/specs/containertransition/render-abortion-test.yaml
@@ -60,22 +60,22 @@ states:
                   value: 1
                   easing: linear
             translateX:
-              initialValue: -0.0390625
+              initialValue: -0.16666666666666666
               keyframes:
                 - duration: 1000
-                  value: 0.0390625
+                  value: 0.16666666666666666
                   easing: linear
                 - duration: 1000
-                  value: 0.1171875
+                  value: 0.5
                   easing: linear
             translateY:
-              initialValue: -0.06944444444444445
+              initialValue: -0.25
               keyframes:
                 - duration: 1000
-                  value: 0.06944444444444445
+                  value: 0.25
                   easing: linear
                 - duration: 1000
-                  value: 0.20833333333333334
+                  value: 0.75
                   easing: linear
   - elements:
       - id: container-render-test

--- a/vt/specs/recttransition/render-abortion-test.yaml
+++ b/vt/specs/recttransition/render-abortion-test.yaml
@@ -53,22 +53,22 @@ states:
                   value: 1
                   easing: linear
             translateX:
-              initialValue: -0.0390625
+              initialValue: -0.25
               keyframes:
                 - duration: 1000
-                  value: 0.0390625
+                  value: 0.25
                   easing: linear
                 - duration: 1000
-                  value: 0.1171875
+                  value: 0.75
                   easing: linear
             translateY:
-              initialValue: -0.06944444444444445
+              initialValue: -0.25
               keyframes:
                 - duration: 1000
-                  value: 0.06944444444444445
+                  value: 0.25
                   easing: linear
                 - duration: 1000
-                  value: 0.20833333333333334
+                  value: 0.75
                   easing: linear
   - elements:
       - id: rect-render-test

--- a/vt/specs/replacetransition/rect-mask-absolute-position.yaml
+++ b/vt/specs/replacetransition/rect-mask-absolute-position.yaml
@@ -1,0 +1,64 @@
+---
+title: Rect Mask Absolute Position
+description: A masked transition with an absolute x tween that moves outside the original snapshot bounds
+specs:
+  - masked transitions should size their offscreen frame to include absolute position tween extents
+  - the incoming rect should be visible at 500ms while it is outside the original rect bounds
+  - replace should finish on the next rect state after 1000ms
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - id: mask-position-start
+    elements:
+      - id: rect1
+        type: rect
+        x: 160
+        "y": 220
+        width: 180
+        height: 180
+        fill: "#F2F2F2"
+        alpha: 1
+  - id: mask-position-end
+    elements:
+      - id: rect1
+        type: rect
+        x: 160
+        "y": 220
+        width: 180
+        height: 180
+        fill: "#4D4D4D"
+        alpha: 1
+    animations:
+      - id: rect-mask-position
+        targetId: rect1
+        type: transition
+        next:
+          tween:
+            x:
+              initialValue: 760
+              keyframes:
+                - duration: 1000
+                  value: 160
+                  easing: linear
+        mask:
+          kind: single
+          texture: mask-full
+          channel: red
+          progress:
+            initialValue: 0
+            keyframes:
+              - duration: 1000
+                value: 1
+                easing: linear

--- a/vt/specs/spritetransition/render-abortion-test.yaml
+++ b/vt/specs/spritetransition/render-abortion-test.yaml
@@ -54,22 +54,22 @@ states:
                   value: 1
                   easing: linear
             translateX:
-              initialValue: -0.0390625
+              initialValue: -0.3333333333333333
               keyframes:
                 - duration: 1000
-                  value: 0.0390625
+                  value: 0.3333333333333333
                   easing: linear
                 - duration: 1000
-                  value: 0.1171875
+                  value: 1
                   easing: linear
             translateY:
-              initialValue: -0.06944444444444445
+              initialValue: -0.3333333333333333
               keyframes:
                 - duration: 1000
-                  value: 0.06944444444444445
+                  value: 0.3333333333333333
                   easing: linear
                 - duration: 1000
-                  value: 0.20833333333333334
+                  value: 1
                   easing: linear
   - elements:
       - id: sprite-render-test

--- a/vt/specs/textbasictransition/render-abortion-test.yaml
+++ b/vt/specs/textbasictransition/render-abortion-test.yaml
@@ -46,22 +46,22 @@ states:
         next:
           tween:
             translateX:
-              initialValue: -0.0390625
+              initialValue: -1
               keyframes:
                 - duration: 1000
-                  value: 0.0390625
+                  value: 0.5
                   easing: linear
                 - duration: 1000
-                  value: 0.1171875
+                  value: 1
                   easing: linear
             translateY:
-              initialValue: -0.06944444444444445
+              initialValue: -1
               keyframes:
                 - duration: 1000
-                  value: 0.027777777777777776
+                  value: 0.5
                   easing: linear
                 - duration: 1000
-                  value: 0.1388888888888889
+                  value: 1
                   easing: linear
   - elements:
       - id: text-render-test


### PR DESCRIPTION
## Summary
- support both absolute x/y and subject-relative translateX/translateY on update and transition tweens
- validate ambiguous x + translateX and y + translateY combinations during animation normalization and schema validation
- change transition translateX/Y from renderer-size scaling to subject-size scaling and update docs/specs
- bump package version to 1.17.6

## Verification
- bun run lint
- bun run build
- bun run test