### PR TITLE
Implement element rotation transforms

### DIFF
--- a/playground/pages/docs/nodes/container.md
+++ b/playground/pages/docs/nodes/container.md
@@ -15,30 +15,32 @@ Try it in the [Playground](/playground/?template=container-layout).
 
 ## Field Reference
 
-| Field        | Type                                     | Required            | Default                  | Notes                                                               |
-| ------------ | ---------------------------------------- | ------------------- | ------------------------ | ------------------------------------------------------------------- |
-| `id`         | string                                   | Yes                 | -                        | Element id.                                                         |
-| `type`       | string                                   | Yes                 | -                        | Must be `container`.                                                |
-| `x`          | number                                   | Yes (public schema) | `0` at runtime           | Position before anchor transform.                                   |
-| `y`          | number                                   | Yes (public schema) | `0` at runtime           | Position before anchor transform.                                   |
-| `width`      | number                                   | No                  | auto                     | Derived from children if omitted.                                   |
-| `height`     | number                                   | No                  | auto                     | Derived from children if omitted.                                   |
-| `anchorX`    | number                                   | No                  | `0`                      | For containers, use `0`, `0.5`, or `1`.                             |
-| `anchorY`    | number                                   | No                  | `0`                      | For containers, use `0`, `0.5`, or `1`.                             |
-| `alpha`      | number                                   | No                  | `1`                      | Opacity `0..1`.                                                     |
-| `blur`       | object                                   | No                  | -                        | Directional Gaussian blur applied to the whole subtree.             |
-| `children`   | array                                    | No                  | `[]`                     | Any registered element plugin type can be nested.                   |
-| `direction`  | `absolute` \| `horizontal` \| `vertical` | No                  | `absolute`               | Auto-positioning for children in non-absolute modes.                |
-| `gapX`       | number                                   | No                  | `0`                      | Horizontal spacing between children, and between wrapped columns.   |
-| `gapY`       | number                                   | No                  | `0`                      | Vertical spacing between children, and between wrapped rows.        |
-| `rotation`   | number                                   | No                  | `0`                      | Degrees.                                                            |
-| `scroll`     | boolean                                  | No                  | `false`                  | Enables clipping and wheel scrolling for overflow.                  |
-| `scrollbar`  | object                                   | No                  | -                        | Optional custom vertical scrollbar chrome for overflow.             |
-| `hover`      | object                                   | No                  | -                        | Hover event config. Supports `inheritToChildren`.                   |
-| `click`      | object                                   | No                  | -                        | Click event config. Supports `inheritToChildren`.                   |
-| `rightClick` | object                                   | No                  | -                        | Right click event config. Supports `inheritToChildren`.             |
-| `scrollUp`   | object                                   | No                  | -                        | Wheel-up payload hook.                                              |
-| `scrollDown` | object                                   | No                  | -                        | Wheel-down payload hook.                                            |
+| Field        | Type                                     | Required            | Default        | Notes                                                             |
+| ------------ | ---------------------------------------- | ------------------- | -------------- | ----------------------------------------------------------------- |
+| `id`         | string                                   | Yes                 | -              | Element id.                                                       |
+| `type`       | string                                   | Yes                 | -              | Must be `container`.                                              |
+| `x`          | number                                   | Yes (public schema) | `0` at runtime | Position before anchor transform.                                 |
+| `y`          | number                                   | Yes (public schema) | `0` at runtime | Position before anchor transform.                                 |
+| `width`      | number                                   | No                  | auto           | Derived from children if omitted.                                 |
+| `height`     | number                                   | No                  | auto           | Derived from children if omitted.                                 |
+| `anchorX`    | number                                   | No                  | `0`            | For containers, use `0`, `0.5`, or `1`.                           |
+| `anchorY`    | number                                   | No                  | `0`            | For containers, use `0`, `0.5`, or `1`.                           |
+| `originX`    | number                                   | No                  | anchor         | Transform origin X in pixels.                                     |
+| `originY`    | number                                   | No                  | anchor         | Transform origin Y in pixels.                                     |
+| `alpha`      | number                                   | No                  | `1`            | Opacity `0..1`.                                                   |
+| `blur`       | object                                   | No                  | -              | Directional Gaussian blur applied to the whole subtree.           |
+| `children`   | array                                    | No                  | `[]`           | Any registered element plugin type can be nested.                 |
+| `direction`  | `absolute` \| `horizontal` \| `vertical` | No                  | `absolute`     | Auto-positioning for children in non-absolute modes.              |
+| `gapX`       | number                                   | No                  | `0`            | Horizontal spacing between children, and between wrapped columns. |
+| `gapY`       | number                                   | No                  | `0`            | Vertical spacing between children, and between wrapped rows.      |
+| `rotation`   | number                                   | No                  | `0`            | Degrees.                                                          |
+| `scroll`     | boolean                                  | No                  | `false`        | Enables clipping and wheel scrolling for overflow.                |
+| `scrollbar`  | object                                   | No                  | -              | Optional custom vertical scrollbar chrome for overflow.           |
+| `hover`      | object                                   | No                  | -              | Hover event config. Supports `inheritToChildren`.                 |
+| `click`      | object                                   | No                  | -              | Click event config. Supports `inheritToChildren`.                 |
+| `rightClick` | object                                   | No                  | -              | Right click event config. Supports `inheritToChildren`.           |
+| `scrollUp`   | object                                   | No                  | -              | Wheel-up payload hook.                                            |
+| `scrollDown` | object                                   | No                  | -              | Wheel-down payload hook.                                          |
 
 ## Layout Behavior Notes
 
@@ -106,12 +108,12 @@ Each visual object supports:
 
 ## Emitted Events
 
-| Event Name   | Fired When               | Payload Shape                               |
-| ------------ | ------------------------ | ------------------------------------------- |
-| `hover`      | pointer enters container | `{ _event: { id }, ...hover.payload }`      |
-| `click`      | pointer up               | `{ _event: { id }, ...click.payload }`      |
-| `rightClick` | right click              | `{ _event: { id }, ...rightClick.payload }` |
-| `scrollUp`   | wheel up over container  | `{ _event: { id }, ...scrollUp.payload }`   |
+| Event Name   | Fired When                | Payload Shape                               |
+| ------------ | ------------------------- | ------------------------------------------- |
+| `hover`      | pointer enters container  | `{ _event: { id }, ...hover.payload }`      |
+| `click`      | pointer up                | `{ _event: { id }, ...click.payload }`      |
+| `rightClick` | right click               | `{ _event: { id }, ...rightClick.payload }` |
+| `scrollUp`   | wheel up over container   | `{ _event: { id }, ...scrollUp.payload }`   |
 | `scrollDown` | wheel down over container | `{ _event: { id }, ...scrollDown.payload }` |
 
 ## Hover Inheritance

--- a/playground/pages/docs/nodes/rect.md
+++ b/playground/pages/docs/nodes/rect.md
@@ -25,6 +25,8 @@ Try it in the [Playground](/playground/?template=basic-shapes).
 | `y`          | number | No       | `0`     | Position before anchor transform.   |
 | `anchorX`    | number | No       | `0`     | Anchor offset ratio.                |
 | `anchorY`    | number | No       | `0`     | Anchor offset ratio.                |
+| `originX`    | number | No       | anchor  | Transform origin X in pixels.       |
+| `originY`    | number | No       | anchor  | Transform origin Y in pixels.       |
 | `alpha`      | number | No       | `1`     | Opacity `0..1`.                     |
 | `fill`       | string | No       | `white` | Fill color.                         |
 | `border`     | object | No       | -       | Border config.                      |

--- a/playground/pages/docs/nodes/sprite.md
+++ b/playground/pages/docs/nodes/sprite.md
@@ -26,7 +26,10 @@ Try it in the [Playground](/playground/?template=sprite-demo).
 | `src`        | string | No                  | `""`           | Asset alias or URL.                         |
 | `anchorX`    | number | No                  | `0`            | Anchor offset ratio.                        |
 | `anchorY`    | number | No                  | `0`            | Anchor offset ratio.                        |
+| `originX`    | number | No                  | anchor         | Transform origin X in pixels.               |
+| `originY`    | number | No                  | anchor         | Transform origin Y in pixels.               |
 | `alpha`      | number | No                  | `1`            | Opacity `0..1`.                             |
