### PR TITLE
feat: add input chrome styling

### DIFF
--- a/docs/input-implementation-plan.md
+++ b/docs/input-implementation-plan.md
@@ -30,7 +30,7 @@ Visible behavior:
 - custom selection highlight rendering
 - clipping inside the input content area
 
-Field chrome should be composed with surrounding Route Graphics elements such as `rect`, `sprite`, or `container`. The input element itself is primarily the editable text layer.
+Basic field chrome is part of the input element through `fill`, `border`, and `focusRing`. More elaborate chrome can still be composed with surrounding Route Graphics elements such as `rect`, `sprite`, or `container`.
 
 Native editing behavior:
 
@@ -161,6 +161,17 @@ Current element shape:
   multiline: false,
   disabled: false,
   maxLength: 80,
+  fill: "#ffffff",
+  border: {
+    width: 1,
+    color: "#2E2E2E",
+    alpha: 1
+  },
+  focusRing: {
+    width: 2,
+    color: "#4A89FF",
+    alpha: 1
+  },
   textStyle: {},
   padding: {
     top: 10,
@@ -189,8 +200,6 @@ Intentionally omitted from the public product surface:
 - browser hint props such as `inputMode` and `enterKeyHint`
 - debug-only visibility controls
 - read-only and autofocus controls
-- built-in field background and border configuration
-- built-in focus ring configuration
 - browser-centric tab-order configuration
 - low-level composition event customization
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/data/docs.yaml
+++ b/playground/data/docs.yaml
@@ -47,6 +47,9 @@ items:
       - id: node-slider
         title: "Slider"
         href: "/docs/nodes/slider/"
+      - id: node-input
+        title: "Input"
+        href: "/docs/nodes/input/"
       - id: node-container
         title: "Container"
         href: "/docs/nodes/container/"

--- a/playground/pages/docs/nodes/input.md
+++ b/playground/pages/docs/nodes/input.md
@@ -1,0 +1,106 @@
+---
+template: docs-documentation
+title: Input Node
+tags: documentation
+sidebarId: node-input
+---
+
+`input` renders an editable text field. Route Graphics draws the visible text, placeholder, caret, selection, fill, border, and focus ring while a hidden native input or textarea provides browser editing behavior.
+
+Try it in the [Playground](/playground/).
+
+## Used In
+
+- `elements[]`
+
+## Field Reference
+
+| Field           | Type             | Required | Default       | Notes                                      |
+| --------------- | ---------------- | -------- | ------------- | ------------------------------------------ |
+| `id`            | string           | Yes      | -             | Element id.                                |
+| `type`          | string           | Yes      | -             | Must be `input`.                           |
+| `x`             | number           | Yes      | -             | Position before anchor transform.          |
+| `y`             | number           | Yes      | -             | Position before anchor transform.          |
+| `width`         | number           | Yes      | -             | Field width.                               |
+| `height`        | number           | Yes      | -             | Field height.                              |
+| `value`         | string           | No       | `""`          | Initial value.                             |
+| `placeholder`   | string           | No       | `""`          | Placeholder text when value is empty.      |
+| `multiline`     | boolean          | No       | `false`       | Uses textarea-style editing.               |
+| `disabled`      | boolean          | No       | `false`       | Disables focus and editing.                |
+| `maxLength`     | number           | No       | -             | Maximum character count.                   |
+| `alpha`         | number           | No       | `1`           | Opacity `0..1`.                            |
+| `fill`          | string \| object | No       | `"#FFFFFF"`   | Field fill. Matches `rect.fill`.           |
+| `border`        | object           | No       | see below     | Field border. Matches `rect.border`.       |
+| `focusRing`     | object           | No       | see below     | Stroke drawn while focused.                |
+| `textStyle`     | object           | No       | default text  | Text style for value and placeholder.      |
+| `padding`       | number \| object | No       | `10 12 10 12` | Inner content padding.                     |
+| `change`        | object           | No       | -             | Change event config.                       |
+| `submit`        | object           | No       | -             | Submit event config.                       |
+| `focusEvent`    | object           | No       | -             | Focus event config.                        |
+| `blurEvent`     | object           | No       | -             | Blur event config.                         |
+
+### `border`
+
+| Field   | Type   | Default     |
+| ------- | ------ | ----------- |
+| `width` | number | `1`         |
+| `color` | string | `"#2E2E2E"` |
+| `alpha` | number | `1`         |
+
+### `focusRing`
+
+| Field   | Type   | Default     |
+| ------- | ------ | ----------- |
+| `width` | number | `2`         |
+| `color` | string | `"#4A89FF"` |
+| `alpha` | number | `1`         |
+
+### `fill`
+
+`fill` accepts the same values as `rect.fill`, including plain colors, `transparent`, solid objects, linear gradients, and radial gradients.
+
+```yaml
+fill: "#111827"
+```
+
+```yaml
+fill:
+  type: linear-gradient
+  start: { x: 0, y: 0 }
+  end: { x: 1, y: 0 }
+  stops:
+    - offset: 0
+      color: "#1D4ED8"
+    - offset: 1
+      color: "#0F766E"
+```
+
+## Example
+
+```yaml
+elements:
+  - id: name
+    type: input
+    x: 60
+    y: 60
+    width: 320
+    height: 56
+    placeholder: Your name
+    fill: "#111827"
+    border:
+      width: 2
+      color: "#64748B"
+      alpha: 1
+    focusRing:
+      width: 4
+      color: "#38BDF8"
+      alpha: 1
+    textStyle:
+      fill: "#F8FAFC"
+      fontSize: 22
+    padding:
+      top: 12
+      right: 16
+      bottom: 12
+      left: 16
+```

--- a/spec/elements/inputShared.spec.js
+++ b/spec/elements/inputShared.spec.js
@@ -1,5 +1,5 @@
-import { Container } from "pixi.js";
-import { describe, expect, it } from "vitest";
+import { Container, FillGradient } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
 import { parseInput } from "../../src/plugins/elements/input/parseInput.js";
 import {
   buildInputRuntime,
@@ -8,7 +8,7 @@ import {
   syncInputView,
 } from "../../src/plugins/elements/input/inputShared.js";
 
-const createRuntime = (state) => {
+const createRuntime = (state, { sync = true } = {}) => {
   const element = parseInput({
     state: {
       id: "input-test",
@@ -29,9 +29,22 @@ const createRuntime = (state) => {
     element,
   });
 
-  syncInputView(runtime, element);
+  if (sync) {
+    syncInputView(runtime, element);
+  }
 
   return { element, runtime };
+};
+
+const createRuntimeWithMockedBackground = (state) => {
+  const result = createRuntime(state, { sync: false });
+
+  result.runtime.background.clear = vi.fn();
+  result.runtime.background.rect = vi.fn();
+  result.runtime.background.fill = vi.fn();
+  result.runtime.background.stroke = vi.fn();
+
+  return result;
 };
 
 describe("inputShared hit testing", () => {
@@ -99,5 +112,116 @@ describe("inputShared hit testing", () => {
         y: actualSecondLineY + runtime.layoutState.layout.lineHeight / 2,
       }),
     ).toBe(secondLineStartIndex);
+  });
+});
+
+describe("inputShared chrome rendering", () => {
+  it("draws the default fill and border chrome", () => {
+    const { element, runtime } = createRuntimeWithMockedBackground({});
+
+    syncInputView(runtime, element);
+
+    expect(runtime.background.rect).toHaveBeenCalledWith(0, 0, 240, 80);
+    expect(runtime.background.fill).toHaveBeenCalledWith("#FFFFFF");
+    expect(runtime.background.stroke).toHaveBeenCalledTimes(1);
+    expect(runtime.background.stroke).toHaveBeenCalledWith({
+      color: "#2E2E2E",
+      alpha: 1,
+      width: 1,
+    });
+  });
+
+  it("draws custom border and focus ring chrome when focused", () => {
+    const { element, runtime } = createRuntimeWithMockedBackground({
+      fill: "#101820",
+      border: {
+        width: 2,
+        color: "#334155",
+        alpha: 0.75,
+      },
+      focusRing: {
+        width: 3,
+        color: "#38BDF8",
+        alpha: 0.9,
+      },
+    });
+
+    runtime.focused = true;
+    syncInputView(runtime, element);
+
+    expect(runtime.background.fill).toHaveBeenCalledWith("#101820");
+    expect(runtime.background.stroke).toHaveBeenCalledTimes(2);
+    expect(runtime.background.stroke).toHaveBeenNthCalledWith(1, {
+      color: "#334155",
+      alpha: 0.75,
+      width: 2,
+    });
+    expect(runtime.background.stroke).toHaveBeenNthCalledWith(2, {
+      color: "#38BDF8",
+      alpha: 0.9,
+      width: 3,
+    });
+  });
+
+  it("does not draw focus ring chrome for disabled inputs", () => {
+    const { element, runtime } = createRuntimeWithMockedBackground({
+      disabled: true,
+      focusRing: {
+        width: 4,
+        color: "#FF0000",
+      },
+    });
+
+    runtime.focused = true;
+    syncInputView(runtime, element);
+
+    expect(runtime.background.stroke).toHaveBeenCalledTimes(1);
+    expect(runtime.background.stroke).toHaveBeenCalledWith({
+      color: "#2E2E2E",
+      alpha: 1,
+      width: 1,
+    });
+  });
+
+  it("supports transparent fills and disabled strokes", () => {
+    const { element, runtime } = createRuntimeWithMockedBackground({
+      fill: "transparent",
+      border: {
+        width: 0,
+      },
+      focusRing: {
+        width: 0,
+      },
+    });
+
+    runtime.focused = true;
+    syncInputView(runtime, element);
+
+    expect(runtime.background.fill).toHaveBeenCalledWith({
+      color: 0x000000,
+      alpha: 0,
+    });
+    expect(runtime.background.stroke).not.toHaveBeenCalled();
+  });
+
+  it("supports rect-compatible gradient fills", () => {
+    const { element, runtime } = createRuntimeWithMockedBackground({
+      fill: {
+        type: "linear-gradient",
+        start: { x: 0, y: 0 },
+        end: { x: 1, y: 0 },
+        stops: [
+          { offset: 0, color: "#101820" },
+          { offset: 1, color: "#38BDF8" },
+        ],
+      },
+    });
+
+    syncInputView(runtime, element);
+
+    const fill = runtime.background.fill.mock.calls[0][0];
+
+    expect(fill).toBeInstanceOf(FillGradient);
+    expect(runtime.background._rtglFillResource).toBe(fill);
   });
 });

--- a/spec/parser/parseInput.test.yaml
+++ b/spec/parser/parseInput.test.yaml
@@ -44,6 +44,15 @@ out:
     right: 12
     bottom: 10
     left: 12
+  fill: "#FFFFFF"
+  border:
+    color: "#2E2E2E"
+    width: 1
+    alpha: 1
+  focusRing:
+    color: "#4A89FF"
+    width: 2
+    alpha: 1
 ---
 case: Test parsing input with custom props
 in:
@@ -77,14 +86,19 @@ in:
         right: 9
         bottom: 10
         left: 11
-      background:
-        fill: "#101010"
+      fill: "#101010"
+      border:
+        width: 1.7
+        color: "#30363D"
+        alpha: 0.65
       selectionStyle:
         alpha: 0.5
       caretStyle:
         width: 3
       focusRing:
-        strokeColor: "#FF0000"
+        width: 3
+        color: "#FF0000"
+        alpha: 0.9
       change:
         payload:
           source: change
@@ -119,6 +133,140 @@ out:
     right: 9
     bottom: 10
     left: 11
+  fill: "#101010"
+  border:
+    color: "#30363D"
+    width: 2
+    alpha: 0.65
+  focusRing:
+    color: "#FF0000"
+    width: 3
+    alpha: 0.9
   change:
     payload:
       source: change
+---
+case: Test parsing input with disabled chrome and gradient fill
+in:
+  - state:
+      id: styled
+      type: input
+      x: 24
+      "y": 32
+      width: 320
+      height: 64
+      fill:
+        type: linear-gradient
+        start: { x: 0, y: 0 }
+        end: { x: 1, y: 0 }
+        stops:
+          - offset: 0
+            color: "#101820"
+          - offset: 1
+            color: "#243B55"
+      border:
+        width: 0
+      focusRing:
+        width: -4
+      textStyle:
+        fill: "#FFFFFF"
+out:
+  id: styled
+  type: input
+  x: 24
+  "y": 32
+  width: 320
+  height: 64
+  alpha: 1
+  value: ""
+  placeholder: ""
+  multiline: false
+  disabled: false
+  textStyle:
+    fill: "#FFFFFF"
+    fontFamily: Arial
+    fontSize: 16
+    align: left
+    lineHeight: 19
+    wordWrap: false
+    breakWords: false
+    whiteSpace: pre
+    strokeColor: transparent
+    strokeWidth: 0
+    wordWrapWidth: 0
+  padding:
+    top: 10
+    right: 12
+    bottom: 10
+    left: 12
+  fill:
+    type: linear-gradient
+    start: { x: 0, y: 0 }
+    end: { x: 1, y: 0 }
+    stops:
+      - offset: 0
+        color: "#101820"
+      - offset: 1
+        color: "#243B55"
+  border:
+    color: "#2E2E2E"
+    width: 0
+    alpha: 1
+  focusRing:
+    color: "#4A89FF"
+    width: 0
+    alpha: 1
+---
+case: Test parsing input stroke style ignores invalid numeric overrides
+in:
+  - state:
+      id: invalid-chrome
+      type: input
+      x: 10
+      "y": 20
+      width: 120
+      height: 32
+      border:
+        width: invalid
+        alpha: invalid
+      focusRing:
+        width: invalid
+        alpha: invalid
+out:
+  id: invalid-chrome
+  type: input
+  x: 10
+  "y": 20
+  width: 120
+  height: 32
+  alpha: 1
+  value: ""
+  placeholder: ""
+  multiline: false
+  disabled: false
+  textStyle:
+    fill: black
+    fontFamily: Arial
+    fontSize: 16
+    align: left
+    lineHeight: 19
+    wordWrap: false
+    breakWords: false
+    whiteSpace: pre
+    strokeColor: transparent
+    strokeWidth: 0
+    wordWrapWidth: 0
+  padding:
+    top: 10
+    right: 12
+    bottom: 10
+    left: 12
+  fill: "#FFFFFF"
+  border:
+    color: "#2E2E2E"
+    width: 1
+    alpha: 1
+  focusRing:
+    color: "#4A89FF"
+    width: 2
+    alpha: 1

--- a/src/plugins/elements/input/inputShared.js
+++ b/src/plugins/elements/input/inputShared.js
@@ -8,6 +8,7 @@ import {
 import applyTextStyle from "../../../util/applyTextStyle.js";
 import { DEFAULT_TEXT_STYLE } from "../../../types.js";
 import { toPixiTextStyle } from "../../../util/toPixiTextStyle.js";
+import { destroyRectFillResource, resolveRectFill } from "../rect/rectFill.js";
 
 export const INPUT_RUNTIME = Symbol("routeGraphicsInputRuntime");
 
@@ -18,18 +19,18 @@ export const DEFAULT_INPUT_PADDING = {
   left: 12,
 };
 
-export const DEFAULT_INPUT_BACKGROUND = {
-  fill: "#FFFFFF",
-  fillAlpha: 1,
-  strokeColor: "#2E2E2E",
-  strokeWidth: 1,
-  strokeAlpha: 1,
+export const DEFAULT_INPUT_FILL = "#FFFFFF";
+
+export const DEFAULT_INPUT_BORDER = {
+  color: "#2E2E2E",
+  width: 1,
+  alpha: 1,
 };
 
 export const DEFAULT_INPUT_FOCUS_RING = {
-  strokeColor: "#4A89FF",
-  strokeWidth: 2,
-  strokeAlpha: 1,
+  color: "#4A89FF",
+  width: 2,
+  alpha: 1,
 };
 
 export const DEFAULT_INPUT_SELECTION_STYLE = {
@@ -94,6 +95,23 @@ export const resolvePadding = (padding) => {
     left: padding?.left ?? DEFAULT_INPUT_PADDING.left,
   };
 };
+
+const resolveStrokeWidth = (width, fallback) => {
+  if (typeof width !== "number" || !Number.isFinite(width)) {
+    return fallback;
+  }
+
+  return Math.max(0, Math.round(width));
+};
+
+const resolveStrokeAlpha = (alpha, fallback) =>
+  typeof alpha === "number" && Number.isFinite(alpha) ? alpha : fallback;
+
+export const resolveInputStrokeStyle = (style, defaults) => ({
+  color: style?.color ?? defaults.color,
+  width: resolveStrokeWidth(style?.width, defaults.width),
+  alpha: resolveStrokeAlpha(style?.alpha, defaults.alpha),
+});
 
 const normalizeInputValue = (value) =>
   String(value ?? "")
@@ -417,6 +435,9 @@ const getMultilineLineOriginX = ({
 export const createInputDisplay = (element) => {
   const background = new Graphics();
   background.label = `${element.id}-background`;
+  background.on("destroyed", () => {
+    destroyRectFillResource(background);
+  });
 
   const selection = new Graphics();
   selection.label = `${element.id}-selection`;
@@ -706,30 +727,31 @@ export const syncInputView = (runtime, element) => {
   runtime.placeholder.visible =
     runtime.value.length === 0 && runtime.composing !== true;
 
-  runtime.background.clear();
-  runtime.background.rect(0, 0, element.width, element.height);
-  runtime.background.fill({
-    color: DEFAULT_INPUT_BACKGROUND.fill,
-    alpha: DEFAULT_INPUT_BACKGROUND.fillAlpha,
-  });
+  const drawBackgroundRect = () => {
+    runtime.background.rect(0, 0, element.width, element.height);
+  };
+  const fill = element.fill !== undefined ? element.fill : DEFAULT_INPUT_FILL;
+  const border = element.border ?? DEFAULT_INPUT_BORDER;
+  const focusRing = element.focusRing ?? DEFAULT_INPUT_FOCUS_RING;
 
-  if (DEFAULT_INPUT_BACKGROUND.strokeWidth > 0) {
+  runtime.background.clear();
+  drawBackgroundRect();
+  runtime.background.fill(resolveRectFill(runtime.background, fill, element));
+
+  if (border.width > 0) {
     runtime.background.stroke({
-      color: DEFAULT_INPUT_BACKGROUND.strokeColor,
-      alpha: DEFAULT_INPUT_BACKGROUND.strokeAlpha,
-      width: DEFAULT_INPUT_BACKGROUND.strokeWidth,
+      color: border.color,
+      alpha: border.alpha,
+      width: border.width,
     });
   }
 
-  if (
-    runtime.focused &&
-    DEFAULT_INPUT_FOCUS_RING.strokeWidth > 0 &&
-    element.disabled !== true
-  ) {
+  if (runtime.focused && focusRing.width > 0 && element.disabled !== true) {
+    drawBackgroundRect();
     runtime.background.stroke({
-      color: DEFAULT_INPUT_FOCUS_RING.strokeColor,
-      alpha: DEFAULT_INPUT_FOCUS_RING.strokeAlpha,
-      width: DEFAULT_INPUT_FOCUS_RING.strokeWidth,
+      color: focusRing.color,
+      alpha: focusRing.alpha,
+      width: focusRing.width,
     });
   }
 

--- a/src/plugins/elements/input/parseInput.js
+++ b/src/plugins/elements/input/parseInput.js
@@ -1,5 +1,12 @@
 import { parseCommonObject } from "../util/parseCommonObject.js";
-import { resolveInputTextStyle, resolvePadding } from "./inputShared.js";
+import {
+  DEFAULT_INPUT_BORDER,
+  DEFAULT_INPUT_FILL,
+  DEFAULT_INPUT_FOCUS_RING,
+  resolveInputStrokeStyle,
+  resolveInputTextStyle,
+  resolvePadding,
+} from "./inputShared.js";
 
 export const parseInput = ({ state }) => {
   const computedObj = parseCommonObject(state);
@@ -23,6 +30,12 @@ export const parseInput = ({ state }) => {
     }),
     textStyle: resolveInputTextStyle(state.textStyle),
     padding: resolvePadding(state.padding),
+    fill: state.fill !== undefined ? state.fill : DEFAULT_INPUT_FILL,
+    border: resolveInputStrokeStyle(state.border, DEFAULT_INPUT_BORDER),
+    focusRing: resolveInputStrokeStyle(
+      state.focusRing,
+      DEFAULT_INPUT_FOCUS_RING,
+    ),
     ...(state.change && { change: state.change }),
     ...(state.submit && { submit: state.submit }),
     ...(state.focusEvent && { focusEvent: state.focusEvent }),

--- a/src/schemas/elements/input.computed.yaml
+++ b/src/schemas/elements/input.computed.yaml
@@ -42,6 +42,26 @@ properties:
     type: boolean
   maxLength:
     type: number
+  fill:
+    description: Input field fill after default resolution
+  border:
+    type: object
+    properties:
+      width:
+        type: number
+      color:
+        type: string
+      alpha:
+        type: number
+  focusRing:
+    type: object
+    properties:
+      width:
+        type: number
+      color:
+        type: string
+      alpha:
+        type: number
   textStyle:
     type: object
   padding:

--- a/src/schemas/elements/input.element.yaml
+++ b/src/schemas/elements/input.element.yaml
@@ -2,6 +2,140 @@ $schema: http://json-schema.org/draft-07/schema#
 title: Input Element
 description: Schema for input element raw input
 type: object
+$def:
+  point:
+    type: object
+    additionalProperties: false
+    required:
+      - x
+      - y
+    properties:
+      x:
+        type: number
+        description: X coordinate
+      y:
+        type: number
+        description: Y coordinate
+  stop:
+    type: object
+    additionalProperties: false
+    required:
+      - offset
+      - color
+    properties:
+      offset:
+        type: number
+        minimum: 0
+        maximum: 1
+        description: Gradient stop offset from 0 to 1
+      color:
+        type: string
+        description: Gradient stop color
+  fill:
+    oneOf:
+      - type: string
+        description: Solid fill color. Use "transparent" for a transparent fill.
+      - type: object
+        additionalProperties: false
+        required:
+          - type
+          - color
+        properties:
+          type:
+            const: solid
+            description: Solid fill type
+          color:
+            type: string
+            description: Solid fill color
+      - type: object
+        additionalProperties: false
+        required:
+          - type
+          - stops
+        properties:
+          type:
+            const: linear-gradient
+            description: Linear gradient fill type
+          start:
+            "$ref": "#/$def/point"
+            description: Gradient start point. Defaults to { x: 0, y: 0 } in local normalized coordinates.
+          end:
+            "$ref": "#/$def/point"
+            description: Gradient end point. Defaults to { x: 0, y: 1 } in local normalized coordinates.
+          stops:
+            type: array
+            minItems: 2
+            items:
+              "$ref": "#/$def/stop"
+          coordinateSpace:
+            type: string
+            enum: [local, global]
+            description: Whether gradient coordinates are relative to the input or the world
+          textureSize:
+            type: number
+            description: Gradient texture resolution hint
+          wrapMode:
+            type: string
+            enum: [clamp-to-edge, repeat]
+            description: Gradient wrap mode
+      - type: object
+        additionalProperties: false
+        required:
+          - type
+          - stops
+        properties:
+          type:
+            const: radial-gradient
+            description: Radial gradient fill type
+          innerCenter:
+            "$ref": "#/$def/point"
+            description: Inner circle center. Defaults to { x: 0.5, y: 0.5 } in local normalized coordinates.
+          innerRadius:
+            type: number
+            description: Inner circle radius. Defaults to 0.
+          outerCenter:
+            "$ref": "#/$def/point"
+            description: Outer circle center. Defaults to the inner center in local normalized coordinates.
+          outerRadius:
+            type: number
+            description: Outer circle radius. Defaults to 0.5.
+          stops:
+            type: array
+            minItems: 2
+            items:
+              "$ref": "#/$def/stop"
+          coordinateSpace:
+            type: string
+            enum: [local, global]
+            description: Whether gradient coordinates are relative to the input or the world
+          textureSize:
+            type: number
+            description: Gradient texture resolution hint
+          wrapMode:
+            type: string
+            enum: [clamp-to-edge, repeat]
+            description: Gradient wrap mode
+          scale:
+            type: number
+            description: Radial gradient ellipse scale
+          rotation:
+            type: number
+            description: Radial gradient rotation in radians
+  stroke:
+    type: object
+    description: Stroke properties
+    properties:
+      width:
+        type: number
+        description: Stroke width in pixels
+      color:
+        type: string
+        description: Stroke color
+      alpha:
+        type: number
+        description: Stroke opacity (0-1)
+        minimum: 0
+        maximum: 1
 required:
   - id
   - type
@@ -51,6 +185,15 @@ properties:
   maxLength:
     type: number
     description: Maximum number of characters
+  fill:
+    "$ref": "#/$def/fill"
+    description: Input field fill. Supports solid colors and structured gradient fills. Defaults to white.
+  border:
+    "$ref": "#/$def/stroke"
+    description: Input border. Uses the same width/color/alpha shape as rect border.
+  focusRing:
+    "$ref": "#/$def/stroke"
+    description: Focus stroke drawn over the border while the input is focused.
   alpha:
     type: number
     description: Opacity/transparency of the input container (0-1)

--- a/src/types.js
+++ b/src/types.js
@@ -506,6 +506,13 @@
  */
 
 /**
+ * @typedef {Object} InputStrokeStyle
+ * @property {number} width
+ * @property {string} color
+ * @property {number} alpha
+ */
+
+/**
  * @typedef {Object} InputComputedProps
  * @property {'input'} type
  * @property {string} value
@@ -514,6 +521,9 @@
  * @property {boolean} [submitOnEnter]
  * @property {boolean} disabled
  * @property {number} [maxLength]
+ * @property {RectFill} fill
+ * @property {InputStrokeStyle} border
+ * @property {InputStrokeStyle} focusRing
  * @property {Object} textStyle
  * @property {InputPadding} padding
  * @property {Object} [change]

--- a/vt/reference/input/styled-input-chrome-01.webp
+++ b/vt/reference/input/styled-input-chrome-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f124fb87e36a1f56d359dd9a4cbec1491ca8eea1a992c43d70f30d1cb55db9cc
+size 10228

--- a/vt/reference/input/styled-input-chrome-02.webp
+++ b/vt/reference/input/styled-input-chrome-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f124fb87e36a1f56d359dd9a4cbec1491ca8eea1a992c43d70f30d1cb55db9cc
+size 10228

--- a/vt/reference/input/styled-input-chrome-03.webp
+++ b/vt/reference/input/styled-input-chrome-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b708179e4b0536ca65a2f436687718590be3a7245caa34dd6eb9f8af1f75a8a
+size 10356

--- a/vt/specs/input/styled-input-chrome.yaml
+++ b/vt/specs/input/styled-input-chrome.yaml
@@ -1,0 +1,125 @@
+---
+title: Styled Input Chrome
+description: Test input fill, border, and focusRing rendering
+specs:
+  - inputs should render custom solid and gradient fills
+  - inputs should render custom borders independently from the text layer
+  - focused inputs should render custom focusRing chrome
+steps:
+  - action: screenshot
+  - action: click
+    x: 120
+    "y": 108
+  - action: wait
+    ms: 100
+  - action: screenshot
+---
+states:
+  - elements:
+      - id: scene-bg
+        type: rect
+        x: 0
+        "y": 0
+        width: 1280
+        height: 720
+        fill: "#0B1020"
+      - id: solid-input
+        type: input
+        x: 80
+        "y": 80
+        width: 360
+        height: 56
+        value: Custom chrome
+        fill: "#111827"
+        border:
+          width: 2
+          color: "#64748B"
+          alpha: 1
+        focusRing:
+          width: 4
+          color: "#38BDF8"
+          alpha: 1
+        textStyle:
+          fill: "#F8FAFC"
+          fontSize: 22
+        padding:
+          top: 12
+          right: 16
+          bottom: 12
+          left: 16
+      - id: gradient-input
+        type: input
+        x: 80
+        "y": 160
+        width: 360
+        height: 56
+        value: Gradient fill
+        fill:
+          type: linear-gradient
+          start: { x: 0, y: 0 }
+          end: { x: 1, y: 0 }
+          stops:
+            - offset: 0
+              color: "#1D4ED8"
+            - offset: 1
+              color: "#0F766E"
+        border:
+          width: 3
+          color: "#ECFEFF"
+          alpha: 0.9
+        focusRing:
+          width: 0
+        textStyle:
+          fill: "#FFFFFF"
+          fontSize: 22
+        padding: 14
+      - id: transparent-input
+        type: input
+        x: 80
+        "y": 240
+        width: 360
+        height: 56
+        value: Transparent fill
+        fill: transparent
+        border:
+          width: 3
+          color: "#F59E0B"
+          alpha: 1
+        focusRing:
+          width: 0
+        textStyle:
+          fill: "#FDE68A"
+          fontSize: 22
+        padding:
+          top: 12
+          right: 16
+          bottom: 12
+          left: 16
+      - id: multiline-input
+        type: input
+        x: 500
+        "y": 80
+        width: 420
+        height: 144
+        multiline: true
+        value: |-
+          Multiline styled input
+          keeps chrome separate
+        fill: "#F8FAFC"
+        border:
+          width: 2
+          color: "#0F172A"
+          alpha: 1
+        focusRing:
+          width: 3
+          color: "#14B8A6"
+          alpha: 1
+        textStyle:
+          fill: "#111827"
+          fontSize: 24
+          lineHeight: 32
+        padding:
+          top: 16
+          right: 18
+          bottom: 16
+          left: 18


### PR DESCRIPTION
## Summary
- add input `fill`, `border`, and `focusRing` chrome using rect-compatible fill semantics
- normalize input chrome through parsing and render it with defensive runtime defaults
- update schemas, docs, parser/runtime tests, and add a styled input VT fixture with accepted references
- bump package version to 1.23.0

## Testing
- `bun run lint`
- `bunx vitest run spec/parser/parseInput.test.yaml spec/elements/inputShared.spec.js spec/elements/inputPlugin.spec.js`
- `bunx vitest run spec/cli/renderPngCli.spec.js` outside sandbox for local listen socket access
- `rtgl vt screenshot --item input/styled-input-chrome --wait-event vt:ready`
- `rtgl vt report --item input/styled-input-chrome`

Note: local `bun run test` / pre-push still fails on existing text and text-revealing parser snapshots with 1px font-metric differences unrelated to this input change; the changed input tests pass.