### PR TITLE
Add animation playback speed control

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/animations/animationBus.spec.js
+++ b/spec/animations/animationBus.spec.js
@@ -134,6 +134,98 @@ describe("animationBus auto tween shorthand", () => {
     expect(element.alpha).toBeCloseTo(0.625);
   });
 
+  it("scales ticked elapsed time by playback speed", () => {
+    const animationBus = createAnimationBus();
+    const onComplete = vi.fn();
+    const element = {
+      x: 0,
+      scale: { x: 1, y: 1 },
+    };
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "fast-x",
+        playbackSpeed: 2,
+        element,
+        properties: {
+          x: {
+            keyframes: [{ duration: 1000, value: 100, easing: "linear" }],
+          },
+        },
+        onComplete,
+      },
+    });
+
+    animationBus.flush();
+    animationBus.tick(250);
+
+    expect(element.x).toBeCloseTo(50);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    animationBus.tick(250);
+
+    expect(element.x).toBeCloseTo(100);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("scales manually sampled time by playback speed", () => {
+    const animationBus = createAnimationBus();
+    const element = {
+      x: 0,
+      scale: { x: 1, y: 1 },
+    };
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "manual-fast-x",
+        playbackSpeed: 2,
+        element,
+        properties: {
+          x: {
+            keyframes: [{ duration: 1000, value: 100, easing: "linear" }],
+          },
+        },
+      },
+    });
+
+    animationBus.setTime(250);
+
+    expect(element.x).toBeCloseTo(50);
+    expect(animationBus.getState().animations[0]).toMatchObject({
+      id: "manual-fast-x",
+      currentTime: 500,
+      playbackSpeed: 2,
+      progress: 0.5,
+    });
+  });
+
+  it("rejects invalid playback speeds", () => {
+    const animationBus = createAnimationBus();
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "bad-speed",
+        playbackSpeed: 0,
+        element: {
+          x: 0,
+          scale: { x: 1, y: 1 },
+        },
+        properties: {
+          x: {
+            keyframes: [{ duration: 1000, value: 100, easing: "linear" }],
+          },
+        },
+      },
+    });
+
+    expect(() => animationBus.flush()).toThrow(
+      'Animation "bad-speed" playback speed must be a finite number greater than 0.',
+    );
+  });
+
   it("applies property path mapping for auto scale tweens", () => {
     const animationBus = createAnimationBus();
     const onComplete = vi.fn();

--- a/spec/parser/normalizeRenderState.test.yaml
+++ b/spec/parser/normalizeRenderState.test.yaml
@@ -449,6 +449,71 @@ out:
   audio: []
   audioEffects: []
 ---
+case: Normalize update animation with playback speed
+in:
+  - id: state-2-speed-update
+    animations:
+      - id: anim-speed-update
+        targetId: portrait
+        type: update
+        playback:
+          speed: 2
+        tween:
+          x:
+            keyframes:
+              - duration: 1000
+                value: 320
+out:
+  id: state-2-speed-update
+  elements: []
+  animations:
+    - id: anim-speed-update
+      targetId: portrait
+      type: update
+      playback:
+        continuity: render
+        speed: 2
+      tween:
+        x:
+          keyframes:
+            - duration: 1000
+              value: 320
+              easing: linear
+  audio: []
+  audioEffects: []
+---
+case: Normalize default playback speed away
+in:
+  - id: state-2-default-speed-update
+    animations:
+      - id: anim-default-speed-update
+        targetId: portrait
+        type: update
+        playback:
+          speed: 1
+        tween:
+          x:
+            keyframes:
+              - duration: 1000
+                value: 320
+out:
+  id: state-2-default-speed-update
+  elements: []
+  animations:
+    - id: anim-default-speed-update
+      targetId: portrait
+      type: update
+      playback:
+        continuity: render
+      tween:
+        x:
+          keyframes:
+            - duration: 1000
+              value: 320
+              easing: linear
+  audio: []
+  audioEffects: []
+---
 case: Normalize transition animation with persistent playback continuity
 in:
   - id: state-2-persistent-transition
@@ -708,6 +773,40 @@ in:
               - duration: 100
                 value: 20
 throws: "animations[0].playback.continuity must be one of: render, persistent."
+---
+case: Throw when playback speed is zero
+in:
+  - id: state-3c-playback-speed-zero
+    animations:
+      - id: anim-playback-speed-zero
+        targetId: text-1
+        type: update
+        playback:
+          continuity: render
+          speed: 0
+        tween:
+          x:
+            keyframes:
+              - duration: 100
+                value: 20
+throws: animations[0].playback.speed must be a finite number greater than 0.
+---
+case: Throw when playback speed is not a number
+in:
+  - id: state-3c-playback-speed-type
+    animations:
+      - id: anim-playback-speed-type
+        targetId: text-1
+        type: update
+        playback:
+          continuity: render
+          speed: fast
+        tween:
+          x:
+            keyframes:
+              - duration: 100
+                value: 20
+throws: animations[0].playback.speed must be a finite number greater than 0.
 ---
 case: Throw when sequence mask uses legacy textures
 in:

--- a/src/plugins/animations/animationBus.js
+++ b/src/plugins/animations/animationBus.js
@@ -14,6 +14,8 @@ import {
   getValueAtTime,
 } from "../../util/animationTimeline.js";
 
+const DEFAULT_PLAYBACK_SPEED = 1;
+
 const hasTranslateProperties = (properties = {}) =>
   Object.keys(properties).some(isTranslateAnimationProperty);
 
@@ -106,10 +108,27 @@ export const createAnimationBus = () => {
   };
 
   const applyTimeToContext = (context, timeMS) => {
-    const nextTime = clampAnimationTime(timeMS, context.duration);
+    const nextTime = clampAnimationTime(
+      timeMS * context.playbackSpeed,
+      context.duration,
+    );
     context.currentTime = nextTime;
     context.applyFrame(nextTime);
     return nextTime >= context.duration;
+  };
+
+  const normalizePlaybackSpeed = (value, animationId) => {
+    if (value === undefined || value === null) {
+      return DEFAULT_PLAYBACK_SPEED;
+    }
+
+    if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+      throw new Error(
+        `Animation "${animationId}" playback speed must be a finite number greater than 0.`,
+      );
+    }
+
+    return value;
   };
 
   const emit = (event, data) => {
@@ -139,6 +158,10 @@ export const createAnimationBus = () => {
     context.targetId = metadata.targetId ?? context.targetId;
     context.signature = metadata.signature ?? context.signature;
     context.continuity = metadata.continuity ?? context.continuity ?? "render";
+    context.playbackSpeed = normalizePlaybackSpeed(
+      metadata.playbackSpeed ?? context.playbackSpeed,
+      context.id,
+    );
     context.onContinuationUpdate =
       metadata.onContinuationUpdate ?? context.onContinuationUpdate;
     return context;
@@ -215,6 +238,7 @@ export const createAnimationBus = () => {
       timelines,
       duration: calculateMaxDuration(timelines),
       currentTime: 0,
+      playbackSpeed: DEFAULT_PLAYBACK_SPEED,
       stateVersion,
       targetState,
       onComplete,
@@ -275,6 +299,7 @@ export const createAnimationBus = () => {
       kind: "custom",
       duration: payload.duration ?? 0,
       currentTime: 0,
+      playbackSpeed: DEFAULT_PLAYBACK_SPEED,
       deferCompletionUntilNextFrame:
         payload.deferCompletionUntilNextFrame === true,
       pendingCompletion: false,
@@ -439,7 +464,7 @@ export const createAnimationBus = () => {
       }
 
       context.currentTime = clampAnimationTime(
-        context.currentTime + deltaMS,
+        context.currentTime + deltaMS * context.playbackSpeed,
         context.duration,
       );
 
@@ -545,6 +570,7 @@ export const createAnimationBus = () => {
       targetId: pendingContext.targetId,
       signature: pendingContext.signature,
       continuity: pendingContext.continuity,
+      playbackSpeed: pendingContext.playbackSpeed,
       onContinuationUpdate:
         payload.onContinuationUpdate ?? pendingContext.onContinuationUpdate,
     });
@@ -599,6 +625,7 @@ export const createAnimationBus = () => {
       id,
       currentTime: ctx.currentTime,
       duration: ctx.duration,
+      playbackSpeed: ctx.playbackSpeed,
       progress: ctx.duration > 0 ? ctx.currentTime / ctx.duration : 0,
     })),
   });

