### PR TITLE
Fix audio transition type naming

### DIFF
--- a/docs/audio-effects.md
+++ b/docs/audio-effects.md
@@ -58,7 +58,7 @@ audio:
 
 audioEffects:
   - id: music-volume
-    type: audioTransition
+    type: audio-transition
     targetId: music
     properties:
       volume:
@@ -200,7 +200,7 @@ nodes that target audio node IDs or other effect IDs.
 
 First implementation effect item types:
 
-- `audioTransition`
+- `audio-transition`
 
 Effects are render-state entries, not resources.
 
@@ -211,7 +211,7 @@ Route Graphics should reject invalid audio render state instead of guessing:
 - duplicate IDs across `audio` nodes and `audioEffects`
 - `audio-channel.children` entries whose type is not `sound`
 - nested `audio-channel` nodes in the first implementation
-- `audioTransition.targetId` that cannot be resolved in the state used for its
+- `audio-transition.targetId` that cannot be resolved in the state used for its
   lifecycle
 - transition phases missing required `duration` or `easing`
 - transition phases that use an unsupported easing name
@@ -219,12 +219,12 @@ Route Graphics should reject invalid audio render state instead of guessing:
 
 ## Audio Transitions
 
-An `audioTransition` automates property changes on a target.
+An `audio-transition` automates property changes on a target.
 
 ```yaml
 audioEffects:
   - id: music-transitions
-    type: audioTransition
+    type: audio-transition
     targetId: music
     properties:
       volume:
@@ -237,12 +237,12 @@ audioEffects:
 
 Fields:
 
-| Field        | Type              | Default  | Description                         |
-| ------------ | ----------------- | -------- | ----------------------------------- |
-| `id`         | string            | required | Stable effect ID                    |
-| `type`       | `audioTransition` | required | Effect type                         |
-| `targetId`   | string            | required | Audio node or effect ID to automate |
-| `properties` | object            | required | Property automation map             |
+| Field        | Type               | Default  | Description                         |
+| ------------ | ------------------ | -------- | ----------------------------------- |
+| `id`         | string             | required | Stable effect ID                    |
+| `type`       | `audio-transition` | required | Effect type                         |
+| `targetId`   | string             | required | Audio node or effect ID to automate |
+| `properties` | object             | required | Property automation map             |
 
 First implementation `targetId` may reference:
 
@@ -276,7 +276,7 @@ First implementation target:
 ```yaml
 audioEffects:
   - id: music-volume
-    type: audioTransition
+    type: audio-transition
     targetId: music
     properties:
       volume:
@@ -290,7 +290,7 @@ Future transition targets:
 ```yaml
 audioEffects:
   - id: bgm-transitions
-    type: audioTransition
+    type: audio-transition
     targetId: bgm
     properties:
       pan:
@@ -373,7 +373,7 @@ Removing a filter without such a transition may change the sound immediately.
 ### Filter Automation
 
 Filter parameters are automated by targeting the filter effect ID with an
-`audioTransition`.
+`audio-transition`.
 
 ```yaml
 audioEffects:
@@ -385,7 +385,7 @@ audioEffects:
     q: 1
 
   - id: music-lowpass-transition
-    type: audioTransition
+    type: audio-transition
     targetId: music-lowpass
     properties:
       frequency:
@@ -435,9 +435,9 @@ individual sound fades.
 Route Graphics should keep audio declarative.
 
 - Added audio node or effect: create it and apply `enter` transition if a
-  matching `audioTransition` exists in the next `audioEffects`.
+  matching `audio-transition` exists in the next `audioEffects`.
 - Updated audio node or effect: update changed properties and apply `update`
-  transition if a matching `audioTransition` exists in the next `audioEffects`.
+  transition if a matching `audio-transition` exists in the next `audioEffects`.
 - Removed audio node or effect: keep the internal node alive until `exit`
   transition from the previous `audioEffects` completes, then stop and clean up.
 
@@ -468,7 +468,7 @@ audio:
 
 audioEffects:
   - id: bgm-volume
