### PR TITLE
fix: preserve text texture padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.23.4",
+  "version": "1.23.5",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/elements/textHoverLayout.spec.js
+++ b/spec/elements/textHoverLayout.spec.js
@@ -36,6 +36,49 @@ const getHorizontalOffset = (layoutWidth, measuredWidth, align) => {
 };
 
 describe("text hover layout", () => {
+  it("applies configured text texture padding", () => {
+    const parent = new Container();
+    const shared = createSharedParams();
+    const element = parseText({
+      state: {
+        id: "text-padding",
+        type: "text",
+        x: 20,
+        y: 30,
+        alpha: 1,
+        content: "Padding",
+        textStyle: {
+          fontSize: 24,
+          fontFamily: "Arial",
+          fill: "#FFFFFF",
+          padding: 18,
+        },
+        hover: {
+          textStyle: {
+            padding: 30,
+          },
+        },
+      },
+    });
+
+    addText({
+      ...shared,
+      parent,
+      zIndex: 0,
+      element,
+    });
+
+    const text = parent.getChildByLabel("text-padding");
+
+    expect(text.style.padding).toBe(18);
+
+    text.emit("pointerover");
+    expect(text.style.padding).toBe(30);
+
+    text.emit("pointerout");
+    expect(text.style.padding).toBe(18);
+  });
+
   it("keeps the text anchor stable when hover styles change text metrics", () => {
     const parent = new Container();
     const shared = createSharedParams();

--- a/src/schemas/elements/text-revealing.computed.yaml
+++ b/src/schemas/elements/text-revealing.computed.yaml
@@ -69,6 +69,10 @@ $def:
       strokeWidth:
         type: number
         description: Text stroke/outline width
+      padding:
+        type: number
+        minimum: 0
+        description: Extra texture padding around rendered glyphs, useful for fonts with overhanging glyph bounds.
       shadow:
         "$ref": "#/$def/textShadow"
   softWipe:

--- a/src/schemas/elements/text-revealing.element.yaml
+++ b/src/schemas/elements/text-revealing.element.yaml
@@ -74,6 +74,10 @@ $def:
       strokeWidth:
         type: number
         description: Text stroke/outline width
+      padding:
+        type: number
+        minimum: 0
+        description: Extra texture padding around rendered glyphs, useful for fonts with overhanging glyph bounds.
       shadow:
         "$ref": "#/$def/textShadow"
   softWipe:

--- a/src/schemas/elements/text.computed.yaml
+++ b/src/schemas/elements/text.computed.yaml
@@ -73,6 +73,10 @@ $def:
       strokeWidth:
         type: number
         description: Text stroke/outline width
+      padding:
+        type: number
+        minimum: 0
+        description: Extra texture padding around rendered glyphs, useful for fonts with overhanging glyph bounds.
       shadow:
         "$ref": "#/$def/textShadow"
   textChunk:

--- a/src/schemas/elements/text.element.yaml
+++ b/src/schemas/elements/text.element.yaml
@@ -75,6 +75,10 @@ $def:
       strokeWidth:
         type: number
         description: Text stroke/outline width
+      padding:
+        type: number
+        minimum: 0
+        description: Extra texture padding around rendered glyphs, useful for fonts with overhanging glyph bounds.
       shadow:
         "$ref": "#/$def/textShadow"
   contentSegment:

--- a/src/types.js
+++ b/src/types.js
@@ -481,6 +481,7 @@
  * @property {number} wordWrapWidth - Word wrap width
  * @property {string} [strokeColor] - Text stroke/outline color
  * @property {number} [strokeWidth] - Text stroke/outline width
+ * @property {number} [padding] - Extra texture padding around rendered glyphs
  * @property {TextShadow | null} [shadow] - Optional text shadow
  */
 
@@ -859,6 +860,7 @@ export const DEFAULT_TEXT_STYLE = {
  * @property {string} fontFamily - The font family of the text
  * @property {string} strokeColor - The stroke color of the text
  * @property {number} strokeWidth - The stroke width of the text
+ * @property {number} [padding] - Extra texture padding around rendered glyphs
  * @property {TextShadow | null} [shadow] - Optional text shadow
  */
 

--- a/src/util/applyTextStyle.js
+++ b/src/util/applyTextStyle.js
@@ -13,6 +13,7 @@ export default (element, style) => {
     strokeColor: style?.strokeColor ?? DEFAULT_TEXT_STYLE.strokeColor,
     strokeWidth: style?.strokeWidth ?? DEFAULT_TEXT_STYLE.strokeWidth,
     wordWrapWidth: style?.wordWrapWidth ?? DEFAULT_TEXT_STYLE.wordWrapWidth,
+    ...(style?.padding !== undefined ? { padding: style.padding } : {}),
     ...(Object.prototype.hasOwnProperty.call(style ?? {}, "shadow")
       ? { shadow: style.shadow }
       : {}),

--- a/vt/reference/textbasic/mr-de-haviland-leading-l-overhang-01.webp
+++ b/vt/reference/textbasic/mr-de-haviland-leading-l-overhang-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32bf183f13c8afb4a30721c18c0f068135e5c8f1719da81faa14b65507dd3564
+size 10754

--- a/vt/specs/textbasic/mr-de-haviland-leading-l-overhang.yaml
+++ b/vt/specs/textbasic/mr-de-haviland-leading-l-overhang.yaml
@@ -1,0 +1,73 @@
+---
+title: Mr De Haviland Leading L Overhang
+specs:
+  - an OFL-licensed script font should render a leading L without clipping the left swash
+  - an unpadded leading L is compared with padded and multi-character samples
+---
+states:
+  - elements:
+      - id: guide-single
+        type: rect
+        x: 96
+        "y": 30
+        width: 2
+        height: 140
+        fill: "#737373"
+      - id: unpadded-single
+        type: text
+        content: L
+        x: 96
+        "y": 34
+        textStyle:
+          fontFamily: mr-de-haviland
+          fontSize: 128
+          fill: "#FFFFFF"
+      - id: guide-padded
+        type: rect
+        x: 260
+        "y": 30
+        width: 2
+        height: 140
+        fill: "#737373"
+      - id: padded-single
+        type: text
+        content: L
+        x: 260
+        "y": 34
+        textStyle:
+          fontFamily: mr-de-haviland
+          fontSize: 128
+          fill: "#FFFFFF"
+          padding: 48
+      - id: guide-word
+        type: rect
+        x: 96
+        "y": 208
+        width: 2
+        height: 110
+        fill: "#737373"
+      - id: leading-word
+        type: text
+        content: LEFT
+        x: 96
+        "y": 214
+        textStyle:
+          fontFamily: mr-de-haviland
+          fontSize: 96
+          fill: "#FFFFFF"
+      - id: guide-repeated
+        type: rect
+        x: 96
+        "y": 342
+        width: 2
+        height: 100
+        fill: "#737373"
+      - id: repeated-leading
+        type: text
+        content: LLLL
+        x: 96
+        "y": 348
+        textStyle:
+          fontFamily: mr-de-haviland
+          fontSize: 88
+          fill: "#FFFFFF"

--- a/vt/static/public/mr-de-haviland-OFL.txt
+++ b/vt/static/public/mr-de-haviland-OFL.txt
@@ -1,0 +1,94 @@
+Copyright (c) 2011 Alejandro Paul (sudtipos@sudtipos.com), 
+with Reserved Font Name "Mr De Haviland"
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/vt/static/public/mr-de-haviland.ttf
+++ b/vt/static/public/mr-de-haviland.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10cd8e34b17a42722dc49d2d62b7fe774595abe34cc89ee1d79663df68ea6089
+size 44672

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -355,6 +355,10 @@
         "bgm-1": { url: "/public/bgm-1.mp3", type: "audio/mpeg" },
         "bgm-2": { url: "/public/bgm-2.mp3", type: "audio/mpeg" },
         "bgm-3": { url: "/public/bgm-3.mp3", type: "audio/mpeg" },
+        "mr-de-haviland": {
+          url: "/public/mr-de-haviland.ttf",
+          type: "font/ttf",
+        },
       };
 
       const shouldLoadOptionalVideo =


### PR DESCRIPTION
## Summary
- preserve `textStyle.padding` when applying Pixi text styles so overhanging glyphs can render with extra texture padding
- add OFL-licensed Mr De Haviland VT coverage for the leading `L` overhang and register the font asset with its OFL text
- document text padding and bump package version to 1.23.5

## Testing
- `bunx vitest run spec/elements/textHoverLayout.spec.js`
- `bunx prettier --check package.json src/util/applyTextStyle.js spec/elements/textHoverLayout.spec.js src/schemas/elements/text.element.yaml src/schemas/elements/text.computed.yaml src/schemas/elements/text-revealing.element.yaml src/schemas/elements/text-revealing.computed.yaml src/types.js vt/specs/textbasic/mr-de-haviland-leading-l-overhang.yaml vt/templates/default.html`
- `bun run vt:generate`
- `bun run vt:screenshot`
- `bun run vt:accept`
- `docker run --rm --user 1000:1000 -e RTGL_VT_DEBUG=true -v /home/tk/Code/yuusoft-org/route-graphics:/workspace docker.io/han4wluc/rtgl:playwright-v1.57.0-rtgl-v1.1.0 rtgl vt report`
- pre-push hook: `bunx prettier --check src`
- pre-push hook: `vitest run`