+| `rotation`   | number | No                  | `0`            | Degrees.                                    |
 | `blur`       | object | No                  | -              | Directional Gaussian blur.                  |
 | `hover`      | object | No                  | -              | Optional hover image/sound/cursor/payload.  |
 | `click`      | object | No                  | -              | Optional pressed image/sound/payload.       |
@@ -38,22 +41,22 @@ Try it in the [Playground](/playground/?template=sprite-demo).
 
 `blur` requires explicit horizontal and vertical axes. There is no scalar shorthand.
 
-| Field              | Type    | Required | Default | Notes                                           |
-| ------------------ | ------- | -------- | ------- | ----------------------------------------------- |
-| `x`                | number  | Yes      | -       | Horizontal blur strength in pixels.             |
-| `y`                | number  | Yes      | -       | Vertical blur strength in pixels.               |
+| Field              | Type    | Required | Default | Notes                                             |
+| ------------------ | ------- | -------- | ------- | ------------------------------------------------- |
+| `x`                | number  | Yes      | -       | Horizontal blur strength in pixels.               |
+| `y`                | number  | Yes      | -       | Vertical blur strength in pixels.                 |
 | `quality`          | number  | No       | `4`     | Number of blur passes. Higher is smoother/slower. |
-| `kernelSize`       | number  | No       | `5`     | One of `5`, `7`, `9`, `11`, `13`, `15`.         |
+| `kernelSize`       | number  | No       | `5`     | One of `5`, `7`, `9`, `11`, `13`, `15`.           |
 | `repeatEdgePixels` | boolean | No       | `false` | Clamp edge pixels instead of padding blur bounds. |
 
 ## Emitted Events
 
-| Event Name   | Fired When            | Payload Shape                               |
-| ------------ | --------------------- | ------------------------------------------- |
-| `hover`      | pointer enters sprite | `{ _event: { id }, ...hover.payload }`      |
-| `click`      | pointer up            | `{ _event: { id }, ...click.payload }`      |
-| `rightClick` | right pointer up      | `{ _event: { id }, ...rightClick.payload }` |
-| `scrollUp`   | wheel up over sprite  | `{ _event: { id }, ...scrollUp.payload }`   |
+| Event Name   | Fired When             | Payload Shape                               |
+| ------------ | ---------------------- | ------------------------------------------- |
+| `hover`      | pointer enters sprite  | `{ _event: { id }, ...hover.payload }`      |
+| `click`      | pointer up             | `{ _event: { id }, ...click.payload }`      |
+| `rightClick` | right pointer up       | `{ _event: { id }, ...rightClick.payload }` |
+| `scrollUp`   | wheel up over sprite   | `{ _event: { id }, ...scrollUp.payload }`   |
 | `scrollDown` | wheel down over sprite | `{ _event: { id }, ...scrollDown.payload }` |
 
 ## Example: Minimal

--- a/spec/animations/animationBus.spec.js
+++ b/spec/animations/animationBus.spec.js
@@ -216,6 +216,39 @@ describe("animationBus auto tween shorthand", () => {
     expect(element._routeGraphicsBlur.y).toBeCloseTo(4);
   });
 
