### PR TITLE
chore: bump route-graphics to 1.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump package version to 1.19.0 for the shader feature release

## Verification
- npm run lint
- npm test -- spec/cli/routeGraphicsCli.spec.js
- pre-push hook: prettier check + full vitest suite