-    type: audioTransition
+    type: audio-transition
     targetId: bgm
     properties:
       volume:
@@ -485,7 +485,7 @@ audio:
 
 audioEffects:
   - id: bgm-volume
-    type: audioTransition
+    type: audio-transition
     targetId: bgm
     properties:
       volume:
@@ -531,10 +531,10 @@ source.stop(now + seconds);
 
 Implemented:
 
-- schemas for `audio-channel`, extended `sound`, and `audioTransition`
+- schemas for `audio-channel`, extended `sound`, and `audio-transition`
 - flat `sound` normalization through an implicit root channel
 - channel gain nodes and internal playback instance IDs
-- `audioTransition` for `volume` on channels and sounds
+- `audio-transition` for `volume` on channels and sounds
 - same-ID, different-source replacement with overlapping internal instances
 - removal of the legacy `sound.delay` interface in favor of `startDelayMs`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -208,7 +208,7 @@ describe("AudioStage graph rendering", () => {
       nextAudioEffects: [
         {
           id: "music-enter",
-          type: "audioTransition",
+          type: "audio-transition",
           targetId: "music",
           properties: {
             volume: {
@@ -241,7 +241,7 @@ describe("AudioStage graph rendering", () => {
       nextAudioEffects: [
         {
           id: "music-update",
-          type: "audioTransition",
+          type: "audio-transition",
           targetId: "music",
           properties: {
             volume: {
@@ -264,7 +264,7 @@ describe("AudioStage graph rendering", () => {
       prevAudioEffects: [
         {
           id: "music-exit",
-          type: "audioTransition",
+          type: "audio-transition",
           targetId: "music",
           properties: {
             volume: {
@@ -298,7 +298,7 @@ describe("AudioStage graph rendering", () => {
       nextAudioEffects: [
         {
           id: "music-enter",
-          type: "audioTransition",
+          type: "audio-transition",
           targetId: "music",
           properties: {
             volume: {
@@ -308,7 +308,7 @@ describe("AudioStage graph rendering", () => {
         },
         {
           id: "bgm-enter",
-          type: "audioTransition",
+          type: "audio-transition",
           targetId: "bgm",
           properties: {
             volume: {
@@ -366,7 +366,7 @@ describe("AudioStage graph rendering", () => {
       prevAudioEffects: [
         {
           id: "music-exit",
-          type: "audioTransition",
+          type: "audio-transition",
           targetId: "music",
           properties: {
             volume: {
@@ -383,7 +383,7 @@ describe("AudioStage graph rendering", () => {
       nextAudioEffects: [
         {
           id: "music-enter",
-          type: "audioTransition",
+          type: "audio-transition",
           targetId: "music",
           properties: {
             volume: {
@@ -419,7 +419,7 @@ describe("AudioStage graph rendering", () => {
       prevAudioEffects: [
         {
           id: "bgm-exit",
-          type: "audioTransition",
+          type: "audio-transition",
           targetId: "bgm",
           properties: {
             volume: {
@@ -431,7 +431,7 @@ describe("AudioStage graph rendering", () => {
       nextAudioEffects: [
         {
           id: "bgm-enter",
-          type: "audioTransition",
+          type: "audio-transition",
           targetId: "bgm",
           properties: {
             volume: {
@@ -584,7 +584,7 @@ describe("AudioStage graph rendering", () => {
         nextAudioEffects: [
           {
             id: "bad",
-            type: "audioTransition",
+            type: "audio-transition",
             targetId: "missing",
             properties: {
               volume: {

--- a/spec/audio/renderAudio.spec.js
+++ b/spec/audio/renderAudio.spec.js
@@ -18,7 +18,7 @@ describe("renderAudio", () => {
     const nextAudioEffects = [
       {
         id: "music-fade",
-        type: "audioTransition",
+        type: "audio-transition",
         targetId: "music",
         properties: {
           volume: {

--- a/spec/util/normalizeAudio.spec.js
+++ b/spec/util/normalizeAudio.spec.js
@@ -115,7 +115,7 @@ describe("normalizeAudioRenderState", () => {
         audioEffects: [
           {
             id: "music",
-            type: "audioTransition",
+            type: "audio-transition",
             targetId: "music",
             properties: {
               volume: {
@@ -195,6 +195,26 @@ describe("normalizeAudioRenderState", () => {
     ).toThrow("audio[0].delay is not supported");
   });
 
+  it("accepts legacy audioTransition effect type as an alias", () => {
+    expect(() =>
+      normalizeAudioRenderState({
+        audio: [{ id: "music", type: "audio-channel" }],
+        audioEffects: [
+          {
+            id: "fade",
+            type: "audioTransition",
+            targetId: "music",
+            properties: {
+              volume: {
+                update: { duration: 100, easing: "linear" },
+              },
+            },
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
   it("validates volume transitions strictly", () => {
     const audio = [{ id: "music", type: "audio-channel" }];
 
@@ -204,7 +224,7 @@ describe("normalizeAudioRenderState", () => {
         audioEffects: [
           {
             id: "fade",
-            type: "audioTransition",
+            type: "audio-transition",
             targetId: "missing",
             properties: {
               volume: {
@@ -222,7 +242,7 @@ describe("normalizeAudioRenderState", () => {
         audioEffects: [
           {
             id: "fade",
-            type: "audioTransition",
+            type: "audio-transition",
             targetId: "music",
             properties: {
               volume: {
@@ -240,7 +260,7 @@ describe("normalizeAudioRenderState", () => {
         audioEffects: [
           {
             id: "fade",
-            type: "audioTransition",
+            type: "audio-transition",
             targetId: "music",
             properties: {
               pan: {
@@ -258,7 +278,7 @@ describe("normalizeAudioRenderState", () => {
         audioEffects: [
           {
             id: "fade",
-            type: "audioTransition",
+            type: "audio-transition",
             targetId: "music",
             properties: {
               volume: {

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -103,7 +103,9 @@ const getVolumeValue = ({ volume, muted }) =>
 const getTransitionPhase = (effects = [], targetId, property, phase) => {
   const transition = effects.find(
     (effect) =>
-      effect.type === "audioTransition" && effect.targetId === targetId,
+      (effect.type === "audio-transition" ||
+        effect.type === "audioTransition") &&
+      effect.targetId === targetId,
   );
 
   return transition?.properties?.[property]?.[phase] ?? null;

--- a/src/schemas/audio/audio-transition.yaml
+++ b/src/schemas/audio/audio-transition.yaml
@@ -12,7 +12,7 @@ properties:
     type: string
     description: Unique identifier
   type:
-    const: audioTransition
+    enum: [audio-transition, audioTransition]
     description: Audio transition
   targetId:
     type: string

--- a/src/types.js
+++ b/src/types.js
@@ -663,7 +663,7 @@
 /**
  * @typedef {Object} AudioTransition
  * @property {string} id - Unique identifier
- * @property {string} type - Should be "audioTransition"
+ * @property {string} type - Should be "audio-transition"
  * @property {string} targetId - Target sound or audio-channel id
  * @property {Object} properties - Transition properties
  */

--- a/src/util/normalizeAudio.js
+++ b/src/util/normalizeAudio.js
@@ -1,5 +1,10 @@
 const AUDIO_NODE_TYPES = new Set(["audio-channel", "sound"]);
-const AUDIO_EFFECT_TYPES = new Set(["audioTransition"]);
+const AUDIO_TRANSITION_TYPE = "audio-transition";
+const LEGACY_AUDIO_TRANSITION_TYPE = "audioTransition";
+const AUDIO_EFFECT_TYPES = new Set([
+  AUDIO_TRANSITION_TYPE,
+  LEGACY_AUDIO_TRANSITION_TYPE,
+]);
 const AUDIO_TRANSITION_PHASES = new Set(["enter", "exit", "update"]);
 const AUDIO_TRANSITION_PROPERTIES = new Set(["volume"]);
 const AUDIO_EASINGS = new Set(["linear"]);
@@ -304,7 +309,10 @@ const validateAudioEffects = (audioEffects, ids, nodeIds) => {
       );
     }
 
-    if (effect.type === "audioTransition") {
+    if (
+      effect.type === AUDIO_TRANSITION_TYPE ||
+      effect.type === LEGACY_AUDIO_TRANSITION_TYPE
+    ) {
       validateAudioTransition(effect, path, nodeIds);
     }
   }

--- a/vt/specs/audio/channel-mixer.yaml
+++ b/vt/specs/audio/channel-mixer.yaml
@@ -37,7 +37,7 @@ states:
             volume: 80
     audioEffects:
       - id: music-volume-update
-        type: audioTransition
+        type: audio-transition
         targetId: music
         properties:
           volume:

--- a/vt/specs/audio/flat-sounds.yaml
+++ b/vt/specs/audio/flat-sounds.yaml
@@ -21,7 +21,7 @@ states:
         volume: 60
     audioEffects:
       - id: flat-bgm-enter
-        type: audioTransition
+        type: audio-transition
         targetId: flat-bgm
         properties:
           volume:
@@ -38,7 +38,7 @@ states:
         volume: 25
     audioEffects:
       - id: flat-bgm-update
-        type: audioTransition
+        type: audio-transition
         targetId: flat-bgm
         properties:
           volume:
@@ -58,7 +58,7 @@ states:
         volume: 55
     audioEffects:
       - id: flat-bgm-replace-enter
-        type: audioTransition
+        type: audio-transition
         targetId: flat-bgm
         properties:
           volume:

--- a/vt/specs/audio/volume-transitions.yaml
+++ b/vt/specs/audio/volume-transitions.yaml
@@ -1,6 +1,6 @@
 ---
 title: Audio Manual - Volume Transitions
-description: Manual fixture for audioTransition enter, update, exit, and same-id source crossfade. Use the state pager or n/b keys.
+description: Manual fixture for audio-transition enter, update, exit, and same-id source crossfade. Use the state pager or n/b keys.
 skipScreenshot: true
 specs:
   - state 1 is silent baseline
@@ -25,7 +25,7 @@ states:
             volume: 100
     audioEffects:
       - id: music-enter
-        type: audioTransition
+        type: audio-transition
         targetId: music
         properties:
           volume:
@@ -46,7 +46,7 @@ states:
             volume: 100
     audioEffects:
       - id: music-update-down
-        type: audioTransition
+        type: audio-transition
         targetId: music
         properties:
           volume:
@@ -54,7 +54,7 @@ states:
               duration: 1500
               easing: linear
       - id: transition-bgm-exit-ready
-        type: audioTransition
+        type: audio-transition
         targetId: transition-bgm
         properties:
           volume:
@@ -75,7 +75,7 @@ states:
             volume: 100
     audioEffects:
       - id: transition-bgm-enter
-        type: audioTransition
+        type: audio-transition
         targetId: transition-bgm
         properties:
           volume:
@@ -88,7 +88,7 @@ states:
               duration: 1200
               easing: linear
       - id: music-exit-ready
-        type: audioTransition
+        type: audio-transition
         targetId: music
         properties:
           volume:


### PR DESCRIPTION
## Summary
- Rename the canonical audio transition effect type from `audioTransition` to `audio-transition`.
- Keep `audioTransition` accepted as a legacy alias in validation, runtime lookup, and schema.
- Bump `route-graphics` to `1.23.2` and update docs/tests/VT fixtures.

## Validation
- `bunx vitest run spec/util/normalizeAudio.spec.js spec/audio/audioStage.spec.js spec/audio/renderAudio.spec.js`
- `bun run build`
- `bunx prettier --check docs/audio-effects.md spec/audio/audioStage.spec.js spec/audio/renderAudio.spec.js spec/util/normalizeAudio.spec.js src/AudioStage.js src/util/normalizeAudio.js src/types.js vt/specs/audio/channel-mixer.yaml vt/specs/audio/flat-sounds.yaml vt/specs/audio/volume-transitions.yaml package.json`

Note: the full pre-push `vitest run` still fails locally in unrelated parser text/text-revealing measurement fixtures by 1px.