### PR TITLE
Fix input keyboard shortcut isolation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/elements/eventSemantics.spec.js
+++ b/spec/elements/eventSemantics.spec.js
@@ -27,15 +27,17 @@ const createSharedParams = () => ({
 
 const createPointerEvent = (button) => ({ button });
 const dispatchKeyboardEvent = (type, key, options = {}) => {
-  document.dispatchEvent(
+  const { target = document, ...eventOptions } = options;
+
+  target.dispatchEvent(
     new KeyboardEvent(type, {
       key,
       code:
-        options.code ??
+        eventOptions.code ??
         (key.length === 1 ? `Key${key.toUpperCase()}` : undefined),
       bubbles: true,
       cancelable: true,
-      ...options,
+      ...eventOptions,
     }),
   );
 };
@@ -774,6 +776,137 @@ describe("event semantics", () => {
       ],
     ]);
 
+    keyboardManager.destroy();
+  });
+
+  it("keyboard manager ignores key events from editable targets", () => {
+    const eventHandler = vi.fn();
+    const keyboardManager = createKeyboardManager(eventHandler);
+    const input = document.createElement("input");
+    const editable = document.createElement("div");
+    editable.contentEditable = "true";
+    document.body.append(input, editable);
+
+    keyboardManager.registerHotkeys({
+      space: {
+        keydown: { payload: { source: "SpaceDown" } },
+        keyup: { payload: { source: "SpaceUp" } },
+      },
+      shift: {
+        keydown: { payload: { source: "ShiftDown" } },
+        keyup: { payload: { source: "ShiftUp" } },
+      },
+    });
+
+    dispatchKeyboardEvent("keydown", " ", {
+      target: input,
+      code: "Space",
+      keyCode: 32,
+      which: 32,
+    });
+    dispatchKeyboardEvent("keyup", " ", {
+      target: input,
+      code: "Space",
+      keyCode: 32,
+      which: 32,
+    });
+    dispatchKeyboardEvent("keydown", "Shift", {
+      target: input,
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+    dispatchKeyboardEvent("keyup", "Shift", {
+      target: input,
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+    dispatchKeyboardEvent("keydown", "Shift", {
+      target: editable,
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+    dispatchKeyboardEvent("keyup", "Shift", {
+      target: editable,
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+
+    expect(eventHandler).not.toHaveBeenCalled();
+
+    input.remove();
+    editable.remove();
+    keyboardManager.destroy();
+  });
+
+  it("keyboard manager drops active keyup bindings when release moves into an input", () => {
+    const eventHandler = vi.fn();
+    const keyboardManager = createKeyboardManager(eventHandler);
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    keyboardManager.registerHotkeys({
+      shift: {
+        keydown: { payload: { source: "ShiftDown" } },
+        keyup: { payload: { source: "ShiftUp" } },
+      },
+    });
+
+    dispatchKeyboardEvent("keydown", "Shift", {
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+    dispatchKeyboardEvent("keyup", "Shift", {
+      target: input,
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+    dispatchKeyboardEvent("keyup", "Shift", {
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+    dispatchKeyboardEvent("keydown", "Shift", {
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+    dispatchKeyboardEvent("keyup", "Shift", {
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+
+    expect(eventHandler.mock.calls).toEqual([
+      [
+        "keydown",
+        {
+          _event: { key: "shift" },
+          source: "ShiftDown",
+        },
+      ],
+      [
+        "keydown",
+        {
+          _event: { key: "shift" },
+          source: "ShiftDown",
+        },
+      ],
+      [
+        "keyup",
+        {
+          _event: { key: "shift" },
+          source: "ShiftUp",
+        },
+      ],
+    ]);
+
+    input.remove();
     keyboardManager.destroy();
   });
 });

--- a/spec/util/inputDomBridge.spec.js
+++ b/spec/util/inputDomBridge.spec.js
@@ -246,6 +246,68 @@ describe("inputDomBridge", () => {
     bridge.destroy();
   });
 
+  it("keeps focused input keyboard events from bubbling to document shortcuts", () => {
+    const { app } = createApp();
+    const bridge = createInputDomBridge({ app });
+    const onDocumentKeydown = vi.fn();
+    const onDocumentKeyup = vi.fn();
+    const callbacks = {
+      onSubmit: vi.fn(),
+    };
+
+    document.addEventListener("keydown", onDocumentKeydown);
+    document.addEventListener("keyup", onDocumentKeyup);
+
+    const input = bridge.mount("name", {
+      value: "abc",
+      padding: { top: 1, right: 1, bottom: 1, left: 1 },
+      textStyle: { fontSize: 18, fill: "#ffffff", align: "left" },
+      getGeometry: () => ({
+        x: 0,
+        y: 0,
+        width: 50,
+        height: 25,
+        visible: true,
+      }),
+      callbacks,
+    });
+
+    input.focus();
+
+    const spaceDown = new KeyboardEvent("keydown", {
+      key: " ",
+      code: "Space",
+      bubbles: true,
+      cancelable: true,
+    });
+    const spaceUp = new KeyboardEvent("keyup", {
+      key: " ",
+      code: "Space",
+      bubbles: true,
+      cancelable: true,
+    });
+    const enterDown = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+
+    input.dispatchEvent(spaceDown);
+    input.dispatchEvent(spaceUp);
+    input.dispatchEvent(enterDown);
+
+    expect(spaceDown.defaultPrevented).toBe(false);
+    expect(spaceUp.defaultPrevented).toBe(false);
+    expect(enterDown.defaultPrevented).toBe(true);
+    expect(callbacks.onSubmit).toHaveBeenCalledTimes(1);
+    expect(onDocumentKeydown).not.toHaveBeenCalled();
+    expect(onDocumentKeyup).not.toHaveBeenCalled();
+
+    document.removeEventListener("keydown", onDocumentKeydown);
+    document.removeEventListener("keyup", onDocumentKeyup);
+    bridge.destroy();
+  });
+
   it("blurs when the pointer lands inside the unclipped box but outside the visible clipped region", () => {
     vi.useFakeTimers();
 

--- a/src/util/inputDomBridge.js
+++ b/src/util/inputDomBridge.js
@@ -354,8 +354,13 @@ export const createInputDomBridge = ({ app }) => {
     element.addEventListener("input", syncFromDom);
     element.addEventListener("select", syncFromDom);
     element.addEventListener("click", () => queueMicrotask(syncFromDom));
-    element.addEventListener("keyup", () => queueMicrotask(syncFromDom));
+    element.addEventListener("keyup", (event) => {
+      event.stopPropagation();
+      queueMicrotask(syncFromDom);
+    });
     element.addEventListener("keydown", (event) => {
+      event.stopPropagation();
+
       const shouldSubmitSingleLine =
         event.key === "Enter" &&
         entry.options.multiline !== true &&

--- a/src/util/keyboardManager.js
+++ b/src/util/keyboardManager.js
@@ -130,8 +130,94 @@ const getShortcutActivationKey = (binding, shortcut) => {
   return `${binding}${SHORTCUT_ACTIVATION_KEY_DELIMITER}${shortcut.shortcut}`;
 };
 
+const isEditableKeyboardTarget = (target) => {
+  if (!target || typeof target !== "object") {
+    return false;
+  }
+
+  const tagName =
+    typeof target.tagName === "string" ? target.tagName.toLowerCase() : "";
+
+  if (["input", "textarea", "select"].includes(tagName)) {
+    return true;
+  }
+
+  if (
+    (typeof HTMLInputElement !== "undefined" &&
+      target instanceof HTMLInputElement) ||
+    (typeof HTMLTextAreaElement !== "undefined" &&
+      target instanceof HTMLTextAreaElement) ||
+    (typeof HTMLSelectElement !== "undefined" &&
+      target instanceof HTMLSelectElement)
+  ) {
+    return true;
+  }
+
+  if (
+    target.isContentEditable === true ||
+    target.contentEditable === "true" ||
+    target.contentEditable === "plaintext-only"
+  ) {
+    return true;
+  }
+
+  if (typeof target.getAttribute === "function") {
+    const contentEditable = target.getAttribute("contenteditable");
+
+    if (contentEditable !== null && contentEditable.toLowerCase() !== "false") {
+      return true;
+    }
+
+    if (target.getAttribute("data-route-graphics-input-id") !== null) {
+      return true;
+    }
+  }
+
+  const closest =
+    typeof target.closest === "function"
+      ? target.closest.bind(target)
+      : typeof target.parentElement?.closest === "function"
+        ? target.parentElement.closest.bind(target.parentElement)
+        : null;
+
+  if (!closest) {
+    return false;
+  }
+
+  return Boolean(
+    closest(
+      '[data-route-graphics-input-id], [contenteditable]:not([contenteditable="false"])',
+    ),
+  );
+};
+
 const shouldHandleKeydown = (event) => {
+  if (isEditableKeyboardTarget(event?.target)) {
+    return false;
+  }
+
   return typeof hotkeys.filter !== "function" || hotkeys.filter(event);
+};
+
+const clearReleasedKeyState = ({
+  activeKeyupShortcuts,
+  activeModifierShortcuts,
+  pressedKeyCodes,
+  releasedKeyCode,
+}) => {
+  for (const [activationKey, activeShortcut] of [...activeKeyupShortcuts]) {
+    if (activeShortcut.releaseCodes.has(releasedKeyCode)) {
+      activeKeyupShortcuts.delete(activationKey);
+    }
+  }
+
+  for (const [activationKey, activeShortcut] of [...activeModifierShortcuts]) {
+    if (activeShortcut.releaseCodes.has(releasedKeyCode)) {
+      activeModifierShortcuts.delete(activationKey);
+    }
+  }
+
+  pressedKeyCodes.delete(releasedKeyCode);
 };
 
 const normalizeBindingConfig = (config) => {
@@ -246,6 +332,7 @@ export const createKeyboardManager = (eventHandler) => {
 
   const onDocumentKeydown = (event) => {
     if (!shouldHandleKeydown(event)) {
+      clearActiveKeyupBindings();
       return;
     }
 
@@ -281,6 +368,16 @@ export const createKeyboardManager = (eventHandler) => {
     const releasedKeyCode = getEventKeyCode(event);
 
     if (typeof releasedKeyCode !== "number") {
+      return;
+    }
+
+    if (isEditableKeyboardTarget(event?.target)) {
+      clearReleasedKeyState({
+        activeKeyupShortcuts,
+        activeModifierShortcuts,
+        pressedKeyCodes,
+        releasedKeyCode,
+      });
       return;
     }
 
@@ -369,6 +466,11 @@ export const createKeyboardManager = (eventHandler) => {
       // hotkeys-js is reliable for combo activation, but not for combo release
       // when modifiers are released before the final non-modifier key.
       hotkeys(binding, (_event, handler) => {
+        if (isEditableKeyboardTarget(_event?.target)) {
+          clearActiveKeyupBindings();
+          return;
+        }
+
         const shortcut = getHandlerShortcut(binding, handler);
 
         if (shortcut?.isModifierOnly) {

--- a/vt/specs/input/input-keyboard-isolation.yaml
+++ b/vt/specs/input/input-keyboard-isolation.yaml
@@ -1,0 +1,124 @@
+---
+title: Input Keyboard Isolation
+description: Focused input typing should not emit global keyboard shortcuts.
+skipInitialScreenshot: true
+specs:
+  - pressing Space while an input is focused should edit the field only
+  - the same global Space shortcut should work after the input loses focus
+steps:
+  - action: customEvent
+    name: clearEvents
+  - action: click
+    x: 180
+    "y": 88
+  - action: wait
+    ms: 100
+  - action: keypress
+    key: A
+  - action: keypress
+    key: Space
+  - action: keypress
+    key: B
+  - action: wait
+    ms: 120
+  - action: assert
+    type: js
+    fn: vtAssert.payloadDeepEquals
+    args:
+      - change
+    value:
+      - _event:
+          id: input-name
+          value: A
+          selectionStart: 1
+          selectionEnd: 1
+          composing: false
+        action: inputChange
+      - _event:
+          id: input-name
+          value: "A "
+          selectionStart: 2
+          selectionEnd: 2
+          composing: false
+        action: inputChange
+      - _event:
+          id: input-name
+          value: A B
+          selectionStart: 3
+          selectionEnd: 3
+          composing: false
+        action: inputChange
+  - action: assert
+    type: js
+    fn: vtAssert.payloadDeepEquals
+    args:
+      - keydown
+    value: []
+  - action: assert
+    type: js
+    fn: vtAssert.payloadDeepEquals
+    args:
+      - keyup
+    value: []
+  - action: customEvent
+    name: clearEvents
+  - action: click
+    x: 20
+    "y": 20
+  - action: wait
+    ms: 100
+  - action: keypress
+    key: Space
+  - action: assert
+    type: js
+    fn: vtAssert.payloadDeepEquals
+    args:
+      - keydown
+    value:
+      - _event:
+          key: space
+        action: globalSpaceDown
+  - action: assert
+    type: js
+    fn: vtAssert.payloadDeepEquals
+    args:
+      - keyup
+    value:
+      - _event:
+          key: space
+        action: globalSpaceUp
+---
+states:
+  - elements:
+      - id: input-bg
+        type: rect
+        x: 0
+        "y": 0
+        width: 1280
+        height: 720
+        fill: "#000000"
+      - id: input-name
+        type: input
+        x: 60
+        "y": 60
+        width: 240
+        height: 56
+        placeholder: Your name
+        textStyle:
+          fill: "#FFFFFF"
+          fontSize: 22
+        focusEvent:
+          payload:
+            action: inputFocus
+        change:
+          payload:
+            action: inputChange
+    global:
+      keyboard:
+        space:
+          keydown:
+            payload:
+              action: globalSpaceDown
+          keyup:
+            payload:
+              action: globalSpaceUp


### PR DESCRIPTION
Summary:
- Suppress Route Graphics global keyboard handling when key events originate from editable text targets.
- Stop hidden input keydown/keyup events from bubbling to document-level shortcuts while preserving normal text editing and submit behavior.
- Add unit and VT coverage for focused inputs using Space without triggering global shortcuts, then bump the package patch version to 1.20.1.

Tests:
- bunx prettier --check src/util/keyboardManager.js src/util/inputDomBridge.js spec/elements/eventSemantics.spec.js spec/util/inputDomBridge.spec.js vt/specs/input/input-keyboard-isolation.yaml package.json
- bun run test
- bun run vt:screenshot
- docker run --rm --user $(id -u):$(id -g) -e RTGL_VT_DEBUG=true -v "$PWD:/workspace" docker.io/han4wluc/rtgl:playwright-v1.57.0-rtgl-v1.1.0 rtgl vt report

VT:
- Screenshot capture completed: 186/186 succeeded.
- Report completed with 0 mismatched images.
