### PR TITLE
fix(text): add automatic glyph texture padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.23.5",
+  "version": "1.23.6",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/elements/textHoverLayout.spec.js
+++ b/spec/elements/textHoverLayout.spec.js
@@ -268,7 +268,7 @@ describe("text hover layout", () => {
       distance: 5,
     });
     expect(text.style.dropShadow.angle).toBeCloseTo(Math.atan2(4, 3), 8);
-    expect(text.style.padding).toBe(9);
+    expect(text.style.padding).toBe(10);
   });
 
   it("deep-merges and removes shadow in interactive textStyle states", () => {

--- a/spec/util/toPixiTextStyle.spec.js
+++ b/spec/util/toPixiTextStyle.spec.js
@@ -51,7 +51,15 @@ describe("toPixiTextStyle", () => {
     });
 
     expect(style.dropShadow).toBeNull();
-    expect(style).not.toHaveProperty("padding");
+    expect(style.padding).toBe(7);
+  });
+
+  it("adds automatic texture padding for glyph overhangs", () => {
+    const style = toPixiTextStyle({
+      fontSize: 160,
+    });
+
+    expect(style.padding).toBe(64);
   });
 
   it("does not expose Pixi dropShadow as public pass-through input", () => {

--- a/src/util/toPixiTextStyle.js
+++ b/src/util/toPixiTextStyle.js
@@ -8,6 +8,32 @@ export const DEFAULT_TEXT_SHADOW = {
   offsetY: 2,
 };
 
+export const AUTOMATIC_TEXT_TEXTURE_PADDING_RATIO = 0.4;
+
+const getNumericFontSize = (fontSize) => {
+  if (typeof fontSize === "number" && Number.isFinite(fontSize)) {
+    return Math.max(0, fontSize);
+  }
+
+  if (typeof fontSize === "string") {
+    const parsedFontSize = Number.parseFloat(fontSize);
+
+    if (Number.isFinite(parsedFontSize)) {
+      return Math.max(0, parsedFontSize);
+    }
+  }
+
+  return DEFAULT_TEXT_STYLE.fontSize;
+};
+
+const getNumericPadding = (padding) =>
+  typeof padding === "number" && Number.isFinite(padding) ? padding : 0;
+
+const getAutomaticTextTexturePadding = (style = {}) =>
+  Math.ceil(
+    getNumericFontSize(style.fontSize) * AUTOMATIC_TEXT_TEXTURE_PADDING_RATIO,
+  );
+
 const getStrokeStyle = (style = {}) => {
   const baseStroke =
     typeof style.stroke === "object" && style.stroke !== null
@@ -66,7 +92,11 @@ export const toPixiTextStyle = (style = {}, options = {}) => {
   if (includeShadow) {
     const pixiDropShadow = toPixiDropShadow(shadow);
     const shadowPadding = getShadowPadding(pixiDropShadow);
-    const padding = Math.max(rest.padding ?? 0, shadowPadding);
+    const padding = Math.max(
+      getNumericPadding(rest.padding),
+      shadowPadding,
+      getAutomaticTextTexturePadding(rest),
+    );
 
     if (shadow !== undefined) {
       pixiStyle.dropShadow = pixiDropShadow;

--- a/vt/reference/textbasic/mr-de-haviland-correct-d-l-overhang-01.webp
+++ b/vt/reference/textbasic/mr-de-haviland-correct-d-l-overhang-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a4bcb0180c796341e2c897fcb3d528c5dfa7db7c72b2a5d059b4373e4f6da8d
+size 14450

--- a/vt/reference/textbasic/mr-de-haviland-correct-d-l-overhang-01.webp
+++ b/vt/reference/textbasic/mr-de-haviland-correct-d-l-overhang-01.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a4bcb0180c796341e2c897fcb3d528c5dfa7db7c72b2a5d059b4373e4f6da8d
-size 14450
+oid sha256:dfe9b0068b0dee71966671949668f080a16233969aa51a1db1fb435a4f40cc58
+size 14316

--- a/vt/reference/textbasic/mr-de-haviland-leading-l-overhang-01.webp
+++ b/vt/reference/textbasic/mr-de-haviland-leading-l-overhang-01.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:32bf183f13c8afb4a30721c18c0f068135e5c8f1719da81faa14b65507dd3564
-size 10754
+oid sha256:ebc198fb1ce3d60be82bcadcaa1e41f7d56e8a73f17f97483c3d34d78c6f4c07
+size 11512

--- a/vt/specs/textbasic/mr-de-haviland-correct-d-l-overhang.yaml
+++ b/vt/specs/textbasic/mr-de-haviland-correct-d-l-overhang.yaml
@@ -2,17 +2,10 @@
 title: Mr De Haviland Correct D L Overhang
 specs:
   - padded D and L samples should keep their left swashes visible
-  - D and L should render correctly without comparison samples
+  - D and L should render correctly without comparison samples or guide marks
 ---
 states:
   - elements:
-      - id: guide-d
-        type: rect
-        x: 240
-        "y": 68
-        width: 2
-        height: 180
-        fill: "#737373"
       - id: correct-d
         type: text
         content: D
@@ -23,13 +16,6 @@ states:
           fontSize: 160
           fill: "#FFFFFF"
           padding: 64
-      - id: guide-l
-        type: rect
-        x: 540
-        "y": 68
-        width: 2
-        height: 180
-        fill: "#737373"
       - id: correct-l
         type: text
         content: L
@@ -40,13 +26,6 @@ states:
           fontSize: 160
           fill: "#FFFFFF"
           padding: 64
-      - id: guide-dl
-        type: rect
-        x: 240
-        "y": 332
-        width: 2
-        height: 170
-        fill: "#737373"
       - id: correct-dl
         type: text
         content: DL
@@ -57,13 +36,6 @@ states:
           fontSize: 150
           fill: "#FFFFFF"
           padding: 64
-      - id: guide-ld
-        type: rect
-        x: 620
-        "y": 332
-        width: 2
-        height: 170
-        fill: "#737373"
       - id: correct-ld
         type: text
         content: LD

--- a/vt/specs/textbasic/mr-de-haviland-correct-d-l-overhang.yaml
+++ b/vt/specs/textbasic/mr-de-haviland-correct-d-l-overhang.yaml
@@ -1,0 +1,76 @@
+---
+title: Mr De Haviland Correct D L Overhang
+specs:
+  - padded D and L samples should keep their left swashes visible
+  - D and L should render correctly without comparison samples
+---
+states:
+  - elements:
+      - id: guide-d
+        type: rect
+        x: 240
+        "y": 68
+        width: 2
+        height: 180
+        fill: "#737373"
+      - id: correct-d
+        type: text
+        content: D
+        x: 240
+        "y": 82
+        textStyle:
+          fontFamily: mr-de-haviland
+          fontSize: 160
+          fill: "#FFFFFF"
+          padding: 64
+      - id: guide-l
+        type: rect
+        x: 540
+        "y": 68
+        width: 2
+        height: 180
+        fill: "#737373"
+      - id: correct-l
+        type: text
+        content: L
+        x: 540
+        "y": 82
+        textStyle:
+          fontFamily: mr-de-haviland
+          fontSize: 160
+          fill: "#FFFFFF"
+          padding: 64
+      - id: guide-dl
+        type: rect
+        x: 240
+        "y": 332
+        width: 2
+        height: 170
+        fill: "#737373"
+      - id: correct-dl
+        type: text
+        content: DL
+        x: 240
+        "y": 342
+        textStyle:
+          fontFamily: mr-de-haviland
+          fontSize: 150
+          fill: "#FFFFFF"
+          padding: 64
+      - id: guide-ld
+        type: rect
+        x: 620
+        "y": 332
+        width: 2
+        height: 170
+        fill: "#737373"
+      - id: correct-ld
+        type: text
+        content: LD
+        x: 620
+        "y": 342
+        textStyle:
+          fontFamily: mr-de-haviland
+          fontSize: 150
+          fill: "#FFFFFF"
+          padding: 64

--- a/vt/specs/textbasic/mr-de-haviland-correct-d-l-overhang.yaml
+++ b/vt/specs/textbasic/mr-de-haviland-correct-d-l-overhang.yaml
@@ -1,7 +1,7 @@
 ---
 title: Mr De Haviland Correct D L Overhang
 specs:
-  - padded D and L samples should keep their left swashes visible
+  - D and L samples should keep their left swashes visible without caller-provided texture padding
   - D and L should render correctly without comparison samples or guide marks
 ---
 states:
@@ -15,7 +15,6 @@ states:
           fontFamily: mr-de-haviland
           fontSize: 160
           fill: "#FFFFFF"
-          padding: 64
       - id: correct-l
         type: text
         content: L
@@ -25,7 +24,6 @@ states:
           fontFamily: mr-de-haviland
           fontSize: 160
           fill: "#FFFFFF"
-          padding: 64
       - id: correct-dl
         type: text
         content: DL
@@ -35,7 +33,6 @@ states:
           fontFamily: mr-de-haviland
           fontSize: 150
           fill: "#FFFFFF"
-          padding: 64
       - id: correct-ld
         type: text
         content: LD
@@ -45,4 +42,3 @@ states:
           fontFamily: mr-de-haviland
           fontSize: 150
           fill: "#FFFFFF"
-          padding: 64

--- a/vt/specs/textbasic/mr-de-haviland-leading-l-overhang.yaml
+++ b/vt/specs/textbasic/mr-de-haviland-leading-l-overhang.yaml
@@ -2,7 +2,7 @@
 title: Mr De Haviland Leading L Overhang
 specs:
   - an OFL-licensed script font should render a leading L without clipping the left swash
-  - an unpadded leading L is compared with padded and multi-character samples
+  - leading L samples should render correctly without caller-provided texture padding
 ---
 states:
   - elements:
@@ -22,14 +22,14 @@ states:
           fontFamily: mr-de-haviland
           fontSize: 128
           fill: "#FFFFFF"
-      - id: guide-padded
+      - id: guide-auto-padding
         type: rect
         x: 260
         "y": 30
         width: 2
         height: 140
         fill: "#737373"
-      - id: padded-single
+      - id: auto-padding-single
         type: text
         content: L
         x: 260
@@ -38,7 +38,6 @@ states:
           fontFamily: mr-de-haviland
           fontSize: 128
           fill: "#FFFFFF"
-          padding: 48
       - id: guide-word
         type: rect
         x: 96


### PR DESCRIPTION
## Summary
- add automatic text texture padding based on font size so overhanging glyphs are not clipped without caller-provided `textStyle.padding`
- keep explicit padding and shadow padding supported by using the largest required texture reserve
- update the Mr De Haviland D/L VT specs to verify the default user path without explicit padding
- bump package version to `1.23.6`

## Testing
- `bunx vitest run spec/util/toPixiTextStyle.spec.js spec/elements/textHoverLayout.spec.js`
- `bun run vt:generate`
- `bun run vt:report` (`703/703`, `0` mismatches)
- `bunx prettier --check src spec/util/toPixiTextStyle.spec.js spec/elements/textHoverLayout.spec.js vt/specs/textbasic/mr-de-haviland-correct-d-l-overhang.yaml vt/specs/textbasic/mr-de-haviland-leading-l-overhang.yaml package.json`
- `bunx vitest run` (`83` files, `585` tests)
- pre-push hook: `bunx prettier --check src`
- pre-push hook: `vitest run` (`83` files, `585` tests)
