### PR TITLE
Fix text reveal indicator offsets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/elements/textRevealingRuntime.indicatorVisual.spec.js
+++ b/spec/elements/textRevealingRuntime.indicatorVisual.spec.js
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { parseTextRevealing } from "../../src/plugins/elements/text-revealing/parseTextRevealing.js";
 import { runTextReveal } from "../../src/plugins/elements/text-revealing/textRevealingRuntime.js";
+import { getCharacterXPositionInATextObject } from "../../src/util/getCharacterXPositionInATextObject.js";
 
 const createCompletionTracker = () => ({
   getVersion: () => 0,
@@ -25,6 +26,22 @@ const getRenderedText = (container) => {
   visit(container);
 
   return textParts.join("");
+};
+
+const getLastRenderedTextObject = (container) => {
+  let lastTextObject;
+  const visit = (node) => {
+    if (typeof node?.text === "string") {
+      lastTextObject = node;
+    }
+
+    if (Array.isArray(node?.children)) {
+      node.children.forEach(visit);
+    }
+  };
+
+  visit(container);
+  return lastTextObject;
 };
 
 let textureIndex = 0;
@@ -153,6 +170,81 @@ describe("runTextReveal indicator visuals", () => {
     expect(indicator.x).toBe(23);
     expect(indicator.y).toBeCloseTo(
       getExpectedIndicatorY(firstLine, indicator, -5),
+    );
+  });
+
+  it("applies visual-specific offsets for revealing and complete indicators", async () => {
+    const completeSrc = createTextureId("complete-offset-visual");
+    const revealingElement = createElement({
+      revealing: {
+        width: 10,
+        height: 6,
+        offsetX: 7,
+        offsetY: 3,
+      },
+      complete: {
+        kind: "image",
+        src: completeSrc,
+        width: 10,
+        height: 6,
+        offsetX: 31,
+        offsetY: -8,
+      },
+      offsetX: 99,
+      offsetY: 99,
+    });
+
+    const revealingResult = await runReveal(revealingElement, "paused-initial");
+    const revealingIndicator =
+      revealingResult.container.getChildByLabel("line-1-indicator");
+    const firstLine = revealingElement.content[0];
+
+    expect(revealingIndicator.x).toBe(7);
+    expect(revealingIndicator.y).toBeCloseTo(
+      getExpectedIndicatorY(firstLine, revealingIndicator, 3),
+    );
+
+    const completeElement = createElement(
+      {
+        revealing: {
+          width: 10,
+          height: 6,
+          offsetX: 7,
+          offsetY: 3,
+        },
+        complete: {
+          kind: "image",
+          src: completeSrc,
+          width: 10,
+          height: 6,
+          offsetX: 31,
+          offsetY: -8,
+        },
+        offsetX: 99,
+        offsetY: 99,
+      },
+      {
+        content: [{ text: "Complete" }],
+        revealEffect: "none",
+      },
+    );
+
+    const completeResult = await runReveal(completeElement, "autoplay");
+    const completeIndicator =
+      completeResult.container.getChildByLabel("line-1-indicator");
+    const completeLine = completeElement.content[0];
+    const completeTextObject = getLastRenderedTextObject(
+      completeResult.container,
+    );
+
+    expect(completeIndicator.x).toBeCloseTo(
+      getCharacterXPositionInATextObject(
+        completeTextObject,
+        completeTextObject.text.length - 1,
+      ) + 31,
+    );
+    expect(completeIndicator.y).toBeCloseTo(
+      getExpectedIndicatorY(completeLine, completeIndicator, -8),
     );
   });
 

--- a/spec/parser/parseTextRevealing.indicatorVisual.spec.js
+++ b/spec/parser/parseTextRevealing.indicatorVisual.spec.js
@@ -37,6 +37,8 @@ describe("parseTextRevealing indicator visuals", () => {
           src: "cursor-sheet",
           width: 18,
           height: 18,
+          offsetX: 20,
+          offsetY: -2,
           atlas,
           clips: {
             blink: ["idle-0", "idle-1"],
@@ -51,6 +53,8 @@ describe("parseTextRevealing indicator visuals", () => {
         complete: {
           kind: "image",
           src: "cursor-complete",
+          offsetX: 24,
+          offsetY: 3,
         },
       }),
     });
@@ -60,6 +64,8 @@ describe("parseTextRevealing indicator visuals", () => {
       src: "cursor-sheet",
       width: 18,
       height: 18,
+      offsetX: 20,
+      offsetY: -2,
       atlas: {
         frames: {
           "idle-0": {
@@ -97,6 +103,8 @@ describe("parseTextRevealing indicator visuals", () => {
       src: "cursor-complete",
       width: 12,
       height: 12,
+      offsetX: 24,
+      offsetY: 3,
     });
   });
 

--- a/src/plugins/elements/text-revealing/parseTextRevealing.js
+++ b/src/plugins/elements/text-revealing/parseTextRevealing.js
@@ -81,6 +81,14 @@ export const normalizeIndicatorVisual = (visual = {}, path) => {
     height: visual.height ?? 12,
   };
 
+  if (visual.offsetX !== undefined) {
+    baseVisual.offsetX = visual.offsetX;
+  }
+
+  if (visual.offsetY !== undefined) {
+    baseVisual.offsetY = visual.offsetY;
+  }
+
   if (kind === "image") {
     return baseVisual;
   }

--- a/src/plugins/elements/text-revealing/textRevealingRuntime.js
+++ b/src/plugins/elements/text-revealing/textRevealingRuntime.js
@@ -372,10 +372,20 @@ const applyCompleteIndicator = (indicatorSprite) => {
   indicatorSprite?.[TEXT_REVEAL_INDICATOR]?.showComplete();
 };
 
-const getIndicatorOffsets = (element) => ({
-  x: element?.indicator?.offsetX ?? DEFAULT_TEXT_REVEAL_INDICATOR_OFFSET_X,
-  y: element?.indicator?.offsetY ?? DEFAULT_TEXT_REVEAL_INDICATOR_OFFSET_Y,
-});
+const getIndicatorOffsets = (element, stateName = "revealing") => {
+  const visual = element?.indicator?.[stateName] ?? {};
+
+  return {
+    x:
+      visual.offsetX ??
+      element?.indicator?.offsetX ??
+      DEFAULT_TEXT_REVEAL_INDICATOR_OFFSET_X,
+    y:
+      visual.offsetY ??
+      element?.indicator?.offsetY ??
+      DEFAULT_TEXT_REVEAL_INDICATOR_OFFSET_Y,
+  };
+};
 
 const getIndicatorLineY = (indicatorSprite, chunk) => {
   if (!chunk) {
@@ -419,9 +429,10 @@ const completeIndicatorAtTextEnd = (
   indicatorSprite,
   chunk,
   lastTextObject,
-  indicatorOffsets,
+  element,
 ) => {
   applyCompleteIndicator(indicatorSprite);
+  const indicatorOffsets = getIndicatorOffsets(element, "complete");
   positionIndicatorForChunk(indicatorSprite, chunk, indicatorOffsets);
   positionIndicatorAtTextEnd(indicatorSprite, lastTextObject, indicatorOffsets);
 };
@@ -595,7 +606,6 @@ const buildFullTextContent = (contentContainer, element) => {
 };
 
 const runNoneReveal = ({ contentContainer, indicatorSprite, element }) => {
-  const indicatorOffsets = getIndicatorOffsets(element);
   const { lastTextObject, lastChunk } = buildFullTextContent(
     contentContainer,
     element,
@@ -605,7 +615,7 @@ const runNoneReveal = ({ contentContainer, indicatorSprite, element }) => {
     indicatorSprite,
     lastChunk,
     lastTextObject,
-    indicatorOffsets,
+    element,
   );
 };
 
@@ -697,7 +707,7 @@ const runTypewriterPrefixReveal = ({
       indicatorSprite,
       lastVisibleChunk ?? firstChunk,
       lastVisibleTextObject,
-      indicatorOffsets,
+      element,
     );
   }
 };
@@ -863,7 +873,7 @@ const runTypewriterReveal = async ({
     indicatorSprite,
     lastVisibleChunk,
     lastVisibleTextObject,
-    indicatorOffsets,
+    element,
   );
 
   if (snapshot) {
@@ -1172,7 +1182,7 @@ const runSoftWipePausedInitialReveal = ({
       indicatorSprite,
       lastChunk,
       lastTextObject,
-      indicatorOffsets,
+      element,
     );
     return;
   }
@@ -1209,7 +1219,7 @@ const runSoftWipePausedInitialReveal = ({
       indicatorSprite,
       lastChunk,
       lastTextObject,
-      indicatorOffsets,
+      element,
     );
     return;
   }
@@ -1253,7 +1263,7 @@ const runSoftWipeReveal = ({
       indicatorSprite,
       lastChunk,
       lastTextObject,
-      indicatorOffsets,
+      element,
     );
     return false;
   }
@@ -1291,7 +1301,7 @@ const runSoftWipeReveal = ({
       indicatorSprite,
       lastChunk,
       lastTextObject,
-      indicatorOffsets,
+      element,
     );
     return false;
   }
@@ -1327,7 +1337,7 @@ const runSoftWipeReveal = ({
         indicatorSprite,
         lastChunk,
         lastTextObject,
-        indicatorOffsets,
+        element,
       );
     }
   };

--- a/src/schemas/elements/text-revealing.computed.yaml
+++ b/src/schemas/elements/text-revealing.computed.yaml
@@ -116,6 +116,12 @@ $def:
         type: number
         description: Display height of the indicator visual
         default: 12
+      offsetX:
+        type: number
+        description: Horizontal offset for this indicator visual. Falls back to indicator.offsetX, then 16.
+      offsetY:
+        type: number
+        description: Vertical offset for this indicator visual. Falls back to indicator.offsetY, then 0.
       atlas:
         type: object
         description: Spritesheet atlas metadata when `kind` is `spritesheet`; uses the same shape as `spritesheet-animation.atlas`.
@@ -237,11 +243,11 @@ properties:
         "$ref": "#/$def/indicatorVisual"
       offsetX:
         type: number
-        description: Horizontal offset between the text and the indicator
+        description: Default horizontal offset between the text and the indicator when a visual does not provide offsetX
         default: 16
       offsetY:
         type: number
-        description: Vertical adjustment from the indicator's automatic line placement; positive values move down
+        description: Default vertical adjustment from the indicator's automatic line placement when a visual does not provide offsetY; positive values move down
         default: 0
   textStyle:
     "$ref": "#/$def/textStyle"

--- a/src/schemas/elements/text-revealing.element.yaml
+++ b/src/schemas/elements/text-revealing.element.yaml
@@ -121,6 +121,12 @@ $def:
         type: number
         description: Display height of the indicator visual
         default: 12
+      offsetX:
+        type: number
+        description: Horizontal offset for this indicator visual. Falls back to indicator.offsetX, then 16.
+      offsetY:
+        type: number
+        description: Vertical offset for this indicator visual. Falls back to indicator.offsetY, then 0.
       atlas:
         type: object
         description: Spritesheet atlas metadata when `kind` is `spritesheet`; uses the same shape as `spritesheet-animation.atlas`.
@@ -223,11 +229,11 @@ properties:
         "$ref": "#/$def/indicatorVisual"
       offsetX:
         type: number
-        description: Horizontal offset between the text and the indicator
+        description: Default horizontal offset between the text and the indicator when a visual does not provide offsetX
         default: 16
       offsetY:
         type: number
-        description: Vertical adjustment from the indicator's automatic line placement; positive values move down
+        description: Default vertical adjustment from the indicator's automatic line placement when a visual does not provide offsetY; positive values move down
         default: 0
   speed:
     type: number

--- a/src/types.js
+++ b/src/types.js
@@ -560,6 +560,8 @@
  * @property {string} [indicator.revealing.src] - Source of the revealing indicator image or spritesheet
  * @property {number} [indicator.revealing.width] - Width of the revealing indicator visual
  * @property {number} [indicator.revealing.height] - Height of the revealing indicator visual
+ * @property {number} [indicator.revealing.offsetX] - Revealing visual horizontal offset; falls back to indicator.offsetX
+ * @property {number} [indicator.revealing.offsetY] - Revealing visual vertical offset; falls back to indicator.offsetY
  * @property {Object} [indicator.revealing.atlas] - Spritesheet atlas metadata when kind is spritesheet
  * @property {Object} [indicator.revealing.clips] - Named spritesheet clips when kind is spritesheet
  * @property {Object} [indicator.revealing.playback] - Spritesheet playback settings when kind is spritesheet
@@ -568,6 +570,8 @@
  * @property {string} [indicator.complete.src] - Source of the complete indicator image or spritesheet
  * @property {number} [indicator.complete.width] - Width of the complete indicator visual
  * @property {number} [indicator.complete.height] - Height of the complete indicator visual
+ * @property {number} [indicator.complete.offsetX] - Complete visual horizontal offset; falls back to indicator.offsetX
+ * @property {number} [indicator.complete.offsetY] - Complete visual vertical offset; falls back to indicator.offsetY
  * @property {Object} [indicator.complete.atlas] - Spritesheet atlas metadata when kind is spritesheet
  * @property {Object} [indicator.complete.clips] - Named spritesheet clips when kind is spritesheet
  * @property {Object} [indicator.complete.playback] - Spritesheet playback settings when kind is spritesheet

--- a/vt/reference/textrevealing/text-revealing-indicator-visual-offsets-01.webp
+++ b/vt/reference/textrevealing/text-revealing-indicator-visual-offsets-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cc8c54dd2e40f375efa8d75ced2fd9efbc3e852a3f05c3898b16f9dfc103bbd
+size 3576

--- a/vt/reference/textrevealing/text-revealing-indicator-visual-offsets-02.webp
+++ b/vt/reference/textrevealing/text-revealing-indicator-visual-offsets-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36d6c0662233f685c2da2bf784c21f8a4d990d9de2628d6cc145000e444c5cc7
+size 11294

--- a/vt/specs/textrevealing/text-revealing-indicator-visual-offsets.yaml
+++ b/vt/specs/textrevealing/text-revealing-indicator-visual-offsets.yaml
@@ -1,0 +1,75 @@
+---
+title: Text Revealing - Indicator Visual Offsets
+description: Validates per-visual indicator offsets for revealing and complete states; colored indicator assets are used intentionally for reveal-state distinction.
+specs:
+  - revealing indicator visual offsets should override the shared indicator offset while text is still revealing
+  - complete indicator visual offsets should override the shared indicator offset after the completion visual swap
+  - vertical offsets should be applied from the automatic line placement for both visual states
+steps:
+  - action: keypress
+    key: "n"
+  - action: screenshot
+---
+states:
+  - id: revealing-visual-offset
+    elements:
+      - id: revealing-offset-line
+        type: text-revealing
+        x: 80
+        "y": 96
+        width: 760
+        speed: 8
+        initialRevealedCharacters: 14
+        revealEffect: softWipe
+        softWipe:
+          easing: linear
+          softness: 0
+        indicator:
+          revealing:
+            src: circle-red
+            width: 14
+            height: 14
+            offsetX: 96
+            offsetY: -18
+          complete:
+            src: circle-green
+            width: 14
+            height: 14
+            offsetX: 28
+            offsetY: 18
+        content:
+          - text: "Revealing visual offset keeps this red indicator ahead of the wipe edge."
+            textStyle:
+              fontSize: 32
+              fill: "#FFFFFF"
+              fontFamily: Arial
+              lineHeight: 1.3
+  - id: complete-visual-offset
+    elements:
+      - id: complete-offset-line
+        type: text-revealing
+        x: 80
+        "y": 210
+        width: 760
+        speed: 100
+        revealEffect: none
+        indicator:
+          revealing:
+            src: circle-red
+            width: 14
+            height: 14
+            offsetX: 96
+            offsetY: -18
+          complete:
+            src: circle-green
+            width: 14
+            height: 14
+            offsetX: 128
+            offsetY: 28
+        content:
+          - text: "Complete visual offset moves this green indicator below and past the finished text."
+            textStyle:
+              fontSize: 32
+              fill: "#FFFFFF"
+              fontFamily: Arial
+              lineHeight: 1.3


### PR DESCRIPTION
## Summary

- Add per-visual `offsetX`/`offsetY` support for text reveal indicator `revealing` and `complete` visuals.
- Keep top-level `indicator.offsetX`/`indicator.offsetY` as fallback defaults when a visual does not define its own offsets.
- Bump `route-graphics` from `1.23.0` to `1.23.1`.

## Validation

- `bunx vitest run spec/parser/parseTextRevealing.indicatorVisual.spec.js spec/elements/textRevealingRuntime.indicatorVisual.spec.js`
- `bunx prettier --check package.json src/plugins/elements/text-revealing/parseTextRevealing.js src/plugins/elements/text-revealing/textRevealingRuntime.js src/schemas/elements/text-revealing.element.yaml src/schemas/elements/text-revealing.computed.yaml src/types.js spec/parser/parseTextRevealing.indicatorVisual.spec.js spec/elements/textRevealingRuntime.indicatorVisual.spec.js`
- `bun run build`

## Notes

- `bun run test` currently fails in unrelated YAML parser snapshots: 13 text metric/position expectation mismatches across `spec/parser/parseText.test.yaml` and `spec/parser/parseTextRevealing.test.yaml`. The focused indicator parser/runtime tests pass.
