### PR TITLE
Improve asset load error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.23.2",
+  "version": "1.23.3",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/pages/docs/guides/assets-loading.md
+++ b/playground/pages/docs/guides/assets-loading.md
@@ -44,6 +44,55 @@ await app.init({
 await app.loadAssets(assetBufferManager.getBufferMap());
 ```
 
+## Load Errors
+
+Asset loading errors are safe to show in application UI. The thrown
+`error.message` and `error.userMessage` use plain language and explain what the
+user can act on:
+
+```text
+Could not load image "hero-texture". Missing, inaccessible, or unsupported image file.
+```
+
+When several assets fail in the same load call, Route Graphics throws an
+`AggregateError` with a short summary:
+
+```text
+Could not load 2 assets: audio "bgm-main", image "hero-texture". Check that the files exist and are supported.
+```
+
+Use `error.userMessage ?? error.message` for alerts or toasts, and log the full
+error object for debugging. The original low-level failure is preserved in
+`error.cause`. Route Graphics also attaches structured diagnostics to
+`error.details`:
+
+```js
+try {
+  await assetBufferManager.load(assets);
+  await app.loadAssets(assetBufferManager.getBufferMap());
+} catch (error) {
+  showToast(error.userMessage ?? error.message);
+  console.error("Failed to load route graphics assets", error);
+}
+```
+
+For a single asset failure, `error.details` may include:
+
+- `assetKey`: alias that failed
+- `assetKind`: user-facing kind, such as `image`, `audio`, `video`, or `font`
+- `assetCategory`: runtime category, such as `texture`, `audio`, `video`, or
+  `font`
+- `type`: MIME type
+- `source`: `url` or `buffer`
+- `url`: source URL, truncated if very long
+- `bufferBytes`: byte length for buffer-backed assets
+- `phase`: loader step that failed
+- `cause`: original low-level error message
+
+For multi-asset failures, `error.details.failures` contains one diagnostic
+object per failed asset. Use that for logs or a separate details view instead of
+putting the full list in the alert.
+
 ## What The Runtime Loads
 
 - Images and other Pixi-compatible textures are loaded into `Assets` and can be used by `sprite`, `slider`, `spritesheet-animation`, `text-revealing`, and particle textures. When possible, images are loaded directly from their source URLs instead of being buffered into JS first.

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -425,6 +425,82 @@ describe("RouteGraphics public API", () => {
     expect(loadAssetsResolved).toBe(true);
   });
 
+  it("adds asset key, type, phase, and cause to Pixi texture load failures", async () => {
+    const { app, pixiMock } = await setupRouteGraphics();
+    pixiMock.Assets.load.mockRejectedValue(new Error("Pixi could not load"));
+
+    let thrownError;
+    try {
+      await app.loadAssets({
+        cityBackground: {
+          source: "url",
+          url: "https://cdn.example.test/city.png",
+          type: "image/png",
+        },
+      });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError?.message).toBe(
+      'Could not load image "cityBackground". Missing, inaccessible, or unsupported image file.',
+    );
+    expect(thrownError?.details).toEqual(
+      expect.objectContaining({
+        assetKey: "cityBackground",
+        assetKind: "image",
+        assetCategory: "texture",
+        phase: "Pixi URL load",
+        type: "image/png",
+        source: "url",
+        url: "https://cdn.example.test/city.png",
+        cause: "Pixi could not load",
+      }),
+    );
+  });
+
+  it("aggregates multiple asset load failures with their root causes", async () => {
+    const audioAsset = {
+      load: vi.fn(() => Promise.reject(new Error("audio decode failed"))),
+      getAsset: vi.fn(),
+    };
+    const { app, pixiMock } = await setupRouteGraphics({ audioAsset });
+    pixiMock.Assets.load.mockRejectedValue(new Error("texture fetch failed"));
+
+    let thrownError;
+    try {
+      await app.loadAssets({
+        click: {
+          buffer: new Uint8Array([1, 2, 3]).buffer,
+          type: "audio/mpeg",
+        },
+        background: {
+          source: "url",
+          url: "https://cdn.example.test/background.png",
+          type: "image/png",
+        },
+      });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError?.message).toBe(
+      'Could not load 2 assets: audio "click", image "background". Check that the files exist and are supported.',
+    );
+    expect(thrownError?.details?.failures).toEqual([
+      expect.objectContaining({
+        assetKey: "click",
+        assetKind: "audio",
+        cause: "audio decode failed",
+      }),
+      expect.objectContaining({
+        assetKey: "background",
+        assetKind: "image",
+        cause: "texture fetch failed",
+      }),
+    ]);
+  });
+
   it("updates the visible stage background graphic color", async () => {
     const { app, pixiMock } = await setupRouteGraphics();
     const appInstance = pixiMock.__getLastApplication();

--- a/spec/audio/audioAsset.spec.js
+++ b/spec/audio/audioAsset.spec.js
@@ -73,4 +73,40 @@ describe("AudioAsset", () => {
     await expect(firstLoad).resolves.toBe(decodedBuffer);
     expect(AudioAsset.getAsset("click")).toBe(decodedBuffer);
   });
+
+  it("rejects decode failures with asset context and root cause", async () => {
+    vi.resetModules();
+
+    const context = {
+      decodeAudioData: vi.fn(() =>
+        Promise.reject(new Error("unsupported codec")),
+      ),
+    };
+    window.AudioContext = vi.fn(function AudioContextMock() {
+      return context;
+    });
+    window.webkitAudioContext = undefined;
+
+    const { AudioAsset } = await import("../../src/AudioAsset.js");
+    const arrayBuffer = new Uint8Array([1, 2, 3]).buffer;
+
+    let thrownError;
+    try {
+      await AudioAsset.load("voice-line", arrayBuffer);
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError?.message).toBe(
+      'Could not load audio "voice-line". Unsupported or damaged audio file.',
+    );
+    expect(thrownError?.details).toEqual(
+      expect.objectContaining({
+        assetKey: "voice-line",
+        assetKind: "audio",
+        phase: "decode",
+        cause: "unsupported codec",
+      }),
+    );
+  });
 });

--- a/spec/util/createAssetBufferManager.spec.js
+++ b/spec/util/createAssetBufferManager.spec.js
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAssetBufferManager } from "../../src/util/createAssetBufferManager.js";
+
+describe("createAssetBufferManager", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects failed fetches with asset key, type, URL, and HTTP status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+        }),
+      ),
+    );
+
+    const manager = createAssetBufferManager();
+
+    let thrownError;
+    try {
+      await manager.load({
+        themeMusic: {
+          url: "https://cdn.example.test/theme.mp3",
+          type: "audio/mpeg",
+        },
+      });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError?.message).toBe(
+      'Could not load asset "themeMusic". File not found.',
+    );
+    expect(thrownError?.details).toEqual(
+      expect.objectContaining({
+        assetKey: "themeMusic",
+        type: "audio/mpeg",
+        url: "https://cdn.example.test/theme.mp3",
+        cause: "HTTP 404 Not Found",
+      }),
+    );
+  });
+
+  it("rejects missing asset URLs with asset key and root cause", async () => {
+    const manager = createAssetBufferManager();
+
+    await expect(
+      manager.load({
+        brokenAsset: {
+          type: "audio/mpeg",
+        },
+      }),
+    ).rejects.toThrow('Could not load asset "brokenAsset". Missing file URL.');
+  });
+});

--- a/src/AudioAsset.js
+++ b/src/AudioAsset.js
@@ -3,6 +3,31 @@ const audioContext = new (window.AudioContext || window.webkitAudioContext)();
 const loadedAssets = {};
 const loadingAssets = {};
 
+const getErrorMessage = (error) => {
+  if (!error) return "Unknown error";
+  if (typeof error === "string") return error;
+  return error.message || String(error);
+};
+
+const createAudioDecodeError = (key, error) => {
+  const rootCauseMessage = "Unsupported or damaged audio file.";
+  const message = `Could not load audio "${key}". ${rootCauseMessage}`;
+  const audioError = new Error(message, {
+    cause: error,
+  });
+
+  audioError.userMessage = message;
+  audioError.rootCauseMessage = rootCauseMessage;
+  audioError.details = {
+    assetKey: key,
+    assetKind: "audio",
+    phase: "decode",
+    cause: getErrorMessage(error),
+  };
+
+  return audioError;
+};
+
 const load = (key, arrayBuffer) => {
   if (loadedAssets[key]) {
     return loadedAssets[key];
@@ -21,7 +46,7 @@ const load = (key, arrayBuffer) => {
       return audioBuffer;
     })
     .catch((error) => {
-      console.error(`AudioAsset.load: Failed to decode ${key}:`, error);
+      throw createAudioDecodeError(key, error);
     })
     .finally(() => {
       delete loadingAssets[key];

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -181,6 +181,213 @@ const createRouteGraphics = () => {
     return "texture";
   };
 
+  const getErrorMessage = (error) => {
+    if (!error) return "Unknown error";
+    if (typeof error === "string") return error;
+    return error.message || String(error);
+  };
+
+  const truncateErrorValue = (value, maxLength = 180) => {
+    if (typeof value !== "string") return undefined;
+    if (value.length <= maxLength) return value;
+    return `${value.slice(0, maxLength - 1)}...`;
+  };
+
+  const getBufferByteLength = (buffer) => {
+    if (!buffer) return 0;
+    if (typeof buffer.byteLength === "number") return buffer.byteLength;
+    return 0;
+  };
+
+  const getAssetKindLabel = (category, asset = {}) => {
+    if (category === "texture") {
+      return asset.type?.startsWith("image/") ? "image" : "visual asset";
+    }
+
+    return category || "asset";
+  };
+
+  const getHttpStatusCode = (message) => {
+    const match = message.match(/HTTP\s+(\d{3})/);
+    return match?.[1];
+  };
+
+  const getFriendlyCauseMessage = ({ category, phase, error }) => {
+    if (error?.rootCauseMessage) {
+      return error.rootCauseMessage;
+    }
+
+    const causeMessage = getErrorMessage(error);
+    const httpStatusCode = getHttpStatusCode(causeMessage);
+
+    if (httpStatusCode === "404") {
+      return "File not found.";
+    }
+
+    if (httpStatusCode === "401" || httpStatusCode === "403") {
+      return "Access denied.";
+    }
+
+    if (httpStatusCode?.startsWith("5")) {
+      return "File server error.";
+    }
+
+    if (/URL is missing/i.test(causeMessage)) {
+      return "Missing file URL.";
+    }
+
+    if (/missing or empty/i.test(causeMessage)) {
+      return "Missing file data.";
+    }
+
+    if (category === "audio" || /decode/i.test(causeMessage)) {
+      return "Unsupported or damaged audio file.";
+    }
+
+    if (category === "font") {
+      return "Unsupported or damaged font file.";
+    }
+
+    if (category === "video") {
+      return "Unsupported, damaged, or inaccessible video file.";
+    }
+
+    if (category === "texture" && phase === "image bitmap creation") {
+      return "Unsupported or damaged image file.";
+    }
+
+    if (category === "texture") {
+      return "Missing, inaccessible, or unsupported image file.";
+    }
+
+    return "File could not be loaded.";
+  };
+
+  const getAssetErrorDetails = ({
+    key,
+    kind,
+    category,
+    phase,
+    asset,
+    error,
+  }) => {
+    const details = {
+      assetKey: key,
+      assetKind: kind,
+      assetCategory: category,
+      phase,
+      cause: getErrorMessage(error),
+    };
+
+    if (asset?.type) details.type = asset.type;
+    if (asset?.source) details.source = asset.source;
+    if (asset?.url) details.url = truncateErrorValue(asset.url);
+    if (asset?.buffer) details.bufferBytes = getBufferByteLength(asset.buffer);
+
+    return details;
+  };
+
+  const createAssetLoadError = ({ key, category, phase, asset, error }) => {
+    const kind = getAssetKindLabel(category, asset);
+    const rootCauseMessage = getFriendlyCauseMessage({
+      category,
+      phase,
+      error,
+    });
+    const message = `Could not load ${kind} "${key}". ${rootCauseMessage}`;
+    const assetError = new Error(message, { cause: error });
+
+    assetError.userMessage = message;
+    assetError.rootCauseMessage = rootCauseMessage;
+    assetError.details = getAssetErrorDetails({
+      key,
+      kind,
+      category,
+      phase,
+      asset,
+      error,
+    });
+
+    return assetError;
+  };
+
+  const loadAssetWithContext = async (
+    { key, category, phase, asset },
+    load,
+  ) => {
+    try {
+      return await load();
+    } catch (error) {
+      throw createAssetLoadError({
+        key,
+        category,
+        phase,
+        asset,
+        error,
+      });
+    }
+  };
+
+  const assertAssetBuffer = (asset, category) => {
+    if (getBufferByteLength(asset?.buffer) === 0) {
+      throw new Error(`${category} asset data is missing or empty.`);
+    }
+  };
+
+  const quoteAssetName = (value) => {
+    if (!value) return "unknown";
+    return `"${String(value).replaceAll('"', '\\"')}"`;
+  };
+
+  const formatAssetFailureName = (failure) => {
+    const { assetKind, assetKey } = failure?.details || {};
+    if (!assetKey) return "unknown asset";
+    if (!assetKind) return quoteAssetName(assetKey);
+    return `${assetKind} ${quoteAssetName(assetKey)}`;
+  };
+
+  const formatAssetFailureNames = (failures) => {
+    const maxVisibleFailures = 3;
+    const visibleNames = failures
+      .slice(0, maxVisibleFailures)
+      .map(formatAssetFailureName);
+    const hiddenCount = failures.length - visibleNames.length;
+    const suffix = hiddenCount > 0 ? `, and ${hiddenCount} more` : "";
+
+    return `${visibleNames.join(", ")}${suffix}`;
+  };
+
+  const throwAssetLoadFailures = (settledResults) => {
+    const failures = settledResults
+      .filter((result) => result.status === "rejected")
+      .map((result) => result.reason);
+
+    if (failures.length === 0) {
+      return;
+    }
+
+    if (failures.length === 1) {
+      throw failures[0];
+    }
+
+    const rootCauseMessage = "Check that the files exist and are supported.";
+    const message = `Could not load ${failures.length} assets: ${formatAssetFailureNames(failures)}. ${rootCauseMessage}`;
+    const aggregateError = new AggregateError(failures, message);
+
+    aggregateError.userMessage = message;
+    aggregateError.rootCauseMessage = rootCauseMessage;
+    aggregateError.details = {
+      failures: failures.map(
+        (failure) =>
+          failure?.details || {
+            cause: getErrorMessage(failure),
+          },
+      ),
+    };
+
+    throw aggregateError;
+  };
+
   const trackVideoSourceUrl = (key, url, { revokable = false } = {}) => {
     videoSourceUrls.set(key, {
       url,
@@ -673,93 +880,156 @@ const createRouteGraphics = () => {
         assetsByType[assetType][key] = asset;
       }
 
-      // Load audio assets using AudioAsset.load in parallel
-      await Promise.all(
-        Object.entries(assetsByType.audio).map(([key, asset]) =>
-          AudioAsset.load(key, asset.buffer),
-        ),
-      );
+      const loadJobs = [];
 
-      // Load font assets
-      await Promise.all(
-        Object.entries(assetsByType.font).map(async ([key, asset]) => {
-          const blob = new Blob([asset.buffer], { type: asset.type });
-          const url = URL.createObjectURL(blob);
-          // Use the key as font family name - this should match the fontFamily in text styles
-          const fontFace = new FontFace(key, `url(${url})`);
-          try {
-            await fontFace.load();
-            document.fonts.add(fontFace);
-          } catch (error) {
-            console.error(`Failed to load font ${key}:`, error);
-          } finally {
-            URL.revokeObjectURL(url);
-          }
+      Object.entries(assetsByType.audio).forEach(([key, asset]) => {
+        loadJobs.push({
+          includeInReturn: false,
+          promise: loadAssetWithContext(
+            {
+              key,
+              category: "audio",
+              phase: "decode",
+              asset,
+            },
+            async () => {
+              assertAssetBuffer(asset, "Audio");
+              return AudioAsset.load(key, asset.buffer);
+            },
+          ),
+        });
+      });
+
+      Object.entries(assetsByType.font).forEach(([key, asset]) => {
+        loadJobs.push({
+          includeInReturn: false,
+          promise: loadAssetWithContext(
+            {
+              key,
+              category: "font",
+              phase: "font face load",
+              asset,
+            },
+            async () => {
+              assertAssetBuffer(asset, "Font");
+              const blob = new Blob([asset.buffer], { type: asset.type });
+              const url = URL.createObjectURL(blob);
+              // Use the key as font family name - this should match the fontFamily in text styles
+              const fontFace = new FontFace(key, `url(${url})`);
+              try {
+                await fontFace.load();
+                document.fonts.add(fontFace);
+              } finally {
+                URL.revokeObjectURL(url);
+              }
+            },
+          ),
+        });
+      });
+
+      Object.entries(assetsByType.texture).forEach(([key, asset]) =>
+        loadJobs.push({
+          includeInReturn: true,
+          promise: loadAssetWithContext(
+            {
+              key,
+              category: "texture",
+              phase:
+                asset?.source === "url" && typeof asset?.url === "string"
+                  ? "Pixi URL load"
+                  : "image bitmap creation",
+              asset,
+            },
+            async () => {
+              if (Assets.cache.has(key)) {
+                return Assets.cache.get(key);
+              }
+
+              if (asset?.source === "url" && typeof asset?.url === "string") {
+                return Assets.load({
+                  alias: key,
+                  src: asset.url,
+                });
+              }
+
+              assertAssetBuffer(asset, "Texture");
+              const blob = new Blob([asset.buffer], { type: asset.type });
+              const imageBitmap = await createImageBitmap(blob);
+              const texture = Texture.from(imageBitmap);
+
+              // Alias the logical asset key so Texture.from("key") resolves
+              // directly from the cache instead of attempting a relative URL fetch.
+              Assets.cache.set(key, texture);
+
+              return texture;
+            },
+          ),
         }),
-      );
-
-      const texturePromises = Object.entries(assetsByType.texture).map(
-        async ([key, asset]) => {
-          if (Assets.cache.has(key)) {
-            return Assets.cache.get(key);
-          }
-
-          if (asset?.source === "url" && typeof asset?.url === "string") {
-            return Assets.load({
-              alias: key,
-              src: asset.url,
-            });
-          }
-
-          const blob = new Blob([asset.buffer], { type: asset.type });
-          const imageBitmap = await createImageBitmap(blob);
-          const texture = Texture.from(imageBitmap);
-
-          // Alias the logical asset key so Texture.from("key") resolves
-          // directly from the cache instead of attempting a relative URL fetch.
-          Assets.cache.set(key, texture);
-
-          return texture;
-        },
       );
 
       // Load video assets via direct URL when possible, otherwise fall back
       // to a revokable blob URL for buffer-backed inputs.
-      const videoPromises = Object.entries(assetsByType.video).map(
-        async ([key, asset]) => {
-          if (Assets.cache.has(key)) {
-            return Assets.cache.get(key);
-          }
-
-          const sourceUrl =
-            asset?.source === "url" && typeof asset?.url === "string"
-              ? asset.url
-              : URL.createObjectURL(
-                  new Blob([asset.buffer], { type: asset.type }),
-                );
-          const isRevokableBlobUrl = asset?.source !== "url";
-
-          trackVideoSourceUrl(key, sourceUrl, {
-            revokable: isRevokableBlobUrl,
-          });
-
-          try {
-            return await loadVideoTexture({
+      Object.entries(assetsByType.video).forEach(([key, asset]) => {
+        loadJobs.push({
+          includeInReturn: true,
+          promise: loadAssetWithContext(
+            {
               key,
-              sourceUrl,
-              mimeType: asset?.type,
-            });
-          } catch (error) {
-            videoSourceUrls.delete(key);
-            if (isRevokableBlobUrl) {
-              URL.revokeObjectURL(sourceUrl);
-            }
-            throw error;
-          }
-        },
-      );
+              category: "video",
+              phase: "video texture load",
+              asset,
+            },
+            async () => {
+              if (Assets.cache.has(key)) {
+                return Assets.cache.get(key);
+              }
 
-      return Promise.all([...texturePromises, ...videoPromises]);
+              if (asset?.source !== "url") {
+                assertAssetBuffer(asset, "Video");
+              }
+
+              const sourceUrl =
+                asset?.source === "url" && typeof asset?.url === "string"
+                  ? asset.url
+                  : URL.createObjectURL(
+                      new Blob([asset.buffer], { type: asset.type }),
+                    );
+              const isRevokableBlobUrl = asset?.source !== "url";
+
+              trackVideoSourceUrl(key, sourceUrl, {
+                revokable: isRevokableBlobUrl,
+              });
+
+              try {
+                return await loadVideoTexture({
+                  key,
+                  sourceUrl,
+                  mimeType: asset?.type,
+                });
+              } catch (error) {
+                videoSourceUrls.delete(key);
+                if (isRevokableBlobUrl) {
+                  URL.revokeObjectURL(sourceUrl);
+                }
+                throw error;
+              }
+            },
+          ),
+        });
+      });
+
+      const settledResults = await Promise.allSettled(
+        loadJobs.map((job) => job.promise),
+      );
+      throwAssetLoadFailures(settledResults);
+
+      return settledResults
+        .map((result, index) =>
+          loadJobs[index].includeInReturn && result.status === "fulfilled"
+            ? result.value
+            : undefined,
+        )
+        .filter(Boolean);
     },
 
     loadAudioAssets: async (urls) => {

--- a/src/util/createAssetBufferManager.js
+++ b/src/util/createAssetBufferManager.js
@@ -4,6 +4,66 @@
 const createAssetBufferManager = () => {
   const cache = new Map();
   const isBlobUrl = (url) => typeof url === "string" && url.startsWith("blob:");
+  const getErrorMessage = (error) => {
+    if (!error) return "Unknown error";
+    if (typeof error === "string") return error;
+    return error.message || String(error);
+  };
+  const truncateErrorValue = (value, maxLength = 180) => {
+    if (typeof value !== "string") return undefined;
+    if (value.length <= maxLength) return value;
+    return `${value.slice(0, maxLength - 1)}...`;
+  };
+  const getHttpStatusCode = (message) => {
+    const match = message.match(/HTTP\s+(\d{3})/);
+    return match?.[1];
+  };
+  const getFriendlyFetchCauseMessage = (error) => {
+    const causeMessage = getErrorMessage(error);
+    const httpStatusCode = getHttpStatusCode(causeMessage);
+
+    if (httpStatusCode === "404") {
+      return "File not found.";
+    }
+
+    if (httpStatusCode === "401" || httpStatusCode === "403") {
+      return "Access denied.";
+    }
+
+    if (httpStatusCode?.startsWith("5")) {
+      return "File server error.";
+    }
+
+    if (/URL is missing/i.test(causeMessage)) {
+      return "Missing file URL.";
+    }
+
+    return "File could not be downloaded.";
+  };
+  const getAssetFetchErrorDetails = ({ key, value, error }) => {
+    const details = {
+      assetKey: key,
+      cause: getErrorMessage(error),
+    };
+
+    if (value?.type) details.type = value.type;
+    if (value?.url) details.url = truncateErrorValue(value.url);
+
+    return details;
+  };
+  const createAssetFetchError = ({ key, value, error }) => {
+    const rootCauseMessage = getFriendlyFetchCauseMessage(error);
+    const message = `Could not load asset "${key}". ${rootCauseMessage}`;
+    const fetchError = new Error(message, {
+      cause: error,
+    });
+
+    fetchError.userMessage = message;
+    fetchError.rootCauseMessage = rootCauseMessage;
+    fetchError.details = getAssetFetchErrorDetails({ key, value, error });
+
+    return fetchError;
+  };
   const shouldCacheByUrl = (value) => {
     return (
       typeof value?.type === "string" &&
@@ -32,25 +92,38 @@ const createAssetBufferManager = () => {
     if (toFetch.length > 0) {
       await Promise.all(
         toFetch.map(async ([key, value]) => {
-          if (shouldCacheByUrl(value)) {
-            cache.set(key, {
-              url: value.url,
+          try {
+            if (!value?.url) {
+              throw new Error("Asset URL is missing.");
+            }
+
+            if (shouldCacheByUrl(value)) {
+              cache.set(key, {
+                url: value.url,
+                type: value.type,
+                source: "url",
+              });
+              return;
+            }
+
+            const resp = await fetch(value.url);
+            if (!resp.ok) {
+              throw new Error(
+                `HTTP ${resp.status}${resp.statusText ? ` ${resp.statusText}` : ""}`,
+              );
+            }
+            const buffer = await resp.arrayBuffer();
+            const bufferData = {
+              buffer,
               type: value.type,
-              source: "url",
-            });
-            return;
+              source: "buffer",
+            };
+
+            // Cache the result
+            cache.set(key, bufferData);
+          } catch (error) {
+            throw createAssetFetchError({ key, value, error });
           }
-
-          const resp = await fetch(value.url);
-          const buffer = await resp.arrayBuffer();
-          const bufferData = {
-            buffer,
-            type: value.type,
-            source: "buffer",
-          };
-
-          // Cache the result
-          cache.set(key, bufferData);
         }),
       );
     }


### PR DESCRIPTION
## Summary
- Add display-safe asset load errors while preserving technical diagnostics in error.details and error.cause
- Surface fetch status, missing URL, empty data, audio decode, font, image, and video root causes
- Document the error contract in the Assets & Loading guide and bump route-graphics to v1.23.3

## Validation
- bunx vitest run spec/RouteGraphics.publicApi.spec.js spec/audio/audioAsset.spec.js spec/util/createAssetBufferManager.spec.js
- bun run lint
- bun run build

## Notes
- bun run test / pre-push hook currently fails unrelated parser fixture assertions in spec/parser/parseText.test.yaml and spec/parser/parseTextRevealing.test.yaml due local text metric differences such as expected height 20 vs received 19. The focused asset-loading tests pass.