+  it("uses degree values for rotation tweens while applying Pixi radians", () => {
+    const animationBus = createAnimationBus();
+    const element = {
+      rotation: Math.PI / 2,
+    };
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "auto-rotation",
+        element,
+        properties: {
+          rotation: {
+            auto: {
+              duration: 200,
+              easing: "linear",
+            },
+          },
+        },
+        targetState: { rotation: 180 },
+      },
+    });
+
+    animationBus.flush();
+    expect(element.rotation).toBeCloseTo(Math.PI / 2);
+
+    animationBus.tick(100);
+    expect(element.rotation).toBeCloseTo((3 * Math.PI) / 4);
+
+    animationBus.tick(100);
+    expect(element.rotation).toBeCloseTo(Math.PI);
+  });
+
   it("applies translate tweens relative to the subject dimensions", () => {
     const animationBus = createAnimationBus();
     const element = {

--- a/spec/animations/runReplaceAnimation.spec.js
+++ b/spec/animations/runReplaceAnimation.spec.js
@@ -225,6 +225,73 @@ describe("runReplaceAnimation", () => {
     expect(tracker.complete).toHaveBeenCalledWith(11);
   });
 
+  it("applies transition rotation tween values as degree deltas", () => {
+    const parent = createParent();
+    const nextDisplayObject = createDisplayObject("scene-root");
+
+    const plugin = {
+      add: vi.fn(({ parent: targetParent, element }) => {
+        nextDisplayObject.label = element.id;
+        targetParent.addChild(nextDisplayObject);
+      }),
+      delete: vi.fn(),
+    };
+
+    const animationBus = {
+      dispatch: vi.fn(),
+    };
+    const app = {
+      renderer: {
+        width: 1280,
+        height: 720,
+        generateTexture: vi.fn(() => Texture.EMPTY),
+      },
+    };
+
+    runReplaceAnimation({
+      app,
+      parent,
+      prevElement: null,
+      nextElement: {
+        id: "scene-root",
+        type: "container",
+        children: [],
+      },
+      animation: {
+        id: "scene-rotate",
+        targetId: "scene-root",
+        type: "transition",
+        next: {
+          tween: {
+            rotation: {
+              keyframes: [{ duration: 300, value: 90, easing: "linear" }],
+            },
+          },
+        },
+      },
+      animations: new Map(),
+      animationBus,
+      completionTracker: {
+        getVersion: () => 0,
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      eventHandler: vi.fn(),
+      elementPlugins: [],
+      plugin,
+      zIndex: 0,
+      signal: new AbortController().signal,
+    });
+
+    const dispatched = animationBus.dispatch.mock.calls[0][0];
+    const overlay = parent.children[1];
+    const wrapper = overlay.children[0];
+
+    dispatched.payload.applyFrame(300);
+
+    expect(wrapper.rotation).toBeCloseTo(Math.PI / 2);
+  });
+
   it("runs persistent transitions without tracking render completion", () => {
     const parent = createParent();
     const nextDisplayObject = createDisplayObject("scene-root");

--- a/spec/elements/addContainer.spec.js
+++ b/spec/elements/addContainer.spec.js
@@ -129,6 +129,48 @@ describe("addContainer", () => {
     });
   });
 
+  it("applies degree rotation around the computed anchor origin", () => {
+    const parent = new Container();
+
+    addContainer({
+      app: { audioStage: { add: vi.fn() } },
+      parent,
+      element: {
+        id: "container-1",
+        type: "container",
+        x: 200,
+        y: 150,
+        width: 240,
+        height: 120,
+        originX: 120,
+        originY: 60,
+        rotation: 45,
+        alpha: 1,
+        children: [],
+      },
+      animations: [],
+      eventHandler: vi.fn(),
+      animationBus: { dispatch: vi.fn() },
+      elementPlugins: [],
+      renderContext: createRenderContext(),
+      zIndex: 0,
+      completionTracker: {
+        getVersion: () => 0,
+        track: () => {},
+        complete: () => {},
+      },
+      signal: new AbortController().signal,
+    });
+
+    const container = parent.getChildByLabel("container-1");
+
+    expect(container.pivot.x).toBe(120);
+    expect(container.pivot.y).toBe(60);
+    expect(container.x).toBe(320);
+    expect(container.y).toBe(210);
+    expect(container.rotation).toBeCloseTo(Math.PI / 4);
+  });
+
   it("falls back to direct child add when sibling ids are duplicated", () => {
     const parent = new Container();
     const renderContext = createRenderContext();

--- a/spec/elements/addRect.spec.js
+++ b/spec/elements/addRect.spec.js
@@ -45,4 +45,96 @@ describe("addRect", () => {
     expect(rectElement.width).toBe(element.width);
     expect(rectElement.height).toBe(element.height);
   });
+
+  it("applies degree rotation around the computed anchor origin", () => {
+    const parent = new Container();
+    const element = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 300,
+        y: 200,
+        width: 120,
+        height: 80,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        fill: "#737373",
+        alpha: 1,
+        rotation: 90,
+      },
+    });
+
+    addRect({
+      app: {
+        audioStage: { add: vi.fn() },
+      },
+      parent,
+      element,
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker: {
+        getVersion: () => 0,
+        track: () => {},
+        complete: () => {},
+      },
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    const rectElement = parent.getChildByLabel("rect-1");
+
+    expect(rectElement.pivot.x).toBe(60);
+    expect(rectElement.pivot.y).toBe(40);
+    expect(rectElement.x).toBe(300);
+    expect(rectElement.y).toBe(200);
+    expect(rectElement.rotation).toBeCloseTo(Math.PI / 2);
+  });
+
+  it("uses explicit origin independently from anchor for rotation", () => {
+    const parent = new Container();
+    const element = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 300,
+        y: 200,
+        width: 120,
+        height: 80,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        originX: 0,
+        originY: 80,
+        fill: "#737373",
+        alpha: 1,
+        rotation: 45,
+      },
+    });
+
+    addRect({
+      app: {
+        audioStage: { add: vi.fn() },
+      },
+      parent,
+      element,
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker: {
+        getVersion: () => 0,
+        track: () => {},
+        complete: () => {},
+      },
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    const rectElement = parent.getChildByLabel("rect-1");
+
+    expect(element.x).toBe(240);
+    expect(element.y).toBe(160);
+    expect(rectElement.pivot.x).toBe(0);
+    expect(rectElement.pivot.y).toBe(80);
+    expect(rectElement.x).toBe(240);
+    expect(rectElement.y).toBe(240);
+    expect(rectElement.rotation).toBeCloseTo(Math.PI / 4);
+  });
 });

--- a/spec/elements/addSprite.spec.js
+++ b/spec/elements/addSprite.spec.js
@@ -1,0 +1,53 @@
+import { Container } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
+import { addSprite } from "../../src/plugins/elements/sprite/addSprite.js";
+import { parseSprite } from "../../src/plugins/elements/sprite/parseSprite.js";
+
+describe("addSprite", () => {
+  it("uses explicit origin independently from anchor for rotation", () => {
+    const parent = new Container();
+    const element = parseSprite({
+      state: {
+        id: "sprite-1",
+        type: "sprite",
+        x: 300,
+        y: 200,
+        width: 120,
+        height: 80,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        originX: 0,
+        originY: 80,
+        alpha: 1,
+        rotation: 45,
+      },
+    });
+
+    addSprite({
+      app: {
+        audioStage: { add: vi.fn() },
+      },
+      parent,
+      element,
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker: {
+        getVersion: () => 0,
+        track: () => {},
+        complete: () => {},
+      },
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    const spriteElement = parent.getChildByLabel("sprite-1");
+
+    expect(element.x).toBe(240);
+    expect(element.y).toBe(160);
+    expect(spriteElement.pivot.x).toBe(0);
+    expect(spriteElement.pivot.y * spriteElement.scale.y).toBeCloseTo(80);
+    expect(spriteElement.x).toBe(240);
+    expect(spriteElement.y).toBe(240);
+    expect(spriteElement.rotation).toBeCloseTo(Math.PI / 4);
+  });
+});

--- a/spec/elements/updateContainer.spec.js
+++ b/spec/elements/updateContainer.spec.js
@@ -121,6 +121,61 @@ describe("updateContainer", () => {
     expect(containerElement.hitArea.height).toBe(200);
   });
 
+  it("applies updated rotation around the computed anchor origin", () => {
+    const parent = new Container();
+    const containerElement = new Container();
+    containerElement.label = "container-1";
+    parent.addChild(containerElement);
+
+    updateContainer({
+      app: { audioStage: { add: vi.fn() } },
+      parent,
+      prevElement: {
+        id: "container-1",
+        type: "container",
+        x: 0,
+        y: 0,
+        width: 240,
+        height: 120,
+        originX: 120,
+        originY: 60,
+        rotation: 0,
+        alpha: 1,
+        children: [],
+      },
+      nextElement: {
+        id: "container-1",
+        type: "container",
+        x: 200,
+        y: 150,
+        width: 240,
+        height: 120,
+        originX: 120,
+        originY: 60,
+        rotation: 45,
+        alpha: 1,
+        children: [],
+      },
+      eventHandler: vi.fn(),
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      elementPlugins: [],
+      zIndex: 0,
+      completionTracker: {
+        getVersion: () => 0,
+        track: () => {},
+        complete: () => {},
+      },
+      signal: new AbortController().signal,
+    });
+
+    expect(containerElement.pivot.x).toBe(120);
+    expect(containerElement.pivot.y).toBe(60);
+    expect(containerElement.x).toBe(320);
+    expect(containerElement.y).toBe(210);
+    expect(containerElement.rotation).toBeCloseTo(Math.PI / 4);
+  });
+
   it("rebuilds scrolling and anchors to bottom when messages are appended", () => {
     const parent = new Container();
     const containerElement = new Container();

--- a/spec/elements/updateRect.spec.js
+++ b/spec/elements/updateRect.spec.js
@@ -227,4 +227,314 @@ describe("updateRect", () => {
     expect(rectElement.width).toBe(nextElement.width);
     expect(rectElement.height).toBe(nextElement.height);
   });
+
+  it("applies updated rotation around the computed anchor origin", () => {
+    const parent = new Container();
+    const rectElement = new Graphics();
+    rectElement.label = "rect-1";
+    parent.addChild(rectElement);
+
+    const prevElement = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 300,
+        y: 200,
+        width: 120,
+        height: 80,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        fill: "#737373",
+        alpha: 1,
+        rotation: 0,
+      },
+    });
+    const nextElement = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 320,
+        y: 240,
+        width: 120,
+        height: 80,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        fill: "#737373",
+        alpha: 1,
+        rotation: 90,
+      },
+    });
+
+    updateRect({
+      app: {
+        audioStage: { add: vi.fn() },
+      },
+      parent,
+      prevElement,
+      nextElement,
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker: {
+        getVersion: () => 0,
+        track: () => {},
+        complete: () => {},
+      },
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    expect(rectElement.pivot.x).toBe(60);
+    expect(rectElement.pivot.y).toBe(40);
+    expect(rectElement.x).toBe(320);
+    expect(rectElement.y).toBe(240);
+    expect(rectElement.rotation).toBeCloseTo(Math.PI / 2);
+  });
+
+  it("uses explicit origin independently from anchor when applying rotation", () => {
+    const parent = new Container();
+    const rectElement = new Graphics();
+    rectElement.label = "rect-1";
+    parent.addChild(rectElement);
+
+    const prevElement = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 300,
+        y: 200,
+        width: 120,
+        height: 80,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        originX: 0,
+        originY: 80,
+        fill: "#737373",
+        alpha: 1,
+        rotation: 0,
+      },
+    });
+    const nextElement = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 320,
+        y: 240,
+        width: 120,
+        height: 80,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        originX: 0,
+        originY: 80,
+        fill: "#737373",
+        alpha: 1,
+        rotation: 45,
+      },
+    });
+
+    updateRect({
+      app: {
+        audioStage: { add: vi.fn() },
+      },
+      parent,
+      prevElement,
+      nextElement,
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker: {
+        getVersion: () => 0,
+        track: () => {},
+        complete: () => {},
+      },
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    expect(nextElement.x).toBe(260);
+    expect(nextElement.y).toBe(200);
+    expect(rectElement.pivot.x).toBe(0);
+    expect(rectElement.pivot.y).toBe(80);
+    expect(rectElement.x).toBe(260);
+    expect(rectElement.y).toBe(280);
+    expect(rectElement.rotation).toBeCloseTo(Math.PI / 4);
+  });
+
+  it("dispatches auto rotation tweens with degree target values", () => {
+    const parent = new Container();
+    const rectElement = new Graphics();
+    rectElement.label = "rect-1";
+    parent.addChild(rectElement);
+
+    const animationBus = { dispatch: vi.fn() };
+    const prevElement = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 300,
+        y: 200,
+        width: 120,
+        height: 80,
+        fill: "#737373",
+        alpha: 1,
+        rotation: 0,
+      },
+    });
+    const nextElement = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 300,
+        y: 200,
+        width: 120,
+        height: 80,
+        fill: "#737373",
+        alpha: 1,
+        rotation: 90,
+      },
+    });
+
+    updateRect({
+      app: {
+        audioStage: { add: vi.fn() },
+      },
+      parent,
+      prevElement,
+      nextElement,
+      animations: [
+        {
+          id: "rect-rotation-auto",
+          targetId: "rect-1",
+          type: "update",
+          tween: {
+            rotation: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+          },
+        },
+      ],
+      animationBus,
+      completionTracker: {
+        getVersion: vi.fn().mockReturnValue(1),
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    expect(animationBus.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "START",
+        payload: expect.objectContaining({
+          id: "rect-rotation-auto",
+          targetState: expect.objectContaining({
+            rotation: 90,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("dispatches auto transform targets using explicit origin coordinates", () => {
+    const parent = new Container();
+    const rectElement = new Graphics();
+    rectElement.label = "rect-1";
+    parent.addChild(rectElement);
+
+    const animationBus = { dispatch: vi.fn() };
+    const prevElement = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 300,
+        y: 200,
+        width: 120,
+        height: 80,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        originX: 0,
+        originY: 80,
+        fill: "#737373",
+        alpha: 1,
+        rotation: 0,
+      },
+    });
+    const nextElement = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 320,
+        y: 240,
+        width: 120,
+        height: 80,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        originX: 0,
+        originY: 80,
+        fill: "#737373",
+        alpha: 1,
+        rotation: 90,
+      },
+    });
+
+    updateRect({
+      app: {
+        audioStage: { add: vi.fn() },
+      },
+      parent,
+      prevElement,
+      nextElement,
+      animations: [
+        {
+          id: "rect-transform-auto",
+          targetId: "rect-1",
+          type: "update",
+          tween: {
+            x: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+            y: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+            rotation: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+          },
+        },
+      ],
+      animationBus,
+      completionTracker: {
+        getVersion: vi.fn().mockReturnValue(1),
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    expect(animationBus.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "START",
+        payload: expect.objectContaining({
+          id: "rect-transform-auto",
+          targetState: expect.objectContaining({
+            x: 260,
+            y: 280,
+            rotation: 90,
+          }),
+        }),
+      }),
+    );
+  });
 });

--- a/spec/elements/updateSprite.spec.js
+++ b/spec/elements/updateSprite.spec.js
@@ -209,4 +209,165 @@ describe("updateSprite", () => {
     expect(spriteElement.width).toBe(80);
     expect(spriteElement.height).toBe(60);
   });
+
+  it("dispatches auto rotation tweens with degree target values", () => {
+    const spriteElement = {
+      label: "sprite-1",
+      texture: { src: "sprite" },
+      x: 10,
+      y: 20,
+      width: 80,
+      height: 60,
+      alpha: 1,
+      rotation: 0,
+      zIndex: 0,
+      removeAllListeners: vi.fn(),
+      on: vi.fn(),
+    };
+    const animationBus = { dispatch: vi.fn() };
+
+    updateSprite({
+      app: {
+        audioStage: { add: vi.fn() },
+      },
+      parent: {
+        children: [spriteElement],
+      },
+      prevElement: {
+        id: "sprite-1",
+        type: "sprite",
+        src: "sprite",
+        x: 10,
+        y: 20,
+        width: 80,
+        height: 60,
+        alpha: 1,
+        rotation: 0,
+      },
+      nextElement: {
+        id: "sprite-1",
+        type: "sprite",
+        src: "sprite",
+        x: 10,
+        y: 20,
+        width: 80,
+        height: 60,
+        alpha: 1,
+        rotation: 180,
+      },
+      animations: [
+        {
+          id: "sprite-rotation-auto",
+          targetId: "sprite-1",
+          type: "update",
+          tween: {
+            rotation: {
+              auto: {
+                duration: 300,
+                easing: "linear",
+              },
+            },
+          },
+        },
+      ],
+      animationBus,
+      completionTracker: {
+        getVersion: vi.fn().mockReturnValue(1),
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      eventHandler: vi.fn(),
+      zIndex: 4,
+    });
+
+    expect(animationBus.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "START",
+        payload: expect.objectContaining({
+          id: "sprite-rotation-auto",
+          targetState: expect.objectContaining({
+            rotation: 180,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("uses explicit origin independently from anchor when applying rotation", () => {
+    const spriteElement = {
+      label: "sprite-1",
+      texture: { src: "sprite" },
+      x: 10,
+      y: 20,
+      width: 80,
+      height: 60,
+      alpha: 1,
+      rotation: 0,
+      pivot: {
+        x: 0,
+        y: 0,
+        set(x, y) {
+          this.x = x;
+          this.y = y;
+        },
+      },
+      scale: {
+        x: 1,
+        y: 1,
+      },
+      zIndex: 0,
+      removeAllListeners: vi.fn(),
+      on: vi.fn(),
+    };
+
+    updateSprite({
+      app: {
+        audioStage: { add: vi.fn() },
+      },
+      parent: {
+        children: [spriteElement],
+      },
+      prevElement: {
+        id: "sprite-1",
+        type: "sprite",
+        src: "sprite",
+        x: 240,
+        y: 160,
+        width: 120,
+        height: 80,
+        originX: 0,
+        originY: 80,
+        alpha: 1,
+        rotation: 0,
+      },
+      nextElement: {
+        id: "sprite-1",
+        type: "sprite",
+        src: "sprite",
+        x: 260,
+        y: 200,
+        width: 120,
+        height: 80,
+        originX: 0,
+        originY: 80,
+        alpha: 1,
+        rotation: 45,
+      },
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker: {
+        getVersion: () => 0,
+        track: () => {},
+        complete: () => {},
+      },
+      eventHandler: vi.fn(),
+      zIndex: 4,
+    });
+
+    expect(spriteElement.pivot.x).toBe(0);
+    expect(spriteElement.pivot.y).toBe(80);
+    expect(spriteElement.x).toBe(260);
+    expect(spriteElement.y).toBe(280);
+    expect(spriteElement.rotation).toBeCloseTo(Math.PI / 4);
+  });
 });

--- a/spec/parser/parseCommonObject.test.yaml
+++ b/spec/parser/parseCommonObject.test.yaml
@@ -61,6 +61,29 @@ in:
     anchorY: 0.5
 throws: "Input Error: Width or height is missing"
 ---
+case: Explicit origin overrides anchor-derived transform origin without changing anchored position
+in:
+  - id: origin-override
+    type: rect
+    x: 200
+    "y": 120
+    width: 80
+    height: 40
+    anchorX: 0.5
+    anchorY: 0.5
+    originX: 10
+    originY: 30
+out:
+  id: origin-override
+  type: rect
+  width: 80
+  height: 40
+  x: 160
+  "y": 100
+  originX: 10
+  originY: 30
+  alpha: 1
+---
 case: Parsing object with no id
 in:
   - type: text

--- a/spec/parser/parseContainer.test.yaml
+++ b/spec/parser/parseContainer.test.yaml
@@ -100,6 +100,38 @@ out:
       rotation: 90
       alpha: 1
 ---
+case: Test parsing container with explicit origin independent of anchor
+in:
+  - state:
+      id: container-origin
+      type: container
+      x: 300
+      "y": 200
+      width: 120
+      height: 80
+      anchorX: 0.5
+      anchorY: 0.5
+      originX: 0
+      originY: 80
+      rotation: 30
+      children: []
+out:
+  id: container-origin
+  type: container
+  direction: absolute
+  gapX: 0
+  gapY: 0
+  width: 120
+  height: 80
+  x: 240
+  "y": 160
+  originX: 0
+  originY: 80
+  scroll: false
+  rotation: 30
+  alpha: 1
+  children: []
+---
 case: Test parsing container hover inheritance config
 in:
   - state:

--- a/spec/parser/parseRect.test.yaml
+++ b/spec/parser/parseRect.test.yaml
@@ -74,6 +74,34 @@ out:
   rotation: 90
   alpha: 1
 ---
+case: Test parsing rect with explicit origin independent of anchor
+in:
+  - state:
+      id: rect-origin
+      type: rect
+      width: 80
+      height: 100
+      x: 240
+      "y": 240
+      anchorX: 0.5
+      anchorY: 0.5
+      originX: 0
+      originY: 100
+      fill: red
+      rotation: 45
+out:
+  id: rect-origin
+  type: rect
+  width: 80
+  height: 100
+  x: 200
+  "y": 190
+  originX: 0
+  originY: 100
+  fill: red
+  rotation: 45
+  alpha: 1
+---
 case: Test parsing rect with border property but only have alpha value
 in:
   - state:

--- a/spec/parser/parseSprite.test.yaml
+++ b/spec/parser/parseSprite.test.yaml
@@ -27,6 +27,7 @@ in:
       "y": 240
       anchorX: 0.5
       anchorY: 0.5
+      rotation: 45
       hover:
         soundSrc: sound-1
         cursor: cursor-1
@@ -50,6 +51,7 @@ out:
   originX: 48
   originY: 40
   alpha: 0.8
+  rotation: 45
   blur:
     x: 4
     "y": 8
@@ -70,6 +72,34 @@ out:
       prop3: "00"
       prop4: "22"
     src: click-src
+---
+case: Test parsing sprite with explicit origin independent of anchor
+in:
+  - state:
+      id: circle-red
+      type: sprite
+      src: file:circle-red
+      width: 80
+      height: 100
+      x: 240
+      "y": 240
+      anchorX: 0.5
+      anchorY: 0.5
+      originX: 0
+      originY: 100
+      rotation: 45
+out:
+  id: circle-red
+  type: sprite
+  width: 80
+  height: 100
+  x: 200
+  "y": 190
+  originX: 0
+  originY: 100
+  alpha: 1
+  rotation: 45
+  src: file:circle-red
 ---
 case: Test parsing sprite to see the default value of url, alpha, and interactive props
 in:
@@ -94,4 +124,5 @@ out:
   originX: 48
   originY: 40
   alpha: 1
+  rotation: 0
   src: ""

--- a/src/plugins/animations/animationPropertyUtils.js
+++ b/src/plugins/animations/animationPropertyUtils.js
@@ -1,3 +1,8 @@
+import {
+  degreesToRadians,
+  radiansToDegrees,
+} from "../elements/util/transform.js";
+
 export const isTranslateAnimationProperty = (property) =>
   property === "translateX" || property === "translateY";
 
@@ -19,7 +24,8 @@ export const getAnimationProperty = (
 
   if (typeof mappedPath === "string") {
     const result = object[mappedPath];
-    return result === undefined ? defaultValue : result;
+    if (result === undefined) return defaultValue;
+    return path === "rotation" ? radiansToDegrees(result) : result;
   }
 
   let result = object;
@@ -30,14 +36,16 @@ export const getAnimationProperty = (
     result = result[key];
   }
 
-  return result === undefined ? defaultValue : result;
+  if (result === undefined) return defaultValue;
+  return path === "rotation" ? radiansToDegrees(result) : result;
 };
 
 export const setAnimationProperty = (object, path, propertyPathMap, value) => {
   const mappedPath = getMappedPath(propertyPathMap, path);
+  const nextValue = path === "rotation" ? degreesToRadians(value) : value;
 
   if (typeof mappedPath === "string") {
-    object[mappedPath] = value;
+    object[mappedPath] = nextValue;
     return object;
   }
 
@@ -50,7 +58,7 @@ export const setAnimationProperty = (object, path, propertyPathMap, value) => {
     current = current[key];
   }
 
-  current[mappedPath[mappedPath.length - 1]] = value;
+  current[mappedPath[mappedPath.length - 1]] = nextValue;
   return object;
 };
 

--- a/src/plugins/animations/replace/runReplaceAnimation.js
+++ b/src/plugins/animations/replace/runReplaceAnimation.js
@@ -20,6 +20,7 @@ import {
 } from "../../elements/renderContext.js";
 import { cleanupParticlesInTree } from "../../elements/particles/particleRuntime.js";
 import { getAnimationContinuitySignature } from "../planAnimations.js";
+import { degreesToRadians } from "../../elements/util/transform.js";
 const DEFAULT_SUBJECT_VALUES = {
   translateX: 0,
   translateY: 0,
@@ -65,8 +66,8 @@ const createSnapshotSubject = (app, displayObject) => {
   });
 
   const sprite = new Sprite(texture);
-  sprite.x = frame.x;
-  sprite.y = frame.y;
+  sprite.x = frame.x - (displayObject.pivot?.x ?? 0);
+  sprite.y = frame.y - (displayObject.pivot?.y ?? 0);
 
   const wrapper = new Container();
   wrapper.x = displayObject.x ?? 0;
@@ -165,7 +166,7 @@ const createSubjectController = (subject, tween) => {
             wrapper.scale.y = base.scaleY * value;
             break;
           case "rotation":
-            wrapper.rotation = base.rotation + value;
+            wrapper.rotation = base.rotation + degreesToRadians(value);
             break;
         }
       }

--- a/src/plugins/elements/container/addContainer.js
+++ b/src/plugins/elements/container/addContainer.js
@@ -8,6 +8,10 @@ import {
   hasBlurUpdateAnimation,
   syncBlurEffect,
 } from "../util/blurEffect.js";
+import {
+  applyElementTransform,
+  getElementTransformTargetState,
+} from "../util/transform.js";
 
 const hasDuplicateChildIds = (children = []) => {
   const seen = new Set();
@@ -78,16 +82,15 @@ export const addContainer = ({
   completionTracker,
   signal,
 }) => {
-  const { id, x, y, children, scroll, alpha } = element;
+  const { id, children, scroll, alpha } = element;
 
   const container = new Container();
   container.label = id;
   container.zIndex = zIndex;
 
   // Apply initial state
-  container.x = Math.round(x);
-  container.y = Math.round(y);
   container.alpha = alpha;
+  applyElementTransform(container, element);
   const shouldForceBlur = hasBlurUpdateAnimation(animations, id);
   syncBlurEffect(container, element.blur, { force: shouldForceBlur });
 
@@ -148,9 +151,7 @@ export const addContainer = ({
     completionTracker,
     element: container,
     targetState: {
-      x,
-      y,
-      alpha,
+      ...getElementTransformTargetState(element, { alpha }),
       ...getBlurTargetState(element, { force: shouldForceBlur }),
     },
     renderContext,

--- a/src/plugins/elements/container/updateContainer.js
+++ b/src/plugins/elements/container/updateContainer.js
@@ -19,6 +19,10 @@ import {
   hasBlurUpdateAnimation,
   syncBlurEffect,
 } from "../util/blurEffect.js";
+import {
+  applyElementTransform,
+  getElementTransformTargetState,
+} from "../util/transform.js";
 
 /**
  * Update container element (synchronous)
@@ -48,7 +52,7 @@ export const updateContainer = ({
 
   containerElement.zIndex = zIndex;
 
-  const { x, y, alpha } = nextElement;
+  const { alpha } = nextElement;
   const shouldForceBlur = hasBlurUpdateAnimation(animations, prevElement.id);
   if (shouldForceBlur) {
     syncBlurEffect(containerElement, prevElement.blur, { force: true });
@@ -56,12 +60,11 @@ export const updateContainer = ({
 
   const updateElement = () => {
     if (!isDeepEqual(prevElement, nextElement)) {
-      containerElement.x = Math.round(x);
-      containerElement.y = Math.round(y);
       containerElement.label = nextElement.id;
       containerElement.alpha = alpha;
       containerElement.scale.x = 1;
       containerElement.scale.y = 1;
+      applyElementTransform(containerElement, nextElement);
       syncBlurEffect(containerElement, nextElement.blur, {
         force: shouldForceBlur,
       });
@@ -161,9 +164,7 @@ export const updateContainer = ({
     completionTracker,
     element: containerElement,
     targetState: {
-      x,
-      y,
-      alpha,
+      ...getElementTransformTargetState(nextElement, { alpha }),
       ...getBlurTargetState(nextElement, {
         force: shouldForceBlur,
       }),

--- a/src/plugins/elements/rect/addRect.js
+++ b/src/plugins/elements/rect/addRect.js
@@ -3,6 +3,10 @@ import { normalizeVolume } from "../../../util/normalizeVolume.js";
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
 import { setupScrollInteraction } from "../util/setupScrollInteraction.js";
 import { isPrimaryPointerEvent } from "../util/isPrimaryPointerEvent.js";
+import {
+  applyElementTransform,
+  getElementTransformTargetState,
+} from "../util/transform.js";
 
 const normalizeRectFill = (fill) =>
   fill === undefined || fill === null || fill === "" || fill === "transparent"
@@ -24,13 +28,12 @@ export const addRect = ({
   completionTracker,
   renderContext,
 }) => {
-  const { id, x, y, width, height, fill, border, alpha, scaleX, scaleY } =
-    element;
+  const { id, width, height, fill, border, alpha, scaleX, scaleY } = element;
 
   const rect = new Graphics();
   rect.label = id;
   rect.zIndex = zIndex;
-  const targetState = { x, y, alpha };
+  const targetState = getElementTransformTargetState(element, { alpha });
 
   if (scaleX !== undefined) {
     targetState.scaleX = scaleX;
@@ -45,13 +48,12 @@ export const addRect = ({
     rect
       .rect(0, 0, Math.round(width), Math.round(height))
       .fill(normalizeRectFill(fill));
-    rect.x = Math.round(x);
-    rect.y = Math.round(y);
     rect.alpha = alpha;
     // Rect computed nodes already bake scale into width/height for layout.
     // Reset the live transform so update tweens do not double-apply scale.
     rect.scale.x = 1;
     rect.scale.y = 1;
+    applyElementTransform(rect, element);
 
     if (border) {
       rect.stroke({

--- a/src/plugins/elements/rect/updateRect.js
+++ b/src/plugins/elements/rect/updateRect.js
@@ -3,6 +3,10 @@ import { normalizeVolume } from "../../../util/normalizeVolume.js";
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
 import { setupScrollInteraction } from "../util/setupScrollInteraction.js";
 import { isPrimaryPointerEvent } from "../util/isPrimaryPointerEvent.js";
+import {
+  applyElementTransform,
+  getElementTransformTargetState,
+} from "../util/transform.js";
 
 const normalizeRectFill = (fill) =>
   fill === undefined || fill === null || fill === "" || fill === "transparent"
@@ -32,9 +36,8 @@ export const updateRect = ({
 
   rectElement.zIndex = zIndex;
 
-  const { x, y, width, height, fill, border, alpha, scaleX, scaleY } =
-    nextElement;
-  const targetState = { x, y, alpha };
+  const { width, height, fill, border, alpha, scaleX, scaleY } = nextElement;
+  const targetState = getElementTransformTargetState(nextElement, { alpha });
 
   if (scaleX !== undefined) {
     targetState.scaleX = scaleX;
@@ -52,13 +55,12 @@ export const updateRect = ({
       rectElement
         .rect(0, 0, Math.round(width), Math.round(height))
         .fill(normalizeRectFill(fill));
-      rectElement.x = Math.round(x);
-      rectElement.y = Math.round(y);
       rectElement.alpha = alpha;
       // Rect computed nodes already bake scale into width/height for layout.
       // Reset the live transform so update tweens do not double-apply scale.
       rectElement.scale.x = 1;
       rectElement.scale.y = 1;
+      applyElementTransform(rectElement, nextElement);
 
       if (border) {
         rectElement.stroke({

--- a/src/plugins/elements/sprite/addSprite.js
+++ b/src/plugins/elements/sprite/addSprite.js
@@ -13,6 +13,10 @@ import {
   createRightPressStateController,
 } from "../util/hoverInheritance.js";
 import { setupScrollInteraction } from "../util/setupScrollInteraction.js";
+import {
+  applyElementTransform,
+  getElementTransformTargetState,
+} from "../util/transform.js";
 
 /**
  * Add sprite element to the stage (synchronous)
@@ -29,18 +33,17 @@ export const addSprite = ({
   renderContext,
   zIndex,
 }) => {
-  const { id, x, y, width, height, src, alpha } = element;
+  const { id, width, height, src, alpha } = element;
   const texture = src ? Texture.from(src) : Texture.EMPTY;
   const sprite = new Sprite(texture);
   sprite.label = id;
   sprite.zIndex = zIndex;
 
   // Apply initial state
-  sprite.x = Math.round(x);
-  sprite.y = Math.round(y);
   sprite.width = Math.round(width);
   sprite.height = Math.round(height);
   sprite.alpha = alpha;
+  applyElementTransform(sprite, element);
   const shouldForceBlur = hasBlurUpdateAnimation(animations, id);
   syncBlurEffect(sprite, element.blur, { force: shouldForceBlur });
 
@@ -221,8 +224,7 @@ export const addSprite = ({
     completionTracker,
     element: sprite,
     targetState: {
-      x,
-      y,
+      ...getElementTransformTargetState(element),
       width,
       height,
       alpha,

--- a/src/plugins/elements/sprite/parseSprite.js
+++ b/src/plugins/elements/sprite/parseSprite.js
@@ -18,6 +18,7 @@ export const parseSprite = ({ state }) => {
     ...computedObj,
     src: state.src ?? "",
     alpha: state.alpha ?? 1,
+    rotation: state.rotation ?? 0,
     ...(state.blur !== undefined && {
       blur: normalizeBlurConfig(state.blur),
     }),

--- a/src/plugins/elements/sprite/updateSprite.js
+++ b/src/plugins/elements/sprite/updateSprite.js
@@ -20,6 +20,10 @@ import {
   createRightPressStateController,
 } from "../util/hoverInheritance.js";
 import { setupScrollInteraction } from "../util/setupScrollInteraction.js";
+import {
+  applyElementTransform,
+  getElementTransformTargetState,
+} from "../util/transform.js";
 
 /**
  * Update sprite element (synchronous)
@@ -44,7 +48,7 @@ export const updateSprite = ({
 
   spriteElement.zIndex = zIndex;
 
-  const { x, y, width, height, src, alpha } = nextElement;
+  const { width, height, src, alpha } = nextElement;
   const shouldForceBlur = hasBlurUpdateAnimation(animations, prevElement.id);
   if (shouldForceBlur) {
     syncBlurEffect(spriteElement, prevElement.blur, { force: true });
@@ -262,11 +266,10 @@ export const updateSprite = ({
         syncSpriteResource();
       }
 
-      spriteElement.x = Math.round(x);
-      spriteElement.y = Math.round(y);
       spriteElement.width = Math.round(width);
       spriteElement.height = Math.round(height);
       spriteElement.alpha = alpha;
+      applyElementTransform(spriteElement, nextElement);
       syncBlurEffect(spriteElement, nextElement.blur, {
         force: shouldForceBlur,
       });
@@ -288,8 +291,7 @@ export const updateSprite = ({
     completionTracker,
     element: spriteElement,
     targetState: {
-      x,
-      y,
+      ...getElementTransformTargetState(nextElement),
       width,
       height,
       alpha,

--- a/src/plugins/elements/util/parseCommonObject.js
+++ b/src/plugins/elements/util/parseCommonObject.js
@@ -49,6 +49,10 @@ export const parseCommonObject = (state) => {
     anchorX: state.anchorX,
     anchorY: state.anchorY,
   });
+  const transformOriginX =
+    typeof state.originX === "number" ? state.originX : originX;
+  const transformOriginY =
+    typeof state.originY === "number" ? state.originY : originY;
 
   // Round all pixel calculations
   let computedObj = {
@@ -58,8 +62,8 @@ export const parseCommonObject = (state) => {
     height: Math.round(heightAfterScale),
     x: Math.round(adjustedPositionX),
     y: Math.round(adjustedPositionY),
-    originX: Math.round(originX),
-    originY: Math.round(originY),
+    originX: Math.round(transformOriginX),
+    originY: Math.round(transformOriginY),
     alpha: state.alpha ?? 1,
   };
 

--- a/src/plugins/elements/util/transform.js
+++ b/src/plugins/elements/util/transform.js
@@ -1,0 +1,41 @@
+export const degreesToRadians = (degrees = 0) => (degrees * Math.PI) / 180;
+
+export const radiansToDegrees = (radians = 0) => (radians * 180) / Math.PI;
+
+const getFiniteScale = (scale) =>
+  typeof scale === "number" && Number.isFinite(scale) && scale !== 0
+    ? scale
+    : 1;
+
+export const getElementTransformPosition = (element) => ({
+  x: Math.round((element.x ?? 0) + (element.originX ?? 0)),
+  y: Math.round((element.y ?? 0) + (element.originY ?? 0)),
+});
+
+export const applyElementTransform = (displayObject, element) => {
+  const originX = element.originX ?? 0;
+  const originY = element.originY ?? 0;
+  const scaleX = getFiniteScale(displayObject.scale?.x);
+  const scaleY = getFiniteScale(displayObject.scale?.y);
+  const position = getElementTransformPosition(element);
+
+  displayObject.pivot?.set?.(originX / scaleX, originY / scaleY);
+  displayObject.x = position.x;
+  displayObject.y = position.y;
+  displayObject.rotation = degreesToRadians(element.rotation ?? 0);
+};
+
+export const getElementTransformTargetState = (element, extra = {}) => {
+  const position = getElementTransformPosition(element);
+  const targetState = {
+    x: position.x,
+    y: position.y,
+    ...extra,
+  };
+
+  if (element.rotation !== undefined) {
+    targetState.rotation = element.rotation;
+  }
+
+  return targetState;
+};

--- a/src/schemas/elements/container.element.yaml
+++ b/src/schemas/elements/container.element.yaml
@@ -34,6 +34,12 @@ properties:
     type: number
     description: Vertical anchor point where 0 is top edge, 1 is bottom edge (100% height). For containers, must be 0, 0.5, or 1.
     default: 0
+  originX:
+    type: number
+    description: Horizontal transform origin in pixels from the container's left edge. Defaults to the anchor-derived X origin.
+  originY:
+    type: number
+    description: Vertical transform origin in pixels from the container's top edge. Defaults to the anchor-derived Y origin.
   alpha:
     type: number
     description: Opacity/transparency of the container (0-1)

--- a/src/schemas/elements/rect.element.yaml
+++ b/src/schemas/elements/rect.element.yaml
@@ -34,6 +34,12 @@ properties:
   anchorY:
     type: number
     description: Vertical anchor point where 0 is top edge, 1 is bottom edge (100% height). Values can extend beyond 0-1 range.
+  originX:
+    type: number
+    description: Horizontal transform origin in pixels from the element's left edge. Defaults to the anchor-derived X origin.
+  originY:
+    type: number
+    description: Vertical transform origin in pixels from the element's top edge. Defaults to the anchor-derived Y origin.
   alpha:
     type: number
     description: Opacity/transparency of the rectangle (0-1)

--- a/src/schemas/elements/sprite.computed.yaml
+++ b/src/schemas/elements/sprite.computed.yaml
@@ -46,6 +46,10 @@ properties:
     description: Opacity/transparency of the sprite (0-1)
     minimum: 0
     maximum: 1
+  rotation:
+    type: number
+    description: Rotation in degrees
+    default: 0
   blur:
     type: object
     description: Directional Gaussian blur configuration.

--- a/src/schemas/elements/sprite.element.yaml
+++ b/src/schemas/elements/sprite.element.yaml
@@ -37,6 +37,12 @@ properties:
     type: number
     description: Vertical anchor point where 0 is top edge, 1 is bottom edge (100% height). Values can extend beyond 0-1 range.
     default: 0
+  originX:
+    type: number
+    description: Horizontal transform origin in pixels from the element's left edge. Defaults to the anchor-derived X origin.
+  originY:
+    type: number
+    description: Vertical transform origin in pixels from the element's top edge. Defaults to the anchor-derived Y origin.
   src:
     type: string
     description: src of the sprite image. the alias of the pre loaded asset. can be empty
@@ -46,6 +52,10 @@ properties:
     minimum: 0
     maximum: 1
     default: 1
+  rotation:
+    type: number
+    description: Rotation in degrees
+    default: 0
   blur:
     type: object
     description: Optional directional Gaussian blur.

--- a/src/types.js
+++ b/src/types.js
@@ -73,6 +73,7 @@
  * @typedef {Object} SpriteComputedProps
  * @property {'sprite'} type
  * @property {number} alpha
+ * @property {number} [rotation] - Rotation in degrees
  * @property {string} url
  * @property {BlurConfig} [blur]
  * @property {SpriteHover} hover

--- a/vt/reference/rect/add-rotation-01.webp
+++ b/vt/reference/rect/add-rotation-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:391a647a170cb365c249357c7a8dbfe479dc5a2cfabad013e7536ce2c9c9fa95
+size 8726

--- a/vt/reference/recttransition/rect-update-rotation-01.webp
+++ b/vt/reference/recttransition/rect-update-rotation-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:526f359f12b78d4694f87095c21c0bce1a00a4cbaa94de519f41e6ba82e64f0d
+size 2442

--- a/vt/reference/recttransition/rect-update-rotation-02.webp
+++ b/vt/reference/recttransition/rect-update-rotation-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cea656ec45c7fc50a3a92f557561ba40abf65eaf5d237e68baf54d4faf0c014
+size 7288

--- a/vt/reference/recttransition/rect-update-rotation-03.webp
+++ b/vt/reference/recttransition/rect-update-rotation-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38f38f098f06137806d6a750940a8b30967f9795a2aad2ae90fc317929772ad6
+size 2446

--- a/vt/reference/sprite/add-rotation-01.webp
+++ b/vt/reference/sprite/add-rotation-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90440b03995d535af22cf90f302ed0e6121601d621261eedeb0ae6de86aa0d0b
+size 6620

--- a/vt/reference/spritetransition/sprite-update-rotation-01.webp
+++ b/vt/reference/spritetransition/sprite-update-rotation-01.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:affccf865b06fc3e524b9314fc3115bc4714c4ff999d61e0a0a9d1824f3b9ff7
-size 3098
+oid sha256:7fea830d153682ca9cab43fc6a17cc523a16f939cdb7b61c39d96c548006b106
+size 2542

--- a/vt/reference/spritetransition/sprite-update-rotation-02.webp
+++ b/vt/reference/spritetransition/sprite-update-rotation-02.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc4172ed021a4ae20318d1a0d46870567cbaaafd1e2e36fe3b109a1a6bd35d1c
-size 3102
+oid sha256:21f4f1e28f39f6852648a014a687cc834812e956bd9ab21413bce02cfce1df48
+size 5288

--- a/vt/reference/spritetransition/sprite-update-rotation-03.webp
+++ b/vt/reference/spritetransition/sprite-update-rotation-03.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5bef107fc0721e1e2bb3590d10652cf7059a93e28b29a3b60688e8de597ffae
-size 3096
+oid sha256:5454d272e1bf601955ca6b9da957f66417c52cc4df949b0eab1330e8e940d148
+size 2538

--- a/vt/specs/rect/add-rotation.yaml
+++ b/vt/specs/rect/add-rotation.yaml
@@ -1,0 +1,81 @@
+---
+title: Rect Static Rotation
+description: Rects rendered with rotation on initial add, including explicit origin overrides.
+specs:
+  - static rect rotation should apply without an animation
+  - omitted origin should default to the anchor-derived pivot
+  - explicit origin should rotate independently from the anchor layout point
+  - explicit origin 0,0 should rotate around the rect's top-left corner
+---
+states:
+  - elements:
+      - id: center-origin-rect
+        type: rect
+        x: 360
+        "y": 360
+        width: 220
+        height: 72
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#FFFFFF"
+        border:
+          width: 6
+          color: "#666666"
+        rotation: 35
+      - id: explicit-origin-rect
+        type: rect
+        x: 850
+        "y": 360
+        width: 220
+        height: 72
+        anchorX: 0.5
+        anchorY: 0.5
+        originX: 0
+        originY: 72
+        fill: "#FFFFFF"
+        border:
+          width: 6
+          color: "#666666"
+        rotation: 35
+      - id: origin-zero-rect
+        type: rect
+        x: 1130
+        "y": 360
+        width: 220
+        height: 72
+        anchorX: 0.5
+        anchorY: 0.5
+        originX: 0
+        originY: 0
+        fill: "#FFFFFF"
+        border:
+          width: 6
+          color: "#666666"
+        rotation: 35
+      - id: center-origin-marker
+        type: rect
+        x: 360
+        "y": 360
+        width: 10
+        height: 10
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#FF3355"
+      - id: explicit-origin-marker
+        type: rect
+        x: 740
+        "y": 396
+        width: 10
+        height: 10
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#FF3355"
+      - id: origin-zero-marker
+        type: rect
+        x: 1020
+        "y": 324
+        width: 10
+        height: 10
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#FF3355"

--- a/vt/specs/recttransition/rect-update-rotation.yaml
+++ b/vt/specs/recttransition/rect-update-rotation.yaml
@@ -1,11 +1,11 @@
 ---
-title: Sprite Update Rotation Transition
-description: Sprites rotating around anchor-derived, explicit, and zero origins during update animations.
+title: Rect Update Rotation Transition
+description: Non-square rects rotating around anchor-derived, explicit, and zero origins during update animations.
 specs:
-  - sprites should rotate from 0 to 90 degrees
+  - rects should rotate from 0 to 90 degrees
   - omitted origin should animate around the anchor-derived pivot
   - explicit origin should animate independently from the anchor layout point
-  - explicit origin 0,0 should animate around the sprite's top-left corner
+  - explicit origin 0,0 should animate around the rect's top-left corner
   - auto rotation tween should use degree values
 steps:
   - action: keypress
@@ -23,39 +23,48 @@ steps:
 ---
 states:
   - elements:
-      - id: center-origin-sprite
-        type: sprite
-        src: slider
+      - id: center-origin-rect
+        type: rect
         x: 360
         "y": 360
-        width: 240
-        height: 24
+        width: 220
+        height: 72
         anchorX: 0.5
         anchorY: 0.5
+        fill: "#FFFFFF"
+        border:
+          width: 6
+          color: "#666666"
         rotation: 0
-      - id: explicit-origin-sprite
-        type: sprite
-        src: slider
+      - id: explicit-origin-rect
+        type: rect
         x: 850
         "y": 360
-        width: 240
-        height: 24
+        width: 220
+        height: 72
         anchorX: 0.5
         anchorY: 0.5
         originX: 0
-        originY: 24
+        originY: 72
+        fill: "#FFFFFF"
+        border:
+          width: 6
+          color: "#666666"
         rotation: 0
-      - id: origin-zero-sprite
-        type: sprite
-        src: slider
+      - id: origin-zero-rect
+        type: rect
         x: 1130
         "y": 360
-        width: 240
-        height: 24
+        width: 220
+        height: 72
         anchorX: 0.5
         anchorY: 0.5
         originX: 0
         originY: 0
+        fill: "#FFFFFF"
+        border:
+          width: 6
+          color: "#666666"
         rotation: 0
       - id: center-origin-marker
         type: rect
@@ -68,8 +77,8 @@ states:
         fill: "#FF3355"
       - id: explicit-origin-marker
         type: rect
-        x: 730
-        "y": 372
+        x: 740
+        "y": 396
         width: 10
         height: 10
         anchorX: 0.5
@@ -77,47 +86,56 @@ states:
         fill: "#FF3355"
       - id: origin-zero-marker
         type: rect
-        x: 1010
-        "y": 348
+        x: 1020
+        "y": 324
         width: 10
         height: 10
         anchorX: 0.5
         anchorY: 0.5
         fill: "#FF3355"
   - elements:
-      - id: center-origin-sprite
-        type: sprite
-        src: slider
+      - id: center-origin-rect
+        type: rect
         x: 360
         "y": 360
-        width: 240
-        height: 24
+        width: 220
+        height: 72
         anchorX: 0.5
         anchorY: 0.5
+        fill: "#FFFFFF"
+        border:
+          width: 6
+          color: "#666666"
         rotation: 90
-      - id: explicit-origin-sprite
-        type: sprite
-        src: slider
+      - id: explicit-origin-rect
+        type: rect
         x: 850
         "y": 360
-        width: 240
-        height: 24
+        width: 220
+        height: 72
         anchorX: 0.5
         anchorY: 0.5
         originX: 0
-        originY: 24
+        originY: 72
+        fill: "#FFFFFF"
+        border:
+          width: 6
+          color: "#666666"
         rotation: 90
-      - id: origin-zero-sprite
-        type: sprite
-        src: slider
+      - id: origin-zero-rect
+        type: rect
         x: 1130
         "y": 360
-        width: 240
-        height: 24
+        width: 220
+        height: 72
         anchorX: 0.5
         anchorY: 0.5
         originX: 0
         originY: 0
+        fill: "#FFFFFF"
+        border:
+          width: 6
+          color: "#666666"
         rotation: 90
       - id: center-origin-marker
         type: rect
@@ -130,8 +148,8 @@ states:
         fill: "#FF3355"
       - id: explicit-origin-marker
         type: rect
-        x: 730
-        "y": 372
+        x: 740
+        "y": 396
         width: 10
         height: 10
         anchorX: 0.5
@@ -139,32 +157,32 @@ states:
         fill: "#FF3355"
       - id: origin-zero-marker
         type: rect
-        x: 1010
-        "y": 348
+        x: 1020
+        "y": 324
         width: 10
         height: 10
         anchorX: 0.5
         anchorY: 0.5
         fill: "#FF3355"
     animations:
-      - id: center-origin-sprite-rotate-auto
-        targetId: center-origin-sprite
+      - id: center-origin-rect-rotate-auto
+        targetId: center-origin-rect
         type: update
         tween:
           rotation:
             auto:
               duration: 1000
               easing: linear
-      - id: explicit-origin-sprite-rotate-auto
-        targetId: explicit-origin-sprite
+      - id: explicit-origin-rect-rotate-auto
+        targetId: explicit-origin-rect
         type: update
         tween:
           rotation:
             auto:
               duration: 1000
               easing: linear
-      - id: origin-zero-sprite-rotate-auto
-        targetId: origin-zero-sprite
+      - id: origin-zero-rect-rotate-auto
+        targetId: origin-zero-rect
         type: update
         tween:
           rotation:

--- a/vt/specs/sprite/add-rotation.yaml
+++ b/vt/specs/sprite/add-rotation.yaml
@@ -1,0 +1,72 @@
+---
+title: Sprite Static Rotation
+description: Sprites rendered with rotation on initial add, including explicit origin overrides.
+specs:
+  - static sprite rotation should apply without an animation
+  - omitted origin should default to the anchor-derived pivot
+  - explicit origin should rotate independently from the anchor layout point
+  - explicit origin 0,0 should rotate around the sprite's top-left corner
+---
+states:
+  - elements:
+      - id: center-origin-sprite
+        type: sprite
+        src: slider
+        x: 360
+        "y": 360
+        width: 240
+        height: 24
+        anchorX: 0.5
+        anchorY: 0.5
+        rotation: 35
+      - id: explicit-origin-sprite
+        type: sprite
+        src: slider
+        x: 850
+        "y": 360
+        width: 240
+        height: 24
+        anchorX: 0.5
+        anchorY: 0.5
+        originX: 0
+        originY: 24
+        rotation: 35
+      - id: origin-zero-sprite
+        type: sprite
+        src: slider
+        x: 1130
+        "y": 360
+        width: 240
+        height: 24
+        anchorX: 0.5
+        anchorY: 0.5
+        originX: 0
+        originY: 0
+        rotation: 35
+      - id: center-origin-marker
+        type: rect
+        x: 360
+        "y": 360
+        width: 10
+        height: 10
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#FF3355"
+      - id: explicit-origin-marker
+        type: rect
+        x: 730
+        "y": 372
+        width: 10
+        height: 10
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#FF3355"
+      - id: origin-zero-marker
+        type: rect
+        x: 1010
+        "y": 348
+        width: 10
+        height: 10
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#FF3355"


### PR DESCRIPTION
## Summary
- add shared transform handling for element origin + degree-based rotation
- keep anchor layout separate from transform origin: originX/originY default to the anchor-derived pivot, and explicit values override only the transform origin
- wire rotation support through rect/container/sprite add/update paths, update tweens, and replace transition subjects
- add parser/runtime tests plus static and animated rect/sprite VT coverage for default, explicit, and zero origins; VTs include small origin square markers

## Verification
- push hook: bunx prettier --check src
- push hook: vitest run (74 files, 497 tests)
- rtgl vt report --item rect/add-rotation.yaml --item sprite/add-rotation.yaml --item recttransition/rect-update-rotation.yaml --item spritetransition/sprite-update-rotation.yaml (8 images, 0 mismatches)