### PR TITLE
feat: add text reveal sound playback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.23.3",
+  "version": "1.24.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -156,7 +156,10 @@ describe("AudioStage graph rendering", () => {
     expect(getAsset).toHaveBeenCalledWith("click-sfx");
     expect(context.sources).toHaveLength(2);
     expect(context.sources[0].loop).toBe(true);
-    expect(context.sources[0].start).toHaveBeenCalledWith(0, 0);
+    expect(context.sources[0].start).toHaveBeenCalledWith(
+      context.currentTime,
+      0,
+    );
   });
 
   it("sanitizes direct audio defaults across repeated ticks", async () => {
@@ -600,7 +603,7 @@ describe("AudioStage graph rendering", () => {
     expect(source.loop).toBe(true);
     expect(source.loopStart).toBe(1);
     expect(source.loopEnd).toBe(4);
-    expect(source.start).toHaveBeenCalledWith(0, 1);
+    expect(source.start).toHaveBeenCalledWith(context.currentTime, 1);
     expect(source.start.mock.calls[0]).toHaveLength(2);
   });
 

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -184,6 +184,15 @@ describe("AudioStage graph rendering", () => {
     expect(context.resume).toHaveBeenCalled();
   });
 
+  it("exposes an explicit resume hook for user input unlocks", async () => {
+    const { stage, context } = await setupAudioStage();
+    context.state = "suspended";
+
+    await stage.resume();
+
+    expect(context.resume).toHaveBeenCalledTimes(1);
+  });
+
   it("resumes a suspended audio context before scheduling delayed playback", async () => {
     const { stage, context, getAsset } = await setupAudioStage();
     context.state = "suspended";

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -5,10 +5,16 @@ const createAudioParam = (initialValue = 0) => {
     value: initialValue,
     cancelScheduledValues: vi.fn(),
     setValueAtTime: vi.fn((value) => {
+      if (!Number.isFinite(value)) {
+        throw new TypeError("AudioParam value must be finite");
+      }
       param.value = value;
       return param;
     }),
     linearRampToValueAtTime: vi.fn((value) => {
+      if (!Number.isFinite(value)) {
+        throw new TypeError("AudioParam value must be finite");
+      }
       param.value = value;
       return param;
     }),
@@ -151,6 +157,20 @@ describe("AudioStage graph rendering", () => {
     expect(context.sources).toHaveLength(2);
     expect(context.sources[0].loop).toBe(true);
     expect(context.sources[0].start).toHaveBeenCalledWith(0, 0);
+  });
+
+  it("sanitizes direct audio defaults across repeated ticks", async () => {
+    const { stage } = await setupAudioStage();
+
+    stage.add({ id: "blip", url: "message-display1", volume: Number.NaN });
+
+    expect(() => stage.tick()).not.toThrow();
+    expect(() => stage.tick()).not.toThrow();
+
+    const blip = findCurrentSound(stage, "blip");
+    expect(blip.gainNode.gain.value).toBe(1);
+    expect(blip.pannerNode.pan.value).toBe(0);
+    expect(blip.source.playbackRate.value).toBe(1);
   });
 
   it("resumes a suspended audio context before playback starts", async () => {

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -22,7 +22,7 @@ const createAudioParam = (initialValue = 0) => {
   return param;
 };
 
-const createAudioContextMock = () => {
+const createAudioContextMock = ({ decodedBuffer = { duration: 1 } } = {}) => {
   const context = {
     currentTime: 10,
     state: "running",
@@ -30,6 +30,7 @@ const createAudioContextMock = () => {
     gainNodes: [],
     pannerNodes: [],
     sources: [],
+    decodeAudioData: vi.fn(() => Promise.resolve(decodedBuffer)),
     resume: vi.fn(() => Promise.resolve()),
     createGain: vi.fn(() => {
       const node = {
@@ -107,6 +108,11 @@ const findCurrentSound = (stage, id) => {
   return inspect.sounds.get(key);
 };
 
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
 describe("AudioStage graph rendering", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -115,6 +121,7 @@ describe("AudioStage graph rendering", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    vi.doUnmock("../../src/AudioAsset.js");
     vi.resetModules();
   });
 
@@ -185,6 +192,69 @@ describe("AudioStage graph rendering", () => {
     });
 
     expect(context.resume).toHaveBeenCalled();
+    expect(context.sources).toHaveLength(0);
+
+    context.state = "running";
+    await flushPromises();
+
+    expect(context.sources).toHaveLength(1);
+  });
+
+  it("cancels suspended-context playback before resume resolves", async () => {
+    const { stage, context, getAsset } = await setupAudioStage();
+    let resolveResume;
+    context.state = "suspended";
+    context.resume.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveResume = () => {
+            context.state = "running";
+            resolve();
+          };
+        }),
+    );
+    const audio = [{ id: "sfx", type: "sound", src: "click" }];
+
+    stage.renderGraph({ nextAudio: audio });
+
+    expect(context.resume).toHaveBeenCalledTimes(1);
+    expect(context.sources).toHaveLength(0);
+
+    stage.renderGraph({ prevAudio: audio, nextAudio: [] });
+    resolveResume();
+    await flushPromises();
+
+    expect(getAsset).not.toHaveBeenCalled();
+    expect(context.sources).toHaveLength(0);
+  });
+
+  it("uses one audio context for asset decode and playback", async () => {
+    vi.resetModules();
+    vi.doUnmock("../../src/AudioAsset.js");
+
+    const decodedBuffer = { duration: 1.25 };
+    const context = createAudioContextMock({ decodedBuffer });
+    const AudioContextMock = vi.fn(function AudioContextMock() {
+      return context;
+    });
+    window.AudioContext = AudioContextMock;
+    window.webkitAudioContext = undefined;
+
+    const { AudioAsset } = await import("../../src/AudioAsset.js");
+    const { createAudioStage } = await import("../../src/AudioStage.js");
+    const arrayBuffer = new Uint8Array([1, 2, 3]).buffer;
+
+    await AudioAsset.load("theme", arrayBuffer);
+
+    const stage = createAudioStage();
+    stage.renderGraph({
+      nextAudio: [{ id: "theme-sound", type: "sound", src: "theme" }],
+    });
+
+    expect(AudioContextMock).toHaveBeenCalledTimes(1);
+    expect(context.decodeAudioData).toHaveBeenCalledWith(arrayBuffer);
+    expect(context.sources).toHaveLength(1);
+    expect(context.sources[0].buffer).toBe(decodedBuffer);
   });
 
   it("exposes an explicit resume hook for user input unlocks", async () => {
@@ -218,6 +288,7 @@ describe("AudioStage graph rendering", () => {
     expect(context.resume).toHaveBeenCalledTimes(1);
     expect(getAsset).not.toHaveBeenCalled();
 
+    await flushPromises();
     vi.advanceTimersByTime(100);
 
     expect(context.resume).toHaveBeenCalledTimes(1);

--- a/spec/elements/textRevealingRuntime.revealSound.spec.js
+++ b/spec/elements/textRevealingRuntime.revealSound.spec.js
@@ -1,0 +1,187 @@
+import { Container } from "pixi.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { parseTextRevealing } from "../../src/plugins/elements/text-revealing/parseTextRevealing.js";
+import { runTextReveal } from "../../src/plugins/elements/text-revealing/textRevealingRuntime.js";
+
+const createCompletionTracker = () => ({
+  getVersion: () => 0,
+  track: vi.fn(),
+  complete: vi.fn(),
+});
+
+const createAudioStage = () => ({
+  add: vi.fn(),
+  remove: vi.fn(),
+  tick: vi.fn(),
+});
+
+const createElement = (overrides = {}) =>
+  parseTextRevealing({
+    state: {
+      id: "line-1",
+      type: "text-revealing",
+      width: 500,
+      speed: 20,
+      revealEffect: "typewriter",
+      revealSound: {
+        src: "voice-blip",
+      },
+      content: [
+        {
+          text: "This line reveals slowly enough for sound lifecycle coverage.",
+        },
+      ],
+      textStyle: {
+        fontSize: 20,
+        fontFamily: "Arial",
+        breakWords: false,
+      },
+      ...overrides,
+    },
+  });
+
+describe("runTextReveal revealSound", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("plays a configured loop while typewriter text is revealing and stops on completion", async () => {
+    const container = new Container();
+    const audioStage = createAudioStage();
+    const element = createElement({
+      revealSound: {
+        src: "voice-blip",
+        volume: 45,
+        loop: false,
+      },
+    });
+
+    const reveal = runTextReveal({
+      container,
+      element,
+      completionTracker: createCompletionTracker(),
+      animationBus: { dispatch: vi.fn() },
+      zIndex: 0,
+      signal: new AbortController().signal,
+      app: { audioStage },
+      playback: "autoplay",
+    });
+
+    expect(audioStage.add).toHaveBeenCalledWith({
+      id: expect.stringContaining("line-1"),
+      url: "voice-blip",
+      volume: 0.45,
+      loop: false,
+    });
+    expect(audioStage.remove).not.toHaveBeenCalled();
+
+    await vi.runAllTimersAsync();
+    await reveal;
+
+    expect(audioStage.remove).toHaveBeenCalledWith(
+      expect.stringContaining("line-1"),
+    );
+  });
+
+  it("stops typewriter reveal sound when the reveal is aborted", async () => {
+    const container = new Container();
+    const audioStage = createAudioStage();
+    const controller = new AbortController();
+    const element = createElement();
+
+    const reveal = runTextReveal({
+      container,
+      element,
+      completionTracker: createCompletionTracker(),
+      animationBus: { dispatch: vi.fn() },
+      zIndex: 0,
+      signal: controller.signal,
+      app: { audioStage },
+      playback: "autoplay",
+    });
+
+    expect(audioStage.add).toHaveBeenCalledTimes(1);
+
+    controller.abort();
+    await reveal;
+
+    expect(audioStage.remove).toHaveBeenCalledWith(
+      expect.stringContaining("line-1"),
+    );
+  });
+
+  it("does not play sound for paused initial or instant reveal renders", async () => {
+    const audioStage = createAudioStage();
+
+    await runTextReveal({
+      container: new Container(),
+      element: createElement(),
+      completionTracker: createCompletionTracker(),
+      animationBus: { dispatch: vi.fn() },
+      zIndex: 0,
+      signal: new AbortController().signal,
+      app: { audioStage },
+      playback: "paused-initial",
+    });
+
+    await runTextReveal({
+      container: new Container(),
+      element: createElement({
+        speed: 100,
+      }),
+      completionTracker: createCompletionTracker(),
+      animationBus: { dispatch: vi.fn() },
+      zIndex: 0,
+      signal: new AbortController().signal,
+      app: { audioStage },
+      playback: "autoplay",
+    });
+
+    expect(audioStage.add).not.toHaveBeenCalled();
+    expect(audioStage.remove).not.toHaveBeenCalled();
+  });
+
+  it("plays soft-wipe reveal sound until the animation completes", async () => {
+    const container = new Container();
+    const audioStage = createAudioStage();
+    const animationBus = { dispatch: vi.fn() };
+    const element = createElement({
+      revealEffect: "softWipe",
+    });
+
+    await runTextReveal({
+      container,
+      element,
+      completionTracker: createCompletionTracker(),
+      animationBus,
+      zIndex: 0,
+      signal: new AbortController().signal,
+      app: { audioStage },
+      playback: "autoplay",
+    });
+
+    expect(audioStage.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "voice-blip",
+        volume: 1,
+        loop: true,
+      }),
+    );
+    expect(audioStage.remove).not.toHaveBeenCalled();
+
+    const startAction = animationBus.dispatch.mock.calls.find(
+      ([action]) => action.type === "START",
+    )?.[0];
+
+    startAction.payload.onComplete();
+
+    expect(audioStage.remove).toHaveBeenCalledWith(
+      expect.stringContaining("line-1"),
+    );
+  });
+});

--- a/spec/elements/updateTextRevealing.spec.js
+++ b/spec/elements/updateTextRevealing.spec.js
@@ -283,6 +283,54 @@ describe("updateTextRevealing", () => {
     );
   });
 
+  it("restarts softWipe reveal when only revealSound changes", async () => {
+    const parent = new Container();
+    const child = new Container();
+    child.label = "line-1";
+    parent.addChild(child);
+
+    await updateTextRevealing({
+      parent,
+      prevElement: createElement({
+        revealEffect: "softWipe",
+        revealSound: {
+          src: "old-blip",
+          volume: 100,
+          loop: true,
+        },
+      }),
+      nextElement: createElement({
+        revealEffect: "softWipe",
+        revealSound: {
+          src: "new-blip",
+          volume: 70,
+          loop: true,
+        },
+      }),
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      renderContext: createRenderContext(),
+      completionTracker: createCompletionTracker(),
+      zIndex: 0,
+      signal: new AbortController().signal,
+    });
+
+    expect(mocks.runTextReveal).toHaveBeenCalledTimes(1);
+    expect(mocks.runTextReveal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playback: "autoplay",
+        element: expect.objectContaining({
+          revealEffect: "softWipe",
+          revealSound: {
+            src: "new-blip",
+            volume: 70,
+            loop: true,
+          },
+        }),
+      }),
+    );
+  });
+
   it("renders immediately at max speed without queueing deferred reveal work", async () => {
     const parent = new Container();
     const child = new Container();

--- a/spec/parser/parseTextRevealing.revealSound.spec.js
+++ b/spec/parser/parseTextRevealing.revealSound.spec.js
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTextRevealing } from "../../src/plugins/elements/text-revealing/parseTextRevealing.js";
+
+const createState = (overrides = {}) => ({
+  id: "line-1",
+  type: "text-revealing",
+  x: 0,
+  y: 0,
+  content: [{ text: "Reveal sound parser coverage." }],
+  textStyle: {
+    fontFamily: "Arial",
+    fontSize: 20,
+    breakWords: false,
+  },
+  ...overrides,
+});
+
+describe("parseTextRevealing revealSound", () => {
+  it("accepts object config and defaults to full-volume looping playback", () => {
+    const parsed = parseTextRevealing({
+      state: createState({
+        revealSound: {
+          src: "voice-blip",
+        },
+      }),
+    });
+
+    expect(parsed.revealSound).toEqual({
+      src: "voice-blip",
+      volume: 100,
+      loop: true,
+    });
+  });
+
+  it("preserves object volume and loop overrides", () => {
+    const parsed = parseTextRevealing({
+      state: createState({
+        revealSound: {
+          src: "voice-blip",
+          volume: 45,
+          loop: false,
+        },
+      }),
+    });
+
+    expect(parsed.revealSound).toEqual({
+      src: "voice-blip",
+      volume: 45,
+      loop: false,
+    });
+  });
+
+  it("rejects invalid reveal sound configuration", () => {
+    expect(() =>
+      parseTextRevealing({
+        state: createState({
+          revealSound: "voice-blip",
+        }),
+      }),
+    ).toThrow("Input Error: revealSound must be an object.");
+
+    expect(() =>
+      parseTextRevealing({
+        state: createState({
+          revealSound: {
+            src: "voice-blip",
+            volume: 120,
+          },
+        }),
+      }),
+    ).toThrow(
+      "Input Error: revealSound.volume must be a finite number between 0 and 100.",
+    );
+
+    expect(() =>
+      parseTextRevealing({
+        state: createState({
+          revealSound: {
+            src: "voice-blip",
+            loop: "yes",
+          },
+        }),
+      }),
+    ).toThrow("Input Error: revealSound.loop must be a boolean.");
+  });
+});

--- a/src/AudioAsset.js
+++ b/src/AudioAsset.js
@@ -1,4 +1,4 @@
-const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+import { getAudioContext } from "./audioContext.js";
 
 const loadedAssets = {};
 const loadingAssets = {};
@@ -39,7 +39,7 @@ const load = (key, arrayBuffer) => {
     return;
   }
 
-  loadingAssets[key] = audioContext
+  loadingAssets[key] = getAudioContext()
     .decodeAudioData(arrayBuffer)
     .then((audioBuffer) => {
       loadedAssets[key] = audioBuffer;

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -7,6 +7,18 @@ const DIRECT_CHANNEL_ID = "__route_graphics_audio_direct__";
 
 let audioContext;
 
+const isAudioDebugEnabled = () =>
+  globalThis.window?.RTGL_AUDIO_DEBUG === true ||
+  globalThis.window?.RTGL_VT_DEBUG === true;
+
+const debugAudio = (message, details = {}) => {
+  if (!isAudioDebugEnabled()) {
+    return;
+  }
+
+  console.log(`[AudioStage] ${message}`, details);
+};
+
 const getAudioContext = () => {
   if (audioContext) return audioContext;
 
@@ -18,6 +30,7 @@ const getAudioContext = () => {
   }
 
   audioContext = new AudioContextCtor();
+  debugAudio("context created", { state: audioContext.state });
   return audioContext;
 };
 
@@ -47,9 +60,32 @@ const getParamValue = (param, fallback = 0) =>
 
 const resumeAudioContext = (context = getAudioContext()) => {
   if (context.state === "suspended" && typeof context.resume === "function") {
-    return context.resume().catch(() => {});
+    const previousState = context.state;
+    debugAudio("resume requested", { state: previousState });
+
+    return context
+      .resume()
+      .then(() => {
+        debugAudio("resume resolved", {
+          previousState,
+          state: context.state,
+        });
+      })
+      .catch((error) => {
+        if (isAudioDebugEnabled()) {
+          console.warn("[AudioStage] resume failed", {
+            previousState,
+            state: context.state,
+            error,
+          });
+        }
+      });
   }
 
+  debugAudio("resume skipped", {
+    state: context.state,
+    canResume: typeof context.resume === "function",
+  });
   return Promise.resolve();
 };
 
@@ -219,6 +255,13 @@ const createSourceForSound = (sound) => {
   const context = getAudioContext();
   resumeAudioContext(context);
   const audioBuffer = AudioAsset.getAsset(sound.src);
+  debugAudio("asset lookup", {
+    id: sound.id,
+    src: sound.src,
+    found: Boolean(audioBuffer),
+    duration: audioBuffer?.duration ?? null,
+    contextState: context.state,
+  });
   if (!audioBuffer) {
     console.warn("AudioStage: asset not found", sound.src);
     return null;
@@ -249,6 +292,16 @@ const createSourceForSound = (sound) => {
   } else {
     source.start(0, offset);
   }
+  debugAudio("source started", {
+    id: sound.id,
+    src: sound.src,
+    loop: source.loop,
+    offset,
+    duration: duration ?? null,
+    playbackRate: sound.playbackRate,
+    gain: getParamValue(sound.gainNode?.gain, null),
+    contextState: context.state,
+  });
 
   return source;
 };
@@ -259,7 +312,17 @@ const playSound = (sound) => {
     sound.pendingTimeoutId = null;
   }
 
-  resumeAudioContext(getAudioContext());
+  const context = getAudioContext();
+  debugAudio("play requested", {
+    id: sound.id,
+    src: sound.src,
+    loop: sound.loop,
+    volume: sound.volume,
+    muted: sound.muted,
+    startDelayMs: sound.startDelayMs,
+    contextState: context.state,
+  });
+  resumeAudioContext(context);
 
   const start = () => {
     sound.pendingTimeoutId = null;
@@ -791,13 +854,26 @@ export const createAudioStage = () => {
     };
 
     directAudios.set(element.id, audio);
+    debugAudio("direct add", {
+      id: audio.id,
+      src: audio.src,
+      loop: audio.loop,
+      volume: audio.volume,
+      muted: audio.muted,
+      pan: audio.pan,
+    });
   };
 
   const remove = (id) => {
-    directAudios.delete(id);
-    currentSoundKeyById.delete(id);
     const internalId = `direct:${id}`;
     const instance = sounds.get(internalId);
+    debugAudio("direct remove", {
+      id,
+      hadAudio: directAudios.has(id),
+      hadInstance: Boolean(instance),
+    });
+    directAudios.delete(id);
+    currentSoundKeyById.delete(id);
     if (instance) {
       removeSoundInstance(instance, [], 0);
     }

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -47,8 +47,10 @@ const getParamValue = (param, fallback = 0) =>
 
 const resumeAudioContext = (context = getAudioContext()) => {
   if (context.state === "suspended" && typeof context.resume === "function") {
-    void context.resume().catch(() => {});
+    return context.resume().catch(() => {});
   }
+
+  return Promise.resolve();
 };
 
 const setParamNow = (param, value, context = getAudioContext()) => {
@@ -803,6 +805,8 @@ export const createAudioStage = () => {
 
   const getById = (id) => directAudios.get(id);
 
+  const resume = () => resumeAudioContext(getAudioContext());
+
   const tick = () => {
     const channel = ensureRootChannel(DIRECT_CHANNEL_ID);
     for (const audio of directAudios.values()) {
@@ -866,6 +870,7 @@ export const createAudioStage = () => {
     add,
     remove,
     getById,
+    resume,
     tick,
     renderGraph,
     destroy,

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -1,11 +1,10 @@
 import { AudioAsset } from "./AudioAsset.js";
 import { normalizeVolume } from "./util/normalizeVolume.js";
 import { normalizeAudioRenderState } from "./util/normalizeAudio.js";
+import { getAudioContext } from "./audioContext.js";
 
 const ROOT_CHANNEL_ID = "__route_graphics_audio_root__";
 const DIRECT_CHANNEL_ID = "__route_graphics_audio_direct__";
-
-let audioContext;
 
 const isAudioDebugEnabled = () =>
   globalThis.window?.RTGL_AUDIO_DEBUG === true ||
@@ -17,21 +16,6 @@ const debugAudio = (message, details = {}) => {
   }
 
   console.log(`[AudioStage] ${message}`, details);
-};
-
-const getAudioContext = () => {
-  if (audioContext) return audioContext;
-
-  const AudioContextCtor =
-    globalThis.window?.AudioContext ?? globalThis.window?.webkitAudioContext;
-
-  if (!AudioContextCtor) {
-    throw new Error("AudioContext is not available in this environment.");
-  }
-
-  audioContext = new AudioContextCtor();
-  debugAudio("context created", { state: audioContext.state });
-  return audioContext;
 };
 
 const connect = (from, to) => {
@@ -248,12 +232,12 @@ const createSoundInstance = ({ sound, channelNode, internalId }) => {
     source: null,
     pendingTimeoutId: null,
     cleanupTimeoutId: null,
+    playRequestId: 0,
   };
 };
 
 const createSourceForSound = (sound) => {
   const context = getAudioContext();
-  resumeAudioContext(context);
   const audioBuffer = AudioAsset.getAsset(sound.src);
   debugAudio("asset lookup", {
     id: sound.id,
@@ -315,6 +299,8 @@ const playSound = (sound) => {
   }
 
   const context = getAudioContext();
+  const playRequestId = (sound.playRequestId ?? 0) + 1;
+  sound.playRequestId = playRequestId;
   debugAudio("play requested", {
     id: sound.id,
     src: sound.src,
@@ -324,22 +310,43 @@ const playSound = (sound) => {
     startDelayMs: sound.startDelayMs,
     contextState: context.state,
   });
-  resumeAudioContext(context);
+  const needsResume =
+    context.state === "suspended" && typeof context.resume === "function";
 
   const start = () => {
+    if (sound.playRequestId !== playRequestId) {
+      return;
+    }
+
     sound.pendingTimeoutId = null;
     sound.source = createSourceForSound(sound);
   };
 
-  if (sound.startDelayMs > 0) {
-    sound.pendingTimeoutId = setTimeout(start, sound.startDelayMs);
+  const scheduleStart = () => {
+    if (sound.playRequestId !== playRequestId) {
+      return;
+    }
+
+    if (sound.startDelayMs > 0) {
+      sound.pendingTimeoutId = setTimeout(start, sound.startDelayMs);
+      return;
+    }
+
+    start();
+  };
+
+  const resumePromise = resumeAudioContext(context);
+  if (needsResume) {
+    void resumePromise.then(scheduleStart);
     return;
   }
 
-  start();
+  scheduleStart();
 };
 
 const stopSource = (sound, delayMs = 0) => {
+  sound.playRequestId = (sound.playRequestId ?? 0) + 1;
+
   if (sound.pendingTimeoutId !== null) {
     clearTimeout(sound.pendingTimeoutId);
     sound.pendingTimeoutId = null;

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -33,8 +33,17 @@ const disconnect = (node) => {
   }
 };
 
+const toFiniteParamValue = (value, fallback = 0) => {
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) {
+    return parsed;
+  }
+
+  return fallback;
+};
+
 const getParamValue = (param, fallback = 0) =>
-  typeof param?.value === "number" ? param.value : fallback;
+  toFiniteParamValue(param?.value, fallback);
 
 const resumeAudioContext = (context = getAudioContext()) => {
   if (context.state === "suspended" && typeof context.resume === "function") {
@@ -44,13 +53,16 @@ const resumeAudioContext = (context = getAudioContext()) => {
 
 const setParamNow = (param, value, context = getAudioContext()) => {
   if (!param) return;
+
+  const nextValue = toFiniteParamValue(value, getParamValue(param));
+
   if (typeof param.cancelScheduledValues === "function") {
     param.cancelScheduledValues(context.currentTime);
   }
   if (typeof param.setValueAtTime === "function") {
-    param.setValueAtTime(value, context.currentTime);
+    param.setValueAtTime(nextValue, context.currentTime);
   } else {
-    param.value = value;
+    param.value = nextValue;
   }
 };
 
@@ -58,8 +70,9 @@ const rampParam = (param, value, durationMs, context = getAudioContext()) => {
   if (!param) return;
 
   const now = context.currentTime;
-  const seconds = durationMs / 1000;
+  const seconds = Math.max(0, toFiniteParamValue(durationMs, 0)) / 1000;
   const currentValue = getParamValue(param);
+  const nextValue = toFiniteParamValue(value, currentValue);
 
   if (typeof param.cancelScheduledValues === "function") {
     param.cancelScheduledValues(now);
@@ -71,11 +84,11 @@ const rampParam = (param, value, durationMs, context = getAudioContext()) => {
   }
 
   if (seconds > 0 && typeof param.linearRampToValueAtTime === "function") {
-    param.linearRampToValueAtTime(value, now + seconds);
+    param.linearRampToValueAtTime(nextValue, now + seconds);
   } else if (typeof param.setValueAtTime === "function") {
-    param.setValueAtTime(value, now + seconds);
+    param.setValueAtTime(nextValue, now + seconds);
   } else {
-    param.value = value;
+    param.value = nextValue;
   }
 };
 
@@ -99,6 +112,21 @@ const createPannerNode = (pan = 0) => {
 
 const getVolumeValue = ({ volume, muted }) =>
   muted ? 0 : normalizeVolume(volume, 100);
+
+const normalizeDirectVolume = (volume, fallback = 1) => {
+  const parsedFallback = Number(fallback);
+  const normalizedFallback = Number.isFinite(parsedFallback)
+    ? parsedFallback
+    : 1;
+  const parsedVolume = Number(volume ?? normalizedFallback);
+  const normalizedVolume = Number.isFinite(parsedVolume)
+    ? parsedVolume
+    : normalizedFallback;
+
+  return (
+    normalizeVolume(normalizedVolume * 100, normalizedFallback * 100) * 100
+  );
+};
 
 const getTransitionPhase = (effects = [], targetId, property, phase) => {
   const transition = effects.find(
@@ -748,8 +776,16 @@ export const createAudioStage = () => {
       type: "sound",
       src: element.url ?? element.src,
       loop: element.loop ?? false,
-      volume: (element.volume ?? 1) * 100,
-      startDelayMs: element.startDelayMs ?? 0,
+      volume: normalizeDirectVolume(element.volume),
+      muted: element.muted ?? false,
+      pan: toFiniteParamValue(element.pan, 0),
+      startDelayMs: Math.max(0, toFiniteParamValue(element.startDelayMs, 0)),
+      playbackRate: toFiniteParamValue(element.playbackRate, 1),
+      startAt: Math.max(0, toFiniteParamValue(element.startAt, 0)),
+      endAt:
+        element.endAt !== undefined && element.endAt !== null
+          ? Math.max(0, toFiniteParamValue(element.endAt, 0))
+          : null,
     };
 
     directAudios.set(element.id, audio);

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -282,20 +282,22 @@ const createSourceForSound = (sound) => {
     sound.endAt !== null && sound.endAt !== undefined
       ? Math.max(sound.endAt - offset, 0)
       : undefined;
+  const startTime = Math.max(0, toFiniteParamValue(context.currentTime, 0));
 
   if (source.loop && sound.endAt !== null && sound.endAt !== undefined) {
     source.loopStart = offset;
     source.loopEnd = sound.endAt;
-    source.start(0, offset);
+    source.start(startTime, offset);
   } else if (duration !== undefined) {
-    source.start(0, offset, duration);
+    source.start(startTime, offset, duration);
   } else {
-    source.start(0, offset);
+    source.start(startTime, offset);
   }
   debugAudio("source started", {
     id: sound.id,
     src: sound.src,
     loop: source.loop,
+    startTime,
     offset,
     duration: duration ?? null,
     playbackRate: sound.playbackRate,

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -650,6 +650,8 @@ const createRouteGraphics = () => {
       app.stage.on(eventType, callback);
     },
 
+    resumeAudio: () => audioStage.resume(),
+
     setAnimationPlaybackMode: (mode) => {
       assertAnimationPlaybackMode(mode);
 

--- a/src/audioContext.js
+++ b/src/audioContext.js
@@ -1,0 +1,28 @@
+let audioContext;
+
+const isAudioDebugEnabled = () =>
+  globalThis.window?.RTGL_AUDIO_DEBUG === true ||
+  globalThis.window?.RTGL_VT_DEBUG === true;
+
+const debugAudioContext = (message, details = {}) => {
+  if (!isAudioDebugEnabled()) {
+    return;
+  }
+
+  console.log(`[AudioContext] ${message}`, details);
+};
+
+export const getAudioContext = () => {
+  if (audioContext) return audioContext;
+
+  const AudioContextCtor =
+    globalThis.window?.AudioContext ?? globalThis.window?.webkitAudioContext;
+
+  if (!AudioContextCtor) {
+    throw new Error("AudioContext is not available in this environment.");
+  }
+
+  audioContext = new AudioContextCtor();
+  debugAudioContext("context created", { state: audioContext.state });
+  return audioContext;
+};

--- a/src/plugins/elements/text-revealing/parseTextRevealing.js
+++ b/src/plugins/elements/text-revealing/parseTextRevealing.js
@@ -26,6 +26,8 @@ const DEFAULT_TEXT_REVEAL_INDICATOR_OFFSET_X = 16;
 const DEFAULT_TEXT_REVEAL_INDICATOR_OFFSET_Y = 0;
 const INDICATOR_VISUAL_KINDS = ["image", "spritesheet"];
 const INDICATOR_VISUAL_KIND_SET = new Set(INDICATOR_VISUAL_KINDS);
+const DEFAULT_REVEAL_SOUND_VOLUME = 100;
+const DEFAULT_REVEAL_SOUND_LOOP = true;
 
 export const normalizeFuriganaPlacement = (placement, path) => {
   if (placement === undefined) {
@@ -112,6 +114,57 @@ export const normalizeIndicatorVisual = (visual = {}, path) => {
     atlas,
     clips,
     playback,
+  };
+};
+
+const normalizeRevealSoundVolume = (volume, path) => {
+  if (volume === undefined) {
+    return DEFAULT_REVEAL_SOUND_VOLUME;
+  }
+
+  if (
+    typeof volume === "number" &&
+    Number.isFinite(volume) &&
+    volume >= 0 &&
+    volume <= 100
+  ) {
+    return volume;
+  }
+
+  throw new Error(
+    `Input Error: ${path}.volume must be a finite number between 0 and 100.`,
+  );
+};
+
+const normalizeRevealSoundLoop = (loop, path) => {
+  if (loop === undefined) {
+    return DEFAULT_REVEAL_SOUND_LOOP;
+  }
+
+  if (typeof loop === "boolean") {
+    return loop;
+  }
+
+  throw new Error(`Input Error: ${path}.loop must be a boolean.`);
+};
+
+export const normalizeRevealSound = (revealSound, path = "revealSound") => {
+  if (revealSound === undefined || revealSound === null) {
+    return null;
+  }
+
+  if (typeof revealSound !== "object" || Array.isArray(revealSound)) {
+    throw new Error(`Input Error: ${path} must be an object.`);
+  }
+
+  if (typeof revealSound.src !== "string" || revealSound.src.length === 0) {
+    throw new Error(`Input Error: ${path}.src must be a non-empty string.`);
+  }
+
+  return {
+    src: revealSound.src,
+    volume: normalizeRevealSoundVolume(revealSound.volume, path),
+    loop: normalizeRevealSoundLoop(revealSound.loop, path),
   };
 };
 
@@ -542,6 +595,7 @@ export const prepareRichTextSegments = ({ content, defaultTextStyle, width }) =>
  * @returns {TextRevealingComputedNode}
  */
 export const parseTextRevealing = ({ state }) => {
+  const revealSound = normalizeRevealSound(state.revealSound);
   const defaultTextStyle = mergeTextStyle(
     {
       ...DEFAULT_TEXT_STYLE,
@@ -614,6 +668,7 @@ export const parseTextRevealing = ({ state }) => {
         state.initialRevealedCharacters,
       ),
     }),
+    ...(revealSound && { revealSound }),
     ...(state.width !== undefined && { width: state.width }),
     ...(state.complete && { complete: state.complete }),
   };

--- a/src/plugins/elements/text-revealing/textRevealingRuntime.js
+++ b/src/plugins/elements/text-revealing/textRevealingRuntime.js
@@ -11,6 +11,7 @@ import {
 import { getCharacterXPositionInATextObject } from "../../../util/getCharacterXPositionInATextObject";
 import abortableSleep from "../../../util/abortableSleep";
 import { toPixiTextStyle } from "../../../util/toPixiTextStyle.js";
+import { normalizeVolume } from "../../../util/normalizeVolume.js";
 import {
   getSoftWipeEdgeWidth,
   getSoftWipeEasing,
@@ -32,6 +33,7 @@ const TEXT_REVEAL_RUNTIME = Symbol("textRevealRuntime");
 const TEXT_REVEAL_SNAPSHOT = Symbol("textRevealSnapshot");
 const TEXT_REVEAL_INDICATOR = Symbol("textRevealIndicator");
 const TEXT_REVEAL_INDICATOR_PLAYBACK = Symbol("textRevealIndicatorPlayback");
+const TEXT_REVEAL_SOUND_ID_PREFIX = "__route_graphics_text_reveal_sound__";
 const DEFAULT_TEXT_REVEAL_SPEED = 50;
 const MIN_TEXT_REVEAL_SPEED = 0;
 const MAX_TEXT_REVEAL_SPEED = 100;
@@ -129,6 +131,44 @@ const getTextRevealCharacterCount = (element) =>
       ),
     0,
   );
+
+const getTextRevealSoundId = (element) =>
+  `${TEXT_REVEAL_SOUND_ID_PREFIX}:${element.id}`;
+
+const startTextRevealSound = ({ app, element }) => {
+  const revealSound = element?.revealSound;
+
+  if (!revealSound?.src || !app?.audioStage) {
+    return () => {};
+  }
+
+  const soundId = getTextRevealSoundId(element);
+  let stopped = false;
+
+  app.audioStage.add({
+    id: soundId,
+    url: revealSound.src,
+    loop: revealSound.loop ?? true,
+    volume: normalizeVolume(revealSound.volume, 100),
+  });
+  app.audioStage.tick?.();
+
+  return () => {
+    if (stopped) {
+      return;
+    }
+
+    stopped = true;
+    app.audioStage.remove(soundId);
+    app.audioStage.tick?.();
+  };
+};
+
+const unregisterTextRevealRuntime = (container, cleanup) => {
+  if (container?.[TEXT_REVEAL_RUNTIME] === cleanup) {
+    delete container[TEXT_REVEAL_RUNTIME];
+  }
+};
 
 export const shouldRenderTextRevealImmediately = (element) =>
   element?.revealEffect === "none" ||
@@ -1241,6 +1281,7 @@ const runSoftWipeReveal = ({
   element,
   animationBus,
   completionTracker,
+  app,
 }) => {
   const indicatorOffsets = getIndicatorOffsets(element);
   const effectiveSpeed = getEffectiveSpeed(element.speed ?? 50);
@@ -1307,6 +1348,7 @@ const runSoftWipeReveal = ({
   }
 
   let finalized = false;
+  const stopRevealSound = startTextRevealSound({ app, element });
 
   const finalize = (completed) => {
     if (finalized) {
@@ -1315,9 +1357,8 @@ const runSoftWipeReveal = ({
 
     finalized = true;
 
-    if (container[TEXT_REVEAL_RUNTIME] === finalizeCleanup) {
-      delete container[TEXT_REVEAL_RUNTIME];
-    }
+    unregisterTextRevealRuntime(container, finalizeCleanup);
+    stopRevealSound();
 
     lineMasks.forEach((lineMask) => {
       if (lineMask.line.container.mask === lineMask.sprite) {
@@ -1504,6 +1545,7 @@ export const runTextReveal = async ({
         element,
         animationBus,
         completionTracker,
+        app,
       });
 
       if (!dispatched && !signal?.aborted && !container.destroyed) {
@@ -1519,20 +1561,37 @@ export const runTextReveal = async ({
       completeIndicatorSetup();
       const startAtCharacter =
         resumableSnapshot?.revealedCharacters ?? initialRevealedCharacters;
+      const totalCharacters = getTextRevealCharacterCount(element);
       const nextSnapshot = setTextRevealSnapshot(container, {
         mode: "typewriter",
         revealedCharacters: startAtCharacter,
         completed: false,
       });
+      const shouldPlayRevealSound = startAtCharacter < totalCharacters;
+      const stopRevealSound = shouldPlayRevealSound
+        ? startTextRevealSound({ app, element })
+        : () => {};
+      const cleanupRevealSound = () => {
+        stopRevealSound();
+      };
 
-      completed = await runTypewriterReveal({
-        contentContainer,
-        indicatorSprite,
-        element,
-        signal,
-        startAtCharacter,
-        snapshot: nextSnapshot,
-      });
+      if (shouldPlayRevealSound) {
+        registerTextRevealRuntime(container, cleanupRevealSound);
+      }
+
+      try {
+        completed = await runTypewriterReveal({
+          contentContainer,
+          indicatorSprite,
+          element,
+          signal,
+          startAtCharacter,
+          snapshot: nextSnapshot,
+        });
+      } finally {
+        cleanupRevealSound();
+        unregisterTextRevealRuntime(container, cleanupRevealSound);
+      }
     }
 
     if (completed && !signal?.aborted && !container.destroyed) {

--- a/src/plugins/elements/text-revealing/textRevealingRuntime.js
+++ b/src/plugins/elements/text-revealing/textRevealingRuntime.js
@@ -135,23 +135,58 @@ const getTextRevealCharacterCount = (element) =>
 const getTextRevealSoundId = (element) =>
   `${TEXT_REVEAL_SOUND_ID_PREFIX}:${element.id}`;
 
+const isRevealSoundDebugEnabled = () =>
+  globalThis.window?.RTGL_AUDIO_DEBUG === true ||
+  globalThis.window?.RTGL_VT_DEBUG === true;
+
+const debugRevealSound = (message, details = {}) => {
+  if (!isRevealSoundDebugEnabled()) {
+    return;
+  }
+
+  console.log(`[TextRevealSound] ${message}`, details);
+};
+
 const startTextRevealSound = ({ app, element }) => {
   const revealSound = element?.revealSound;
 
-  if (!revealSound?.src || !app?.audioStage) {
+  if (!revealSound?.src) {
+    return () => {};
+  }
+
+  if (!app?.audioStage) {
+    debugRevealSound("skipped: audioStage unavailable", {
+      elementId: element?.id,
+      src: revealSound.src,
+    });
     return () => {};
   }
 
   const soundId = getTextRevealSoundId(element);
+  const volume = normalizeVolume(revealSound.volume, 100);
   let stopped = false;
+
+  debugRevealSound("start", {
+    elementId: element.id,
+    soundId,
+    src: revealSound.src,
+    loop: revealSound.loop ?? true,
+    configuredVolume: revealSound.volume,
+    normalizedVolume: volume,
+  });
 
   app.audioStage.add({
     id: soundId,
     url: revealSound.src,
     loop: revealSound.loop ?? true,
-    volume: normalizeVolume(revealSound.volume, 100),
+    volume,
   });
   app.audioStage.tick?.();
+  debugRevealSound("registered", {
+    elementId: element.id,
+    soundId,
+    directAudio: app.audioStage.getById?.(soundId) ?? null,
+  });
 
   return () => {
     if (stopped) {
@@ -159,6 +194,11 @@ const startTextRevealSound = ({ app, element }) => {
     }
 
     stopped = true;
+    debugRevealSound("stop", {
+      elementId: element.id,
+      soundId,
+      src: revealSound.src,
+    });
     app.audioStage.remove(soundId);
     app.audioStage.tick?.();
   };

--- a/src/plugins/elements/text-revealing/updateTextRevealing.js
+++ b/src/plugins/elements/text-revealing/updateTextRevealing.js
@@ -18,6 +18,7 @@ const getRevealIdentity = (element = {}) =>
     initialRevealedCharacters: element.initialRevealedCharacters ?? 0,
     width: element.width ?? null,
     indicator: element.indicator ?? null,
+    revealSound: element.revealSound ?? null,
     x: element.x ?? null,
     y: element.y ?? null,
     alpha: element.alpha ?? 1,

--- a/src/schemas/elements/text-revealing.element.yaml
+++ b/src/schemas/elements/text-revealing.element.yaml
@@ -251,6 +251,25 @@ properties:
     default: typewriter
   softWipe:
     "$ref": "#/$def/softWipe"
+  revealSound:
+    type: object
+    description: Sound to play while text is actively revealing.
+    required:
+      - src
+    properties:
+      src:
+        type: string
+        description: Source alias or URL for the reveal sound
+      volume:
+        type: number
+        description: Volume. 0 means muted. 100 means original full volume.
+        default: 100
+        minimum: 0
+        maximum: 100
+      loop:
+        type: boolean
+        description: Whether the reveal sound loops until the reveal finishes
+        default: true
   textStyle:
     "$ref": "#/$def/textStyle"
   complete:

--- a/src/types.js
+++ b/src/types.js
@@ -579,6 +579,10 @@
  * @property {number} [indicator.offsetY=0] - Vertical adjustment from the indicator's automatic line placement; positive values move down
  * @property {'typewriter' | 'softWipe' | 'none'} [revealEffect='typewriter'] - Text reveal effect (typewriter = per-character reveal, softWipe = full-text soft mask wipe, none = skip animation)
  * @property {SoftWipeConfig} [softWipe] - Parameters for the softWipe reveal effect
+ * @property {Object} [revealSound] - Sound to play while text is actively revealing
+ * @property {string} revealSound.src - Source alias or URL for the reveal sound
+ * @property {number} [revealSound.volume=100] - Reveal sound volume where 0 is muted and 100 is full volume
+ * @property {boolean} [revealSound.loop=true] - Whether the reveal sound loops until revealing finishes
  * @typedef {ComputedNode & TextRevealingComputedProps} TextRevealingComputedNode
  */
 

--- a/vt/reference/textrevealing/text-revealing-reveal-sound-01.webp
+++ b/vt/reference/textrevealing/text-revealing-reveal-sound-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/textrevealing/text-revealing-reveal-sound-02.webp
+++ b/vt/reference/textrevealing/text-revealing-reveal-sound-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e42a3e8889072b30aa879d48b2ada64e3b50794d165160b6ccfc282ab85b5517
+size 1700

--- a/vt/reference/textrevealing/text-revealing-reveal-sound-03.webp
+++ b/vt/reference/textrevealing/text-revealing-reveal-sound-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:296e3fb0a71fc892d933888ad15232afe0019c168895464487d6bc2e69cbc373
+size 2308

--- a/vt/reference/textrevealing/text-revealing-reveal-sound-04.webp
+++ b/vt/reference/textrevealing/text-revealing-reveal-sound-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6b91f319511a5ece65c2efb9d04ad70a55171c4b7d8acbfa55e70ead385dfee
+size 2400

--- a/vt/specs/textrevealing/text-revealing-reveal-sound.yaml
+++ b/vt/specs/textrevealing/text-revealing-reveal-sound.yaml
@@ -1,0 +1,61 @@
+---
+title: Text Revealing - Reveal Sound
+description: Manual fixture for text-revealing revealSound playback. The configured sound should loop while text is actively revealing and stop when the reveal completes.
+specs:
+  - revealSound should use object config with src, volume, and loop
+  - sound should start when the typewriter reveal begins
+  - sound should stop after the text finishes revealing
+steps:
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 1200
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 4200
+  - action: screenshot
+---
+states:
+  - id: reveal-sound-blank
+    elements: []
+  - id: reveal-sound-typewriter
+    elements:
+      - id: reveal-sound-line
+        type: text-revealing
+        x: 80
+        "y": 120
+        width: 620
+        speed: 18
+        revealEffect: typewriter
+        revealSound:
+          src: sfx-1
+          volume: 70
+          loop: true
+        indicator:
+          revealing:
+            src: circle-red
+            width: 12
+            height: 12
+          complete:
+            src: circle-green
+            width: 12
+            height: 12
+          offsetX: 12
+        content:
+          - text: "This line has revealSound enabled. The audio should loop only while these characters are typing,"
+            textStyle:
+              fontSize: 30
+              fill: "#FFFFFF"
+              fontFamily: Arial
+              lineHeight: 1.35
+          - text: " then stop once the final word appears."
+            textStyle:
+              fontSize: 30
+              fill: "#D9D9D9"
+              fontFamily: Arial
+              lineHeight: 1.35

--- a/vt/specs/textrevealing/text-revealing-reveal-sound.yaml
+++ b/vt/specs/textrevealing/text-revealing-reveal-sound.yaml
@@ -33,7 +33,7 @@ states:
         speed: 18
         revealEffect: typewriter
         revealSound:
-          src: sfx-1
+          src: message-display1
           volume: 70
           loop: true
         indicator:

--- a/vt/specs/textrevealing/update-text-revealing-continue-from-offset-typewriter.yaml
+++ b/vt/specs/textrevealing/update-text-revealing-continue-from-offset-typewriter.yaml
@@ -1,5 +1,6 @@
 ---
 title: Update Text Revealing Continue From Offset Typewriter
+diffThreshold: 0.5
 description: |
   Same text-revealing element id can append content and reveal only the new suffix
   when initialRevealedCharacters marks the already-visible prefix.

--- a/vt/static/public/message-display1.mp3
+++ b/vt/static/public/message-display1.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07fe92fcc28629ec7af4e5f28c5d2ca1542e2a808efd226ed2b228635d4f413c
+size 25703

--- a/vt/static/public/message-display1.mp3
+++ b/vt/static/public/message-display1.mp3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:07fe92fcc28629ec7af4e5f28c5d2ca1542e2a808efd226ed2b228635d4f413c
-size 25703
+oid sha256:efd3c92944bbdf6961c11a03351b138951bb52b96d738a9a1485756f1dc89d73
+size 25122

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -423,6 +423,18 @@
         (Array.isArray(state?.elements) &&
           state.elements.some(elementHasRevealSound));
       const hasAudioStates = states.some(stateHasAudio);
+      const audioAssetKeys = Object.entries(assetsObject)
+        .filter(([, asset]) => asset?.type?.startsWith?.("audio/"))
+        .map(([key]) => key);
+      if (hasAudioStates) {
+        window.RTGL_AUDIO_DEBUG = true;
+        console.log("[VT audio] debug enabled", {
+          audioAssetKeys,
+          audioStateIds: states
+            .filter(stateHasAudio)
+            .map((state, stateIndex) => state?.id ?? `state-${stateIndex}`),
+        });
+      }
       if (!useBrowserScreenshot) {
         let vtScreenshotHookPrimed = false;
         const waitForStableScreenshotFrame = async () => {
@@ -637,6 +649,9 @@
       });
       window.__VT_ROUTE_GRAPHICS__ = app;
       await app.loadAssets(assetBufferManager.getBufferMap());
+      if (hasAudioStates) {
+        console.log("[VT audio] assets decoded", { audioAssetKeys });
+      }
       document.body.appendChild(app.canvas);
       document.body.appendChild(pager);
       if (states.length > 0) {

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -412,9 +412,16 @@
       const vtState = Object.assign({}, ...vtDocuments);
       const states = vtState.states ?? [];
       const useBrowserScreenshot = vtState.useBrowserScreenshot === true;
+      const elementHasRevealSound = (element) =>
+        Boolean(element?.revealSound) ||
+        (Array.isArray(element?.children) &&
+          element.children.some(elementHasRevealSound));
       const stateHasAudio = (state) =>
         (Array.isArray(state?.audio) && state.audio.length > 0) ||
-        (Array.isArray(state?.audioEffects) && state.audioEffects.length > 0);
+        (Array.isArray(state?.audioEffects) &&
+          state.audioEffects.length > 0) ||
+        (Array.isArray(state?.elements) &&
+          state.elements.some(elementHasRevealSound));
       const hasAudioStates = states.some(stateHasAudio);
       if (!useBrowserScreenshot) {
         let vtScreenshotHookPrimed = false;
@@ -564,6 +571,8 @@
 
       let hasStartedAudioFixtureFromPointer = false;
       const startAudioFixtureFromPointer = (event) => {
+        void app.resumeAudio?.();
+
         if (!hasAudioStates || hasStartedAudioFixtureFromPointer) {
           return;
         }
@@ -588,6 +597,13 @@
       document.addEventListener("pointerdown", startAudioFixtureFromPointer, {
         capture: true,
       });
+      document.addEventListener(
+        "keydown",
+        () => {
+          void app.resumeAudio?.();
+        },
+        { capture: true },
+      );
 
       await app.init({
         width: 1280,

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -353,7 +353,7 @@
         "sfx-1": { url: "/public/sfx-1.mp3", type: "audio/mpeg" },
         "sfx-2": { url: "/public/sfx-2.wav", type: "audio/wav" },
         "message-display1": {
-          url: "/public/message-display1.mp3",
+          url: "/public/message-display1.mp3?v=2",
           type: "audio/mpeg",
         },
         "bgm-1": { url: "/public/bgm-1.mp3", type: "audio/mpeg" },

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -352,6 +352,10 @@
         },
         "sfx-1": { url: "/public/sfx-1.mp3", type: "audio/mpeg" },
         "sfx-2": { url: "/public/sfx-2.wav", type: "audio/wav" },
+        "message-display1": {
+          url: "/public/message-display1.mp3",
+          type: "audio/mpeg",
+        },
         "bgm-1": { url: "/public/bgm-1.mp3", type: "audio/mpeg" },
         "bgm-2": { url: "/public/bgm-2.mp3", type: "audio/mpeg" },
         "bgm-3": { url: "/public/bgm-3.mp3", type: "audio/mpeg" },


### PR DESCRIPTION
Summary:
- Add object-only revealSound config for text-revealing elements.
- Play the configured sound during active typewriter/soft-wipe reveals and stop it on completion, abort, restart, replace, or delete.
- Bump package version to 1.24.0.

Tests:
- npm test -- spec/parser/parseTextRevealing.revealSound.spec.js spec/elements/textRevealingRuntime.revealSound.spec.js spec/elements/textRevealingRuntime.instant.spec.js spec/elements/textRevealingRuntime.resume.spec.js spec/elements/textRevealingRuntime.softWipe.spec.js
- Pre-push full suite: 589 tests passed