### PR TITLE
chore: bump route-graphics to 1.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.17.6",
+  "version": "1.18.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump package version from 1.17.6 to 1.18.0

## Testing
- pre-push hook: bunx prettier --check src
- pre-push hook: vitest run