--- a/src/plugins/animations/planAnimations.test.js
+++ b/src/plugins/animations/planAnimations.test.js
@@ -44,4 +44,31 @@ describe("getAnimationContinuitySignature", () => {
       }),
     );
   });
+
+  it("includes playback speed in persistent signatures", () => {
+    const base = {
+      id: "slide",
+      targetId: "portrait",
+      type: "update",
+      playback: {
+        continuity: "persistent",
+        speed: 1,
+      },
+      tween: {
+        x: {
+          keyframes: [{ duration: 1000, value: 400, easing: "linear" }],
+        },
+      },
+    };
+
+    expect(getAnimationContinuitySignature(base)).not.toBe(
+      getAnimationContinuitySignature({
+        ...base,
+        playback: {
+          continuity: "persistent",
+          speed: 2,
+        },
+      }),
+    );
+  });
 });

--- a/src/plugins/animations/replace/runReplaceAnimation.js
+++ b/src/plugins/animations/replace/runReplaceAnimation.js
@@ -1671,6 +1671,7 @@ export const runReplaceAnimation = ({
       targetId: animation.targetId,
       signature: continuitySignature,
       continuity: "persistent",
+      playbackSpeed: animation.playback?.speed,
       onCancel: () => {
         transitionSignalController?.abort();
         clearDeferredMountOperations(hiddenMountContext);
@@ -1768,6 +1769,7 @@ export const runReplaceAnimation = ({
       targetId: animation.targetId,
       signature: continuitySignature,
       continuity: isPersistent ? "persistent" : "render",
+      playbackSpeed: animation.playback?.speed,
       onContinuationUpdate: handleContinuationUpdate,
       duration: replaceOverlay.duration,
       deferCompletionUntilNextFrame: animation.compositor !== undefined,

--- a/src/plugins/animations/updateAnimationDispatch.js
+++ b/src/plugins/animations/updateAnimationDispatch.js
@@ -88,6 +88,7 @@ export const dispatchUpdateAnimationsNow = ({
         animationType: animation.type,
         targetId: animation.targetId,
         continuity: animation.playback?.continuity ?? "render",
+        playbackSpeed: animation.playback?.speed,
         signature:
           animation.signature ??
           JSON.stringify({

--- a/src/schemas/animations/animation.yaml
+++ b/src/schemas/animations/animation.yaml
@@ -270,12 +270,15 @@ $defs:
               - required: [softness]
   playback:
     type: object
-    required:
-      - continuity
     properties:
       continuity:
         type: string
         enum: [render, persistent]
+        default: render
+      speed:
+        type: number
+        exclusiveMinimum: 0
+        description: Playback speed multiplier. 1 is authored speed, 2 is twice as fast, 0.5 is half speed.
     additionalProperties: false
 properties:
   id:

--- a/src/util/normalizeAnimations.js
+++ b/src/util/normalizeAnimations.js
@@ -3,6 +3,8 @@ import { normalizeShaderCompositor } from "../plugins/elements/util/shaderConfig
 
 const ANIMATION_TYPES = new Set(["update", "transition"]);
 const CONTINUITY_MODES = new Set(["render", "persistent"]);
+const DEFAULT_PLAYBACK_CONTINUITY = "render";
+const DEFAULT_PLAYBACK_SPEED = 1;
 const UPDATE_TWEEN_PROPERTIES = new Set([
   "alpha",
   "x",
@@ -50,18 +52,32 @@ const assertNumber = (value, path) => {
   }
 };
 
+const assertPositiveFiniteNumber = (value, path) => {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`${path} must be a finite number greater than 0.`);
+  }
+};
+
 const normalizePlayback = (playback, path) => {
   assertPlainObject(playback, path);
 
-  if (!CONTINUITY_MODES.has(playback.continuity)) {
+  const continuity = playback.continuity ?? DEFAULT_PLAYBACK_CONTINUITY;
+  if (!CONTINUITY_MODES.has(continuity)) {
     throw new Error(
       `${path}.continuity must be one of: ${Array.from(CONTINUITY_MODES).join(", ")}.`,
     );
   }
 
-  return {
-    continuity: playback.continuity,
-  };
+  const normalized = { continuity };
+
+  if (playback.speed !== undefined) {
+    assertPositiveFiniteNumber(playback.speed, `${path}.speed`);
+    if (playback.speed !== DEFAULT_PLAYBACK_SPEED) {
+      normalized.speed = playback.speed;
+    }
+  }
+
+  return normalized;
 };
 
 const normalizeAutoTween = (autoConfig, path) => {

--- a/vt/reference/spritetransition/sprite-playback-speed-01.webp
+++ b/vt/reference/spritetransition/sprite-playback-speed-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f0dc0be03709f0a4b8d05038ea9bd72e10e82d3f9314537645509ce1fcbe733
+size 4112

--- a/vt/reference/spritetransition/sprite-playback-speed-02.webp
+++ b/vt/reference/spritetransition/sprite-playback-speed-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45787ee344ed140b59ba02ce228ed015412ad55c630b5ff4214d6c6027aa56ed
+size 4122

--- a/vt/specs/spritetransition/sprite-playback-speed.yaml
+++ b/vt/specs/spritetransition/sprite-playback-speed.yaml
@@ -1,0 +1,71 @@
+---
+title: Sprite Playback Speed
+description: Verifies tween playback speed scales elapsed animation time.
+specs:
+  - speed 2 should complete the top sprite movement after 500ms
+  - speed 0.5 should move the bottom sprite one quarter of the authored distance after 500ms
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - elements:
+      - id: fast-sprite
+        type: sprite
+        src: circle-green
+        x: 100
+        "y": 120
+        width: 120
+        height: 120
+      - id: slow-sprite
+        type: sprite
+        src: circle-blue
+        x: 100
+        "y": 360
+        width: 120
+        height: 120
+  - elements:
+      - id: fast-sprite
+        type: sprite
+        src: circle-green
+        x: 900
+        "y": 120
+        width: 120
+        height: 120
+      - id: slow-sprite
+        type: sprite
+        src: circle-blue
+        x: 900
+        "y": 360
+        width: 120
+        height: 120
+    animations:
+      - id: fast-sprite-move
+        targetId: fast-sprite
+        type: update
+        playback:
+          speed: 2
+        tween:
+          x:
+            initialValue: 100
+            keyframes:
+              - duration: 1000
+                value: 900
+                easing: linear
+      - id: slow-sprite-move
+        targetId: slow-sprite
+        type: update
+        playback:
+          speed: 0.5
+        tween:
+          x:
+            initialValue: 100
+            keyframes:
+              - duration: 1000
+                value: 900
+                easing: linear


### PR DESCRIPTION
## Summary
- Add `playback.speed` to animation schemas and render-state normalization.
- Scale animation bus ticked and sampled time by the speed multiplier.
- Thread speed through update, transition, and persistent animation continuity paths.
- Add sprite-transition VT coverage for fast and slow playback from one authored animation.

## Testing
- `bun run lint`
- `bun run test`
- `bun run build`
- `env RTGL_VT_DEBUG=true rtgl vt screenshot --wait-event vt:ready --item spritetransition/sprite-playback-speed.yaml --concurrency 1 --timeout 60000`
- `rtgl vt report --item spritetransition/sprite-playback-speed.yaml`