### PR TITLE
fix: isolate input keyboard handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.20.2",
+  "version": "1.20.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/elements/eventSemantics.spec.js
+++ b/spec/elements/eventSemantics.spec.js
@@ -27,15 +27,17 @@ const createSharedParams = () => ({
 
 const createPointerEvent = (button) => ({ button });
 const dispatchKeyboardEvent = (type, key, options = {}) => {
-  document.dispatchEvent(
+  const { target = document, ...eventOptions } = options;
+
+  target.dispatchEvent(
     new KeyboardEvent(type, {
       key,
       code:
-        options.code ??
+        eventOptions.code ??
         (key.length === 1 ? `Key${key.toUpperCase()}` : undefined),
       bubbles: true,
       cancelable: true,
-      ...options,
+      ...eventOptions,
     }),
   );
 };
@@ -774,6 +776,137 @@ describe("event semantics", () => {
       ],
     ]);
 
+    keyboardManager.destroy();
+  });
+
+  it("keyboard manager ignores key events from editable targets", () => {
+    const eventHandler = vi.fn();
+    const keyboardManager = createKeyboardManager(eventHandler);
+    const input = document.createElement("input");
+    const editable = document.createElement("div");
+    editable.contentEditable = "true";
+    document.body.append(input, editable);
+
+    keyboardManager.registerHotkeys({
+      space: {
+        keydown: { payload: { source: "SpaceDown" } },
+        keyup: { payload: { source: "SpaceUp" } },
+      },
+      shift: {
+        keydown: { payload: { source: "ShiftDown" } },
+        keyup: { payload: { source: "ShiftUp" } },
+      },
+    });
+
+    dispatchKeyboardEvent("keydown", " ", {
+      target: input,
+      code: "Space",
+      keyCode: 32,
+      which: 32,
+    });
+    dispatchKeyboardEvent("keyup", " ", {
+      target: input,
+      code: "Space",
+      keyCode: 32,
+      which: 32,
+    });
+    dispatchKeyboardEvent("keydown", "Shift", {
+      target: input,
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+    dispatchKeyboardEvent("keyup", "Shift", {
+      target: input,
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+    dispatchKeyboardEvent("keydown", "Shift", {
+      target: editable,
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+    dispatchKeyboardEvent("keyup", "Shift", {
+      target: editable,
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+
+    expect(eventHandler).not.toHaveBeenCalled();
+
+    input.remove();
+    editable.remove();
+    keyboardManager.destroy();
+  });
+
+  it("keyboard manager drops active keyup bindings when release moves into an input", () => {
+    const eventHandler = vi.fn();
+    const keyboardManager = createKeyboardManager(eventHandler);
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    keyboardManager.registerHotkeys({
+      shift: {
+        keydown: { payload: { source: "ShiftDown" } },
+        keyup: { payload: { source: "ShiftUp" } },
+      },
+    });
+
+    dispatchKeyboardEvent("keydown", "Shift", {
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+    dispatchKeyboardEvent("keyup", "Shift", {
+      target: input,
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+    dispatchKeyboardEvent("keyup", "Shift", {
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+    dispatchKeyboardEvent("keydown", "Shift", {
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+    dispatchKeyboardEvent("keyup", "Shift", {
+      code: "ShiftLeft",
+      keyCode: 16,
+      which: 16,
+    });
+
+    expect(eventHandler.mock.calls).toEqual([
+      [
+        "keydown",
+        {
+          _event: { key: "shift" },
+          source: "ShiftDown",
+        },
+      ],
+      [
+        "keydown",
+        {
+          _event: { key: "shift" },
+          source: "ShiftDown",
+        },
+      ],
+      [
+        "keyup",
+        {
+          _event: { key: "shift" },
+          source: "ShiftUp",
+        },
+      ],
+    ]);
+
+    input.remove();
     keyboardManager.destroy();
   });
 });

--- a/spec/elements/eventSemantics.spec.js
+++ b/spec/elements/eventSemantics.spec.js
@@ -792,6 +792,10 @@ describe("event semantics", () => {
         keydown: { payload: { source: "SpaceDown" } },
         keyup: { payload: { source: "SpaceUp" } },
       },
+      enter: {
+        keydown: { payload: { source: "EnterDown" } },
+        keyup: { payload: { source: "EnterUp" } },
+      },
       shift: {
         keydown: { payload: { source: "ShiftDown" } },
         keyup: { payload: { source: "ShiftUp" } },
@@ -839,6 +843,108 @@ describe("event semantics", () => {
 
     input.remove();
     editable.remove();
+    keyboardManager.destroy();
+  });
+
+  it("keyboard manager ignores document-level shortcuts while an editable element is focused", () => {
+    const eventHandler = vi.fn();
+    const keyboardManager = createKeyboardManager(eventHandler);
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    keyboardManager.registerHotkeys({
+      space: {
+        keydown: { payload: { source: "SpaceDown" } },
+        keyup: { payload: { source: "SpaceUp" } },
+      },
+      enter: {
+        keydown: { payload: { source: "EnterDown" } },
+        keyup: { payload: { source: "EnterUp" } },
+      },
+    });
+
+    input.focus();
+
+    dispatchKeyboardEvent("keydown", " ", {
+      code: "Space",
+      keyCode: 32,
+      which: 32,
+    });
+    dispatchKeyboardEvent("keyup", " ", {
+      code: "Space",
+      keyCode: 32,
+      which: 32,
+    });
+    dispatchKeyboardEvent("keydown", "Enter", {
+      code: "Enter",
+      keyCode: 13,
+      which: 13,
+    });
+    dispatchKeyboardEvent("keyup", "Enter", {
+      code: "Enter",
+      keyCode: 13,
+      which: 13,
+    });
+    hotkeys.trigger("space");
+    hotkeys.trigger("enter");
+
+    expect(eventHandler).not.toHaveBeenCalled();
+
+    input.blur();
+
+    dispatchKeyboardEvent("keydown", " ", {
+      code: "Space",
+      keyCode: 32,
+      which: 32,
+    });
+    dispatchKeyboardEvent("keyup", " ", {
+      code: "Space",
+      keyCode: 32,
+      which: 32,
+    });
+    dispatchKeyboardEvent("keydown", "Enter", {
+      code: "Enter",
+      keyCode: 13,
+      which: 13,
+    });
+    dispatchKeyboardEvent("keyup", "Enter", {
+      code: "Enter",
+      keyCode: 13,
+      which: 13,
+    });
+
+    expect(eventHandler.mock.calls).toEqual([
+      [
+        "keydown",
+        {
+          _event: { key: "space" },
+          source: "SpaceDown",
+        },
+      ],
+      [
+        "keyup",
+        {
+          _event: { key: "space" },
+          source: "SpaceUp",
+        },
+      ],
+      [
+        "keydown",
+        {
+          _event: { key: "enter" },
+          source: "EnterDown",
+        },
+      ],
+      [
+        "keyup",
+        {
+          _event: { key: "enter" },
+          source: "EnterUp",
+        },
+      ],
+    ]);
+
+    input.remove();
     keyboardManager.destroy();
   });
 

--- a/spec/elements/inputPlugin.spec.js
+++ b/spec/elements/inputPlugin.spec.js
@@ -70,6 +70,7 @@ describe("input plugin", () => {
     expect(inputContainer.alpha).toBe(1);
 
     const mountOptions = bridgeState.mountArgs[1];
+    expect(mountOptions.callbacks.onSubmit).toBeUndefined();
     mountOptions.callbacks.onFocus({
       value: "",
       selectionStart: 0,
@@ -117,6 +118,7 @@ describe("input plugin", () => {
 
     expect(app.inputDomBridge.update).toHaveBeenCalledTimes(1);
     expect(bridgeState.updateArgs[1].value).toBe("native text");
+    expect(bridgeState.updateArgs[1].callbacks.onSubmit).toBeUndefined();
   });
 
   it("emits focus only once while the field stays focused across repeated native focus callbacks", () => {
@@ -167,6 +169,56 @@ describe("input plugin", () => {
     expect(
       eventHandler.mock.calls.filter(([eventName]) => eventName === "focus"),
     ).toHaveLength(1);
+  });
+
+  it("emits submit payload when configured", () => {
+    const parent = new Container();
+    const eventHandler = vi.fn();
+    const { app, bridgeState } = createApp();
+    const element = parseInput({
+      state: {
+        id: "name",
+        type: "input",
+        x: 20,
+        y: 40,
+        width: 200,
+        height: 44,
+        submit: {
+          payload: {
+            action: "nextLine",
+          },
+        },
+      },
+    });
+
+    addInput({
+      app,
+      parent,
+      element,
+      eventHandler,
+      zIndex: 0,
+    });
+
+    const { callbacks } = bridgeState.mountArgs[1];
+
+    callbacks.onSubmit({
+      value: "Jane",
+      selectionStart: 4,
+      selectionEnd: 4,
+      focused: true,
+      composing: false,
+    });
+
+    expect(eventHandler).toHaveBeenCalledWith("submit", {
+      _event: {
+        id: "name",
+        value: "Jane",
+        selectionStart: 4,
+        selectionEnd: 4,
+        composing: false,
+      },
+      action: "nextLine",
+    });
   });
 
   it("passes multiline fields through to the DOM bridge and updates their transform", () => {

--- a/spec/elements/inputPlugin.spec.js
+++ b/spec/elements/inputPlugin.spec.js
@@ -303,10 +303,15 @@ describe("input plugin", () => {
 
     const inputContainer = parent.getChildByLabel("name");
 
-    inputContainer.emit("pointerdown", {
+    const pointerDownEvent = {
       global: { x: 24, y: 52 },
       shiftKey: false,
-    });
+      stopPropagation: vi.fn(),
+    };
+
+    inputContainer.emit("pointerdown", pointerDownEvent);
+
+    expect(pointerDownEvent.stopPropagation).toHaveBeenCalledTimes(1);
 
     expect(app.inputDomBridge.focus).toHaveBeenCalledWith(
       "name",
@@ -317,9 +322,14 @@ describe("input plugin", () => {
     );
     expect(app.inputDomBridge.focus).toHaveBeenCalledTimes(1);
 
-    inputContainer.emit("globalpointermove", {
+    const pointerMoveEvent = {
       global: { x: 120, y: 52 },
-    });
+      stopPropagation: vi.fn(),
+    };
+
+    inputContainer.emit("globalpointermove", pointerMoveEvent);
+
+    expect(pointerMoveEvent.stopPropagation).toHaveBeenCalledTimes(1);
 
     expect(app.inputDomBridge.setSelection).toHaveBeenCalledWith(
       "name",
@@ -327,9 +337,20 @@ describe("input plugin", () => {
       expect.any(Number),
     );
 
-    inputContainer.emit("pointerup", {
+    const pointerUpEvent = {
       global: { x: 120, y: 52 },
-    });
+      stopPropagation: vi.fn(),
+    };
+
+    inputContainer.emit("pointerup", pointerUpEvent);
+
+    expect(pointerUpEvent.stopPropagation).toHaveBeenCalledTimes(1);
+
+    const rightClickEvent = { stopPropagation: vi.fn() };
+
+    inputContainer.emit("rightclick", rightClickEvent);
+
+    expect(rightClickEvent.stopPropagation).toHaveBeenCalledTimes(1);
   });
 
   it("runs update animations before unmounting a deleted input", () => {

--- a/spec/parser/parseInput.test.yaml
+++ b/spec/parser/parseInput.test.yaml
@@ -57,6 +57,7 @@ in:
       value: hunter2
       placeholder: Password
       multiline: true
+      submitOnEnter: false
       secure: true
       readOnly: true
       disabled: true
@@ -98,6 +99,7 @@ out:
   value: hunter2
   placeholder: Password
   multiline: true
+  submitOnEnter: false
   disabled: true
   maxLength: 32
   textStyle:

--- a/spec/util/inputDomBridge.spec.js
+++ b/spec/util/inputDomBridge.spec.js
@@ -246,6 +246,90 @@ describe("inputDomBridge", () => {
     bridge.destroy();
   });
 
+  it("prevents single-line Enter without submitting when submitOnEnter is false", () => {
+    const { app } = createApp();
+    const bridge = createInputDomBridge({ app });
+    const callbacks = {
+      onSubmit: vi.fn(),
+    };
+
+    const input = bridge.mount("name", {
+      value: "abc",
+      submitOnEnter: false,
+      padding: { top: 1, right: 1, bottom: 1, left: 1 },
+      textStyle: { fontSize: 18, fill: "#ffffff", align: "left" },
+      getGeometry: () => ({
+        x: 0,
+        y: 0,
+        width: 50,
+        height: 25,
+        visible: true,
+      }),
+      callbacks,
+    });
+    const onLaterInputKeydown = vi.fn();
+    input.addEventListener("keydown", onLaterInputKeydown);
+    input.focus();
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+
+    input.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(callbacks.onSubmit).not.toHaveBeenCalled();
+    expect(onLaterInputKeydown).not.toHaveBeenCalled();
+
+    bridge.destroy();
+  });
+
+  it("prevents multiline Enter from inserting a line break when submitOnEnter is false", () => {
+    const { app } = createApp();
+    const bridge = createInputDomBridge({ app });
+    const callbacks = {
+      onSubmit: vi.fn(),
+      onValueChange: vi.fn(),
+    };
+
+    const input = bridge.mount("bio", {
+      value: "abc",
+      multiline: true,
+      submitOnEnter: false,
+      padding: { top: 1, right: 1, bottom: 1, left: 1 },
+      textStyle: { fontSize: 18, fill: "#ffffff", align: "left" },
+      getGeometry: () => ({
+        x: 0,
+        y: 0,
+        width: 50,
+        height: 25,
+        visible: true,
+      }),
+      callbacks,
+    });
+    const onLaterInputKeydown = vi.fn();
+    input.addEventListener("keydown", onLaterInputKeydown);
+    input.focus();
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+
+    input.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(input.value).toBe("abc");
+    expect(callbacks.onSubmit).not.toHaveBeenCalled();
+    expect(callbacks.onValueChange).not.toHaveBeenCalled();
+    expect(onLaterInputKeydown).not.toHaveBeenCalled();
+
+    bridge.destroy();
+  });
+
   it("keeps focused input keyboard events from bubbling to document shortcuts", () => {
     const { app } = createApp();
     const bridge = createInputDomBridge({ app });

--- a/spec/util/inputDomBridge.spec.js
+++ b/spec/util/inputDomBridge.spec.js
@@ -246,6 +246,68 @@ describe("inputDomBridge", () => {
     bridge.destroy();
   });
 
+  it("keeps focused input keyboard events from bubbling to document shortcuts", () => {
+    const { app } = createApp();
+    const bridge = createInputDomBridge({ app });
+    const onDocumentKeydown = vi.fn();
+    const onDocumentKeyup = vi.fn();
+    const callbacks = {
+      onSubmit: vi.fn(),
+    };
+
+    document.addEventListener("keydown", onDocumentKeydown);
+    document.addEventListener("keyup", onDocumentKeyup);
+
+    const input = bridge.mount("name", {
+      value: "abc",
+      padding: { top: 1, right: 1, bottom: 1, left: 1 },
+      textStyle: { fontSize: 18, fill: "#ffffff", align: "left" },
+      getGeometry: () => ({
+        x: 0,
+        y: 0,
+        width: 50,
+        height: 25,
+        visible: true,
+      }),
+      callbacks,
+    });
+
+    input.focus();
+
+    const spaceDown = new KeyboardEvent("keydown", {
+      key: " ",
+      code: "Space",
+      bubbles: true,
+      cancelable: true,
+    });
+    const spaceUp = new KeyboardEvent("keyup", {
+      key: " ",
+      code: "Space",
+      bubbles: true,
+      cancelable: true,
+    });
+    const enterDown = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+
+    input.dispatchEvent(spaceDown);
+    input.dispatchEvent(spaceUp);
+    input.dispatchEvent(enterDown);
+
+    expect(spaceDown.defaultPrevented).toBe(false);
+    expect(spaceUp.defaultPrevented).toBe(false);
+    expect(enterDown.defaultPrevented).toBe(true);
+    expect(callbacks.onSubmit).toHaveBeenCalledTimes(1);
+    expect(onDocumentKeydown).not.toHaveBeenCalled();
+    expect(onDocumentKeyup).not.toHaveBeenCalled();
+
+    document.removeEventListener("keydown", onDocumentKeydown);
+    document.removeEventListener("keyup", onDocumentKeyup);
+    bridge.destroy();
+  });
+
   it("blurs when the pointer lands inside the unclipped box but outside the visible clipped region", () => {
     vi.useFakeTimers();
 

--- a/src/plugins/elements/input/addInput.js
+++ b/src/plugins/elements/input/addInput.js
@@ -26,17 +26,11 @@ const emitInputEvent = ({
       selectionEnd: snapshot.selectionEnd,
       composing: snapshot.composing,
     },
-    ...(eventConfig.payload ?? {}),
+    ...eventConfig.payload,
   });
 };
 
-const createCallbacks = ({
-  app,
-  container,
-  element,
-  runtime,
-  eventHandler,
-}) => ({
+const createCallbacks = ({ element, runtime, eventHandler }) => ({
   onValueChange: (snapshot) => {
     runtime.value = snapshot.value;
     runtime.selectionStart = snapshot.selectionStart;
@@ -109,15 +103,17 @@ const createCallbacks = ({
       snapshot,
     });
   },
-  onSubmit: (snapshot) => {
-    emitInputEvent({
-      eventHandler,
-      eventName: "submit",
-      element,
-      eventConfig: element.submit,
-      snapshot,
-    });
-  },
+  ...(element.submit && {
+    onSubmit: (snapshot) => {
+      emitInputEvent({
+        eventHandler,
+        eventName: "submit",
+        element,
+        eventConfig: element.submit,
+        snapshot,
+      });
+    },
+  }),
   onCompositionStart: (snapshot) => {
     runtime.composing = true;
     syncInputView(runtime, element);
@@ -320,8 +316,6 @@ export const addInput = ({
     ...element,
     value: runtime.value,
     callbacks: createCallbacks({
-      app,
-      container,
       element,
       runtime,
       eventHandler,

--- a/src/plugins/elements/input/addInput.js
+++ b/src/plugins/elements/input/addInput.js
@@ -235,6 +235,10 @@ export const addInput = ({
     app.inputDomBridge.setSelection(element.id, start, end);
   };
 
+  const stopInputPointerPropagation = (event) => {
+    event?.stopPropagation?.();
+  };
+
   const updateRuntimeSelection = ({
     start,
     end,
@@ -252,6 +256,8 @@ export const addInput = ({
   };
 
   const dragStartListener = (event) => {
+    stopInputPointerPropagation(event);
+
     if (runtime.element.disabled === true) return;
 
     const localPoint = container.toLocal(event.global);
@@ -279,6 +285,8 @@ export const addInput = ({
   const dragMoveListener = (event) => {
     if (!runtime.draggingSelection || runtime.element.disabled === true) return;
 
+    stopInputPointerPropagation(event);
+
     const localPoint = container.toLocal(event.global);
     const index = getInputIndexFromLocalPoint(runtime, localPoint);
     const anchor = runtime.selectionAnchor ?? index;
@@ -292,21 +300,27 @@ export const addInput = ({
     });
   };
 
-  const dragEndListener = () => {
+  const dragEndListener = (event) => {
+    stopInputPointerPropagation(event);
     runtime.draggingSelection = false;
   };
 
-  container.on("pointerdown", dragStartListener);
-  container.on("globalpointermove", dragMoveListener);
-  container.on("pointerup", dragEndListener);
-  container.on("pointerupoutside", dragEndListener);
-  container.on("pointerup", () => {
+  const releaseListener = (event) => {
+    stopInputPointerPropagation(event);
+    runtime.draggingSelection = false;
+
     if (runtime.element.disabled === true) return;
     app.inputDomBridge.focus(element.id, {
       selectionStart: runtime.selectionStart,
       selectionEnd: runtime.selectionEnd,
     });
-  });
+  };
+
+  container.on("pointerdown", dragStartListener);
+  container.on("globalpointermove", dragMoveListener);
+  container.on("pointerup", releaseListener);
+  container.on("pointerupoutside", dragEndListener);
+  container.on("rightclick", stopInputPointerPropagation);
 
   container[INPUT_RUNTIME] = runtime;
 

--- a/src/plugins/elements/input/parseInput.js
+++ b/src/plugins/elements/input/parseInput.js
@@ -15,6 +15,9 @@ export const parseInput = ({ state }) => {
     placeholder,
     multiline: state.multiline === true,
     disabled: state.disabled === true,
+    ...(typeof state.submitOnEnter === "boolean" && {
+      submitOnEnter: state.submitOnEnter,
+    }),
     ...(typeof state.maxLength === "number" && {
       maxLength: Math.round(state.maxLength),
     }),

--- a/src/plugins/elements/input/updateInput.js
+++ b/src/plugins/elements/input/updateInput.js
@@ -22,7 +22,7 @@ const emitInputEvent = ({
       selectionEnd: snapshot.selectionEnd,
       composing: snapshot.composing,
     },
-    ...(eventConfig.payload ?? {}),
+    ...eventConfig.payload,
   });
 };
 
@@ -99,15 +99,17 @@ const createCallbacks = ({ element, runtime, eventHandler }) => ({
       snapshot,
     });
   },
-  onSubmit: (snapshot) => {
-    emitInputEvent({
-      eventHandler,
-      eventName: "submit",
-      element,
-      eventConfig: element.submit,
-      snapshot,
-    });
-  },
+  ...(element.submit && {
+    onSubmit: (snapshot) => {
+      emitInputEvent({
+        eventHandler,
+        eventName: "submit",
+        element,
+        eventConfig: element.submit,
+        snapshot,
+      });
+    },
+  }),
   onCompositionStart: (snapshot) => {
     runtime.composing = true;
     syncInputView(runtime, element);

--- a/src/schemas/elements/input.computed.yaml
+++ b/src/schemas/elements/input.computed.yaml
@@ -36,6 +36,8 @@ properties:
     type: string
   multiline:
     type: boolean
+  submitOnEnter:
+    type: boolean
   disabled:
     type: boolean
   maxLength:

--- a/src/schemas/elements/input.element.yaml
+++ b/src/schemas/elements/input.element.yaml
@@ -40,6 +40,10 @@ properties:
     type: boolean
     description: Use a native textarea and render explicit line breaks
     default: false
+  submitOnEnter:
+    type: boolean
+    description: Emit the input submit event when Enter is pressed; when false, Enter is consumed and will not insert multiline line breaks
+    default: true
   disabled:
     type: boolean
     description: Disable focus and editing

--- a/src/types.js
+++ b/src/types.js
@@ -511,6 +511,7 @@
  * @property {string} value
  * @property {string} placeholder
  * @property {boolean} multiline
+ * @property {boolean} [submitOnEnter]
  * @property {boolean} disabled
  * @property {number} [maxLength]
  * @property {Object} textStyle

--- a/src/util/inputDomBridge.js
+++ b/src/util/inputDomBridge.js
@@ -268,7 +268,6 @@ export const createInputDomBridge = ({ app }) => {
     if (isPointerWithinEntryGeometry({ app, entry: activeEntry, event })) {
       return;
     }
-
     activeEntry.element.blur();
   };
 
@@ -344,7 +343,6 @@ export const createInputDomBridge = ({ app }) => {
           entry.lastSnapshot = snapshot;
           return;
         }
-
         entry.lastSnapshot = snapshot;
         entry.callbacks.onBlur?.(snapshot);
         entry.callbacks.onSelectionChange?.(snapshot);
@@ -356,23 +354,39 @@ export const createInputDomBridge = ({ app }) => {
     element.addEventListener("click", () => queueMicrotask(syncFromDom));
     element.addEventListener("keyup", (event) => {
       event.stopPropagation();
+      event.stopImmediatePropagation?.();
       queueMicrotask(syncFromDom);
     });
     element.addEventListener("keydown", (event) => {
       event.stopPropagation();
+      event.stopImmediatePropagation?.();
 
-      const shouldSubmitSingleLine =
+      const submitOnEnter = entry.options.submitOnEnter !== false;
+      const shouldConsumeEnter = entry.options.submitOnEnter === false;
+      const hasSubmitCallback = typeof entry.callbacks.onSubmit === "function";
+      const isSingleLineEnter =
         event.key === "Enter" &&
         entry.options.multiline !== true &&
         !event.shiftKey;
+      const shouldSubmitSingleLine =
+        isSingleLineEnter && submitOnEnter && hasSubmitCallback;
       const shouldSubmitMultiline =
         event.key === "Enter" &&
         entry.options.multiline === true &&
-        (event.ctrlKey || event.metaKey);
+        (event.ctrlKey || event.metaKey) &&
+        submitOnEnter &&
+        hasSubmitCallback;
+
+      if (
+        isSingleLineEnter ||
+        shouldSubmitMultiline ||
+        (event.key === "Enter" && shouldConsumeEnter)
+      ) {
+        event.preventDefault();
+      }
 
       if (shouldSubmitSingleLine || shouldSubmitMultiline) {
-        event.preventDefault();
-        entry.callbacks.onSubmit?.(getSnapshot(entry), event);
+        entry.callbacks.onSubmit(getSnapshot(entry), event);
       }
 
       if (event.key === "Escape") {
@@ -445,7 +459,6 @@ export const createInputDomBridge = ({ app }) => {
     entries.set(id, entry);
     syncGeometry(entry);
     entry.lastSnapshot = getSnapshot(entry);
-
     return entry.element;
   };
 
@@ -524,13 +537,11 @@ export const createInputDomBridge = ({ app }) => {
     if (!entry || entry.element.disabled) return;
 
     const isAlreadyFocused = document.activeElement === entry.element;
-
     activeId = id;
     applyPointerInteractivity(entry, activeId);
     if (!isAlreadyFocused) {
       entry.element.focus();
     }
-
     if (selectAll) {
       entry.element.select?.();
       notifySnapshot(entry, entry.lastSnapshot);
@@ -579,7 +590,6 @@ export const createInputDomBridge = ({ app }) => {
 
   const blur = (id) => {
     const entry = entries.get(id);
-
     entry?.element.blur();
   };
 
@@ -587,7 +597,6 @@ export const createInputDomBridge = ({ app }) => {
     const entry = entries.get(id);
 
     if (!entry) return;
-
     if (activeId === id) {
       activeId = null;
     }

--- a/src/util/inputDomBridge.js
+++ b/src/util/inputDomBridge.js
@@ -354,8 +354,13 @@ export const createInputDomBridge = ({ app }) => {
     element.addEventListener("input", syncFromDom);
     element.addEventListener("select", syncFromDom);
     element.addEventListener("click", () => queueMicrotask(syncFromDom));
-    element.addEventListener("keyup", () => queueMicrotask(syncFromDom));
+    element.addEventListener("keyup", (event) => {
+      event.stopPropagation();
+      queueMicrotask(syncFromDom);
+    });
     element.addEventListener("keydown", (event) => {
+      event.stopPropagation();
+
       const shouldSubmitSingleLine =
         event.key === "Enter" &&
         entry.options.multiline !== true &&

--- a/src/util/keyboardManager.js
+++ b/src/util/keyboardManager.js
@@ -130,8 +130,94 @@ const getShortcutActivationKey = (binding, shortcut) => {
   return `${binding}${SHORTCUT_ACTIVATION_KEY_DELIMITER}${shortcut.shortcut}`;
 };
 
+const isEditableKeyboardTarget = (target) => {
+  if (!target || typeof target !== "object") {
+    return false;
+  }
+
+  const tagName =
+    typeof target.tagName === "string" ? target.tagName.toLowerCase() : "";
+
+  if (["input", "textarea", "select"].includes(tagName)) {
+    return true;
+  }
+
+  if (
+    (typeof HTMLInputElement !== "undefined" &&
+      target instanceof HTMLInputElement) ||
+    (typeof HTMLTextAreaElement !== "undefined" &&
+      target instanceof HTMLTextAreaElement) ||
+    (typeof HTMLSelectElement !== "undefined" &&
+      target instanceof HTMLSelectElement)
+  ) {
+    return true;
+  }
+
+  if (
+    target.isContentEditable === true ||
+    target.contentEditable === "true" ||
+    target.contentEditable === "plaintext-only"
+  ) {
+    return true;
+  }
+
+  if (typeof target.getAttribute === "function") {
+    const contentEditable = target.getAttribute("contenteditable");
+
+    if (contentEditable !== null && contentEditable.toLowerCase() !== "false") {
+      return true;
+    }
+
+    if (target.getAttribute("data-route-graphics-input-id") !== null) {
+      return true;
+    }
+  }
+
+  const closest =
+    typeof target.closest === "function"
+      ? target.closest.bind(target)
+      : typeof target.parentElement?.closest === "function"
+        ? target.parentElement.closest.bind(target.parentElement)
+        : null;
+
+  if (!closest) {
+    return false;
+  }
+
+  return Boolean(
+    closest(
+      '[data-route-graphics-input-id], [contenteditable]:not([contenteditable="false"])',
+    ),
+  );
+};
+
 const shouldHandleKeydown = (event) => {
+  if (isEditableKeyboardTarget(event?.target)) {
+    return false;
+  }
+
   return typeof hotkeys.filter !== "function" || hotkeys.filter(event);
+};
+
+const clearReleasedKeyState = ({
+  activeKeyupShortcuts,
+  activeModifierShortcuts,
+  pressedKeyCodes,
+  releasedKeyCode,
+}) => {
+  for (const [activationKey, activeShortcut] of [...activeKeyupShortcuts]) {
+    if (activeShortcut.releaseCodes.has(releasedKeyCode)) {
+      activeKeyupShortcuts.delete(activationKey);
+    }
+  }
+
+  for (const [activationKey, activeShortcut] of [...activeModifierShortcuts]) {
+    if (activeShortcut.releaseCodes.has(releasedKeyCode)) {
+      activeModifierShortcuts.delete(activationKey);
+    }
+  }
+
+  pressedKeyCodes.delete(releasedKeyCode);
 };
 
 const normalizeBindingConfig = (config) => {
@@ -246,6 +332,7 @@ export const createKeyboardManager = (eventHandler) => {
 
   const onDocumentKeydown = (event) => {
     if (!shouldHandleKeydown(event)) {
+      clearActiveKeyupBindings();
       return;
     }
 
@@ -281,6 +368,16 @@ export const createKeyboardManager = (eventHandler) => {
     const releasedKeyCode = getEventKeyCode(event);
 
     if (typeof releasedKeyCode !== "number") {
+      return;
+    }
+
+    if (isEditableKeyboardTarget(event?.target)) {
+      clearReleasedKeyState({
+        activeKeyupShortcuts,
+        activeModifierShortcuts,
+        pressedKeyCodes,
+        releasedKeyCode,
+      });
       return;
     }
 
@@ -369,6 +466,11 @@ export const createKeyboardManager = (eventHandler) => {
       // hotkeys-js is reliable for combo activation, but not for combo release
       // when modifiers are released before the final non-modifier key.
       hotkeys(binding, (_event, handler) => {
+        if (isEditableKeyboardTarget(_event?.target)) {
+          clearActiveKeyupBindings();
+          return;
+        }
+
         const shortcut = getHandlerShortcut(binding, handler);
 
         if (shortcut?.isModifierOnly) {

--- a/src/util/keyboardManager.js
+++ b/src/util/keyboardManager.js
@@ -191,12 +191,32 @@ const isEditableKeyboardTarget = (target) => {
   );
 };
 
-const shouldHandleKeydown = (event) => {
-  if (isEditableKeyboardTarget(event?.target)) {
-    return false;
+const getActiveKeyboardTarget = () => {
+  if (typeof document === "undefined") {
+    return null;
   }
 
-  return typeof hotkeys.filter !== "function" || hotkeys.filter(event);
+  return document.activeElement ?? null;
+};
+
+const isEditableKeyboardEvent = (event) => {
+  if (isEditableKeyboardTarget(event?.target)) {
+    return true;
+  }
+
+  return isEditableKeyboardTarget(getActiveKeyboardTarget());
+};
+
+const getKeydownBlockReason = (event) => {
+  if (isEditableKeyboardEvent(event)) {
+    return "editable-context";
+  }
+
+  if (typeof hotkeys.filter === "function" && !hotkeys.filter(event)) {
+    return "hotkeys-filter";
+  }
+
+  return null;
 };
 
 const clearReleasedKeyState = ({
@@ -205,13 +225,17 @@ const clearReleasedKeyState = ({
   pressedKeyCodes,
   releasedKeyCode,
 }) => {
-  for (const [activationKey, activeShortcut] of [...activeKeyupShortcuts]) {
+  for (const [activationKey, activeShortcut] of Array.from(
+    activeKeyupShortcuts,
+  )) {
     if (activeShortcut.releaseCodes.has(releasedKeyCode)) {
       activeKeyupShortcuts.delete(activationKey);
     }
   }
 
-  for (const [activationKey, activeShortcut] of [...activeModifierShortcuts]) {
+  for (const [activationKey, activeShortcut] of Array.from(
+    activeModifierShortcuts,
+  )) {
     if (activeShortcut.releaseCodes.has(releasedKeyCode)) {
       activeModifierShortcuts.delete(activationKey);
     }
@@ -272,15 +296,17 @@ export const createKeyboardManager = (eventHandler) => {
   };
 
   const clearBindingState = (binding) => {
-    for (const [activationKey, activeShortcut] of [...activeKeyupShortcuts]) {
+    for (const [activationKey, activeShortcut] of Array.from(
+      activeKeyupShortcuts,
+    )) {
       if (activeShortcut.binding === binding) {
         activeKeyupShortcuts.delete(activationKey);
       }
     }
 
-    for (const [activationKey, activeShortcut] of [
-      ...activeModifierShortcuts,
-    ]) {
+    for (const [activationKey, activeShortcut] of Array.from(
+      activeModifierShortcuts,
+    )) {
       if (activeShortcut.binding === binding) {
         activeModifierShortcuts.delete(activationKey);
       }
@@ -331,7 +357,9 @@ export const createKeyboardManager = (eventHandler) => {
   };
 
   const onDocumentKeydown = (event) => {
-    if (!shouldHandleKeydown(event)) {
+    const blockReason = getKeydownBlockReason(event);
+
+    if (blockReason) {
       clearActiveKeyupBindings();
       return;
     }
@@ -341,7 +369,6 @@ export const createKeyboardManager = (eventHandler) => {
     if (typeof pressedKeyCode !== "number") {
       return;
     }
-
     pressedKeyCodes.add(pressedKeyCode);
 
     for (const [binding, config] of registeredBindings) {
@@ -365,23 +392,29 @@ export const createKeyboardManager = (eventHandler) => {
   };
 
   const onDocumentKeyup = (event) => {
+    const isEditableEvent = isEditableKeyboardEvent(event);
     const releasedKeyCode = getEventKeyCode(event);
+
+    if (isEditableEvent) {
+      if (typeof releasedKeyCode === "number") {
+        clearReleasedKeyState({
+          activeKeyupShortcuts,
+          activeModifierShortcuts,
+          pressedKeyCodes,
+          releasedKeyCode,
+        });
+      } else {
+        clearActiveKeyupBindings();
+      }
+      return;
+    }
 
     if (typeof releasedKeyCode !== "number") {
       return;
     }
-
-    if (isEditableKeyboardTarget(event?.target)) {
-      clearReleasedKeyState({
-        activeKeyupShortcuts,
-        activeModifierShortcuts,
-        pressedKeyCodes,
-        releasedKeyCode,
-      });
-      return;
-    }
-
-    for (const [activationKey, activeShortcut] of [...activeKeyupShortcuts]) {
+    for (const [activationKey, activeShortcut] of Array.from(
+      activeKeyupShortcuts,
+    )) {
       const config = registeredBindings.get(activeShortcut.binding);
 
       if (!activeShortcut.releaseCodes.has(releasedKeyCode) || !config?.keyup) {
@@ -392,9 +425,9 @@ export const createKeyboardManager = (eventHandler) => {
       emitKeyboardEvent("keyup", activeShortcut.binding, config.keyup.payload);
     }
 
-    for (const [activationKey, activeShortcut] of [
-      ...activeModifierShortcuts,
-    ]) {
+    for (const [activationKey, activeShortcut] of Array.from(
+      activeModifierShortcuts,
+    )) {
       if (activeShortcut.releaseCodes.has(releasedKeyCode)) {
         activeModifierShortcuts.delete(activationKey);
       }
@@ -466,7 +499,7 @@ export const createKeyboardManager = (eventHandler) => {
       // hotkeys-js is reliable for combo activation, but not for combo release
       // when modifiers are released before the final non-modifier key.
       hotkeys(binding, (_event, handler) => {
-        if (isEditableKeyboardTarget(_event?.target)) {
+        if (isEditableKeyboardEvent(_event)) {
           clearActiveKeyupBindings();
           return;
         }

--- a/vt/specs/input/input-keyboard-isolation.yaml
+++ b/vt/specs/input/input-keyboard-isolation.yaml
@@ -1,0 +1,124 @@
+---
+title: Input Keyboard Isolation
+description: Focused input typing should not emit global keyboard shortcuts.
+skipInitialScreenshot: true
+specs:
+  - pressing Space while an input is focused should edit the field only
+  - the same global Space shortcut should work after the input loses focus
+steps:
+  - action: customEvent
+    name: clearEvents
+  - action: click
+    x: 180
+    "y": 88
+  - action: wait
+    ms: 100
+  - action: keypress
+    key: A
+  - action: keypress
+    key: Space
+  - action: keypress
+    key: B
+  - action: wait
+    ms: 120
+  - action: assert
+    type: js
+    fn: vtAssert.payloadDeepEquals
+    args:
+      - change
+    value:
+      - _event:
+          id: input-name
+          value: A
+          selectionStart: 1
+          selectionEnd: 1
+          composing: false
+        action: inputChange
+      - _event:
+          id: input-name
+          value: "A "
+          selectionStart: 2
+          selectionEnd: 2
+          composing: false
+        action: inputChange
+      - _event:
+          id: input-name
+          value: A B
+          selectionStart: 3
+          selectionEnd: 3
+          composing: false
+        action: inputChange
+  - action: assert
+    type: js
+    fn: vtAssert.payloadDeepEquals
+    args:
+      - keydown
+    value: []
+  - action: assert
+    type: js
+    fn: vtAssert.payloadDeepEquals
+    args:
+      - keyup
+    value: []
+  - action: customEvent
+    name: clearEvents
+  - action: click
+    x: 20
+    "y": 20
+  - action: wait
+    ms: 100
+  - action: keypress
+    key: Space
+  - action: assert
+    type: js
+    fn: vtAssert.payloadDeepEquals
+    args:
+      - keydown
+    value:
+      - _event:
+          key: space
+        action: globalSpaceDown
+  - action: assert
+    type: js
+    fn: vtAssert.payloadDeepEquals
+    args:
+      - keyup
+    value:
+      - _event:
+          key: space
+        action: globalSpaceUp
+---
+states:
+  - elements:
+      - id: input-bg
+        type: rect
+        x: 0
+        "y": 0
+        width: 1280
+        height: 720
+        fill: "#000000"
+      - id: input-name
+        type: input
+        x: 60
+        "y": 60
+        width: 240
+        height: 56
+        placeholder: Your name
+        textStyle:
+          fill: "#FFFFFF"
+          fontSize: 22
+        focusEvent:
+          payload:
+            action: inputFocus
+        change:
+          payload:
+            action: inputChange
+    global:
+      keyboard:
+        space:
+          keydown:
+            payload:
+              action: globalSpaceDown
+          keyup:
+            payload:
+              action: globalSpaceUp

--- a/vt/specs/input/input-keyboard-isolation.yaml
+++ b/vt/specs/input/input-keyboard-isolation.yaml
@@ -3,6 +3,7 @@ title: Input Keyboard Isolation
 description: Focused input typing should not emit global keyboard shortcuts.
 skipInitialScreenshot: true
 specs:
+  - clicking an input inside a clickable container should not emit the container click
   - pressing Space while an input is focused should edit the field only
   - pressing Enter while an input is focused should not emit global keyboard shortcuts
   - the same global Space and Enter shortcuts should work after the input loses focus
@@ -63,6 +64,12 @@ steps:
     args:
       - keyup
     value: []
+  - action: assert
+    type: js
+    fn: vtAssert.payloadDeepEquals
+    args:
+      - click
+    value: []
   - action: customEvent
     name: clearEvents
   - action: click
@@ -108,22 +115,32 @@ states:
         width: 1280
         height: 720
         fill: "#000000"
-      - id: input-name
-        type: input
+      - id: input-wrapper
+        type: container
         x: 60
         "y": 60
         width: 240
         height: 56
-        placeholder: Your name
-        textStyle:
-          fill: "#FFFFFF"
-          fontSize: 22
-        focusEvent:
+        click:
           payload:
-            action: inputFocus
-        change:
-          payload:
-            action: inputChange
+            action: parentClick
+        children:
+          - id: input-name
+            type: input
+            x: 0
+            "y": 0
+            width: 240
+            height: 56
+            placeholder: Your name
+            textStyle:
+              fill: "#FFFFFF"
+              fontSize: 22
+            focusEvent:
+              payload:
+                action: inputFocus
+            change:
+              payload:
+                action: inputChange
     global:
       keyboard:
         space:

--- a/vt/specs/input/input-keyboard-isolation.yaml
+++ b/vt/specs/input/input-keyboard-isolation.yaml
@@ -4,7 +4,8 @@ description: Focused input typing should not emit global keyboard shortcuts.
 skipInitialScreenshot: true
 specs:
   - pressing Space while an input is focused should edit the field only
-  - the same global Space shortcut should work after the input loses focus
+  - pressing Enter while an input is focused should not emit global keyboard shortcuts
+  - the same global Space and Enter shortcuts should work after the input loses focus
 steps:
   - action: customEvent
     name: clearEvents
@@ -19,6 +20,8 @@ steps:
     key: Space
   - action: keypress
     key: B
+  - action: keypress
+    key: Enter
   - action: wait
     ms: 120
   - action: assert
@@ -69,6 +72,8 @@ steps:
     ms: 100
   - action: keypress
     key: Space
+  - action: keypress
+    key: Enter
   - action: assert
     type: js
     fn: vtAssert.payloadDeepEquals
@@ -78,6 +83,9 @@ steps:
       - _event:
           key: space
         action: globalSpaceDown
+      - _event:
+          key: enter
+        action: globalEnterDown
   - action: assert
     type: js
     fn: vtAssert.payloadDeepEquals
@@ -87,6 +95,9 @@ steps:
       - _event:
           key: space
         action: globalSpaceUp
+      - _event:
+          key: enter
+        action: globalEnterUp
 ---
 states:
   - elements:
@@ -122,3 +133,10 @@ states:
           keyup:
             payload:
               action: globalSpaceUp
+        enter:
+          keydown:
+            payload:
+              action: globalEnterDown
+          keyup:
+            payload:
+              action: globalEnterUp


### PR DESCRIPTION
Bumps route-graphics to 1.20.2, adds submitOnEnter input behavior, wires submit callbacks only for configured submit events, and prevents focused native inputs from triggering global keyboard shortcuts. Testing: focused Vitest specs, parseInput YAML spec, Prettier check, oxlint src, and pre-push full test suite passed.