### PR TITLE
Fix video texture playback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -420,6 +420,17 @@ describe("RouteGraphics public API", () => {
     expect(
       createdVideos.every((video) => video.crossOrigin === "anonymous"),
     ).toBe(true);
+    expect(
+      createdVideos.every((video) => {
+        const sourceElement = video.querySelector("source");
+
+        return (
+          sourceElement?.src &&
+          sourceElement.type === "video/mp4" &&
+          video.getAttribute("webkit-playsinline") === ""
+        );
+      }),
+    ).toBe(true);
   });
 
   it("awaits audio asset decoding during loadAssets", async () => {

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -356,6 +356,14 @@ describe("RouteGraphics public API", () => {
             value: window.HTMLMediaElement.HAVE_CURRENT_DATA,
             configurable: true,
           });
+          Object.defineProperty(element, "videoWidth", {
+            value: 1280,
+            configurable: true,
+          });
+          Object.defineProperty(element, "videoHeight", {
+            value: 720,
+            configurable: true,
+          });
           element.load = vi.fn();
         }
 

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -211,6 +211,7 @@ const createPixiModuleMock = () => {
         set: vi.fn((key, value) => assetCache.set(key, value)),
       },
     },
+    detectVideoAlphaMode: vi.fn().mockResolvedValue("premultiplied-alpha"),
     Graphics: MockGraphics,
     LoaderParserPriority: {
       High: 1,
@@ -402,6 +403,11 @@ describe("RouteGraphics public API", () => {
         source: expect.any(Object),
       }),
     );
+    const bufferVideoTexture = pixiMock.Assets.cache.set.mock.calls.find(
+      ([key]) => key === "bufferVideo",
+    )?.[1];
+    expect(bufferVideoTexture.source.alphaMode).toBe("premultiplied-alpha");
+    expect(pixiMock.detectVideoAlphaMode).toHaveBeenCalled();
     expect(createdVideos).toHaveLength(2);
     expect(
       createdVideos.every((video) => video.crossOrigin === "anonymous"),

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -533,7 +533,7 @@ describe("RouteGraphics public API", () => {
     }
 
     expect(thrownError?.message).toBe(
-      'Could not load 2 assets: audio "click", image "background". Check that the files exist and are supported.',
+      'Could not load 2 assets: audio "click", image "background". audio "click": Unsupported or damaged audio file.; image "background": Missing, inaccessible, or unsupported image file.',
     );
     expect(thrownError?.details?.failures).toEqual([
       expect.objectContaining({
@@ -545,6 +545,91 @@ describe("RouteGraphics public API", () => {
         assetKey: "background",
         assetKind: "image",
         cause: "texture fetch failed",
+      }),
+    ]);
+  });
+
+  it("surfaces media element diagnostics for multiple video load failures", async () => {
+    const { app } = await setupRouteGraphics();
+    const createdVideos = [];
+    const createObjectURL = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:http://route-graphics/video");
+    const originalCreateElement = document.createElement.bind(document);
+    const createElement = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tagName, ...args) => {
+        const element = originalCreateElement(tagName, ...args);
+
+        if (tagName === "video") {
+          createdVideos.push(element);
+          Object.defineProperty(element, "readyState", {
+            value: 0,
+            configurable: true,
+          });
+          Object.defineProperty(element, "networkState", {
+            value: 3,
+            configurable: true,
+          });
+          Object.defineProperty(element, "error", {
+            value: {
+              code: 4,
+              message: "No supported source was found",
+            },
+            configurable: true,
+          });
+          Object.defineProperty(element, "currentSrc", {
+            value: "blob:http://route-graphics/video",
+            configurable: true,
+          });
+          element.load = vi.fn(() => {
+            queueMicrotask(() => {
+              element.dispatchEvent(new Event("error"));
+            });
+          });
+        }
+
+        return element;
+      });
+
+    let thrownError;
+    try {
+      await app.loadAssets({
+        introVideo: {
+          buffer: new Uint8Array([1, 2, 3]).buffer,
+          type: "video/mp4",
+        },
+        outroVideo: {
+          buffer: new Uint8Array([4, 5, 6]).buffer,
+          type: "video/mp4",
+        },
+      });
+    } catch (error) {
+      thrownError = error;
+    } finally {
+      createElement.mockRestore();
+      createObjectURL.mockRestore();
+    }
+
+    expect(createdVideos).toHaveLength(2);
+    expect(thrownError?.message).toContain(
+      'Could not load 2 assets: video "introVideo", video "outroVideo".',
+    );
+    expect(thrownError?.message).toContain(
+      'video "introVideo": Video element failed to load (code=4, message=No supported source was found, networkState=3, readyState=0, src=blob:http://route-graphics/video).',
+    );
+    expect(thrownError?.details?.failures).toEqual([
+      expect.objectContaining({
+        assetKey: "introVideo",
+        assetKind: "video",
+        cause:
+          'Failed to load video asset "introVideo" (code=4, message=No supported source was found, networkState=3, readyState=0, src=blob:http://route-graphics/video).',
+      }),
+      expect.objectContaining({
+        assetKey: "outroVideo",
+        assetKind: "video",
+        cause:
+          'Failed to load video asset "outroVideo" (code=4, message=No supported source was found, networkState=3, readyState=0, src=blob:http://route-graphics/video).',
       }),
     ]);
   });

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -113,10 +113,61 @@ const createPixiModuleMock = () => {
   class MockSprite extends MockDisplayObject {
     constructor(texture = null) {
       super();
-      this.texture = texture;
       this.scale = { x: 1, y: 1, set: vi.fn() };
       this.rotation = 0;
       this.filters = [];
+      this.texture = texture;
+    }
+
+    set texture(value) {
+      this._texture = value;
+
+      if (this._width) {
+        this.width = this._width;
+      }
+
+      if (this._height) {
+        this.height = this._height;
+      }
+    }
+
+    get texture() {
+      return this._texture;
+    }
+
+    set width(value) {
+      if (!this.scale) {
+        this._width = value;
+        return;
+      }
+
+      const textureWidth = this.texture?.orig?.width ?? 1;
+      const sign = Math.sign(this.scale?.x) || 1;
+
+      this.scale.x = textureWidth === 0 ? sign : (value / textureWidth) * sign;
+      this._width = value;
+    }
+
+    get width() {
+      return Math.abs(this.scale.x) * (this.texture?.orig?.width ?? 1);
+    }
+
+    set height(value) {
+      if (!this.scale) {
+        this._height = value;
+        return;
+      }
+
+      const textureHeight = this.texture?.orig?.height ?? 1;
+      const sign = Math.sign(this.scale?.y) || 1;
+
+      this.scale.y =
+        textureHeight === 0 ? sign : (value / textureHeight) * sign;
+      this._height = value;
+    }
+
+    get height() {
+      return Math.abs(this.scale.y) * (this.texture?.orig?.height ?? 1);
     }
   }
 
@@ -235,13 +286,30 @@ const createPixiModuleMock = () => {
 
       constructor(options = {}) {
         this.source = options.source;
+        this.orig = {
+          width: this.source?.width ?? 1,
+          height: this.source?.height ?? 1,
+        };
+        this.frame = this.orig;
+        this.destroy = vi.fn();
+
+        if (this.source) {
+          this.source.__mockTextures ??= new Set();
+          this.source.__mockTextures.add(this);
+        }
       }
 
-      static from() {
-        return {
-          source: { resource: { width: 1, height: 1 } },
-          destroy: vi.fn(),
-        };
+      static from(source) {
+        return (
+          assetCache.get(source) ??
+          new MockTexture({
+            source: {
+              resource: { width: 1, height: 1 },
+              width: 1,
+              height: 1,
+            },
+          })
+        );
       }
 
       once() {
@@ -253,6 +321,16 @@ const createPixiModuleMock = () => {
         Object.assign(this, options);
         this.destroyed = false;
         this.update = vi.fn();
+      }
+
+      resize(width, height) {
+        this.width = width;
+        this.height = height;
+
+        for (const texture of this.__mockTextures ?? []) {
+          texture.orig.width = width;
+          texture.orig.height = height;
+        }
       }
 
       once() {
@@ -627,6 +705,120 @@ describe("RouteGraphics public API", () => {
         source: expect.any(Object),
       }),
     );
+  });
+
+  it("preserves video sprite dimensions when lazy metadata resizes the texture", async () => {
+    const { app, pixiMock } = await setupRouteGraphics({
+      pluginsFactory: async () => {
+        const { videoPlugin } =
+          await import("../src/plugins/elements/video/index.js");
+
+        return {
+          elements: [videoPlugin],
+          animations: [],
+          audio: [],
+        };
+      },
+    });
+    const createdVideos = [];
+    const originalHTMLVideoElement = globalThis.HTMLVideoElement;
+    Object.defineProperty(globalThis, "HTMLVideoElement", {
+      value: window.HTMLVideoElement,
+      configurable: true,
+    });
+    const createObjectURL = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:http://route-graphics/video");
+    const originalCreateElement = document.createElement.bind(document);
+    const createElement = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tagName, ...args) => {
+        const element = originalCreateElement(tagName, ...args);
+
+        if (tagName === "video") {
+          createdVideos.push(element);
+          Object.defineProperty(element, "readyState", {
+            value: 0,
+            configurable: true,
+          });
+          Object.defineProperty(element, "videoWidth", {
+            value: 0,
+            configurable: true,
+          });
+          Object.defineProperty(element, "videoHeight", {
+            value: 0,
+            configurable: true,
+          });
+          element.load = vi.fn();
+          element.pause = vi.fn();
+          element.play = vi.fn();
+        }
+
+        return element;
+      });
+
+    try {
+      await app.loadAssets({
+        introVideo: {
+          buffer: new Uint8Array([1, 2, 3]).buffer,
+          type: "video/mp4",
+        },
+      });
+
+      app.render({
+        id: "video-state",
+        elements: [
+          {
+            id: "intro",
+            type: "video",
+            x: 0,
+            y: 0,
+            width: 320,
+            height: 180,
+            src: "introVideo",
+          },
+        ],
+      });
+
+      const sprite = app.findElementByLabel("intro");
+      const texture = pixiMock.Assets.cache.get("introVideo");
+
+      expect(sprite.width).toBe(320);
+      expect(sprite.height).toBe(180);
+      expect(texture.source.width).toBe(1);
+      expect(texture.source.height).toBe(1);
+
+      Object.defineProperty(createdVideos[0], "readyState", {
+        value: 2,
+        configurable: true,
+      });
+      Object.defineProperty(createdVideos[0], "videoWidth", {
+        value: 1920,
+        configurable: true,
+      });
+      Object.defineProperty(createdVideos[0], "videoHeight", {
+        value: 1080,
+        configurable: true,
+      });
+
+      createdVideos[0].dispatchEvent(new window.Event("loadeddata"));
+
+      expect(texture.source.width).toBe(1920);
+      expect(texture.source.height).toBe(1080);
+      expect(texture.orig.width).toBe(1920);
+      expect(texture.orig.height).toBe(1080);
+      expect(sprite.width).toBe(320);
+      expect(sprite.height).toBe(180);
+      expect(sprite.scale.x).toBeCloseTo(320 / 1920);
+      expect(sprite.scale.y).toBeCloseTo(180 / 1080);
+    } finally {
+      Object.defineProperty(globalThis, "HTMLVideoElement", {
+        value: originalHTMLVideoElement,
+        configurable: true,
+      });
+      createElement.mockRestore();
+      createObjectURL.mockRestore();
+    }
   });
 
   it("updates the visible stage background graphic color", async () => {

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -707,7 +707,113 @@ describe("RouteGraphics public API", () => {
     );
   });
 
-  it("preserves video sprite dimensions when lazy metadata resizes the texture", async () => {
+  it("updates lazy video texture when first mounted after frame data is ready", async () => {
+    const { app, pixiMock } = await setupRouteGraphics({
+      pluginsFactory: async () => {
+        const { videoPlugin } =
+          await import("../src/plugins/elements/video/index.js");
+
+        return {
+          elements: [videoPlugin],
+          animations: [],
+          audio: [],
+        };
+      },
+    });
+    const createdVideos = [];
+    const originalHTMLVideoElement = globalThis.HTMLVideoElement;
+    Object.defineProperty(globalThis, "HTMLVideoElement", {
+      value: window.HTMLVideoElement,
+      configurable: true,
+    });
+    const createObjectURL = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:http://route-graphics/video");
+    const originalCreateElement = document.createElement.bind(document);
+    const createElement = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tagName, ...args) => {
+        const element = originalCreateElement(tagName, ...args);
+
+        if (tagName === "video") {
+          createdVideos.push(element);
+          Object.defineProperty(element, "readyState", {
+            value: 0,
+            configurable: true,
+          });
+          Object.defineProperty(element, "videoWidth", {
+            value: 0,
+            configurable: true,
+          });
+          Object.defineProperty(element, "videoHeight", {
+            value: 0,
+            configurable: true,
+          });
+          element.load = vi.fn();
+          element.pause = vi.fn();
+          element.play = vi.fn();
+        }
+
+        return element;
+      });
+
+    try {
+      await app.loadAssets({
+        introVideo: {
+          buffer: new Uint8Array([1, 2, 3]).buffer,
+          type: "video/mp4",
+        },
+      });
+
+      const texture = pixiMock.Assets.cache.get("introVideo");
+      expect(texture.source.update).not.toHaveBeenCalled();
+
+      Object.defineProperty(createdVideos[0], "readyState", {
+        value: window.HTMLMediaElement.HAVE_CURRENT_DATA,
+        configurable: true,
+      });
+      Object.defineProperty(createdVideos[0], "videoWidth", {
+        value: 640,
+        configurable: true,
+      });
+      Object.defineProperty(createdVideos[0], "videoHeight", {
+        value: 360,
+        configurable: true,
+      });
+
+      app.render({
+        id: "video-state",
+        elements: [
+          {
+            id: "intro",
+            type: "video",
+            x: 0,
+            y: 0,
+            width: 320,
+            height: 180,
+            src: "introVideo",
+          },
+        ],
+      });
+
+      const sprite = app.findElementByLabel("intro");
+
+      expect(texture.source.width).toBe(640);
+      expect(texture.source.height).toBe(360);
+      expect(texture.source.update).toHaveBeenCalled();
+      expect(sprite.width).toBe(320);
+      expect(sprite.height).toBe(180);
+    } finally {
+      Object.defineProperty(globalThis, "HTMLVideoElement", {
+        value: originalHTMLVideoElement,
+        configurable: true,
+      });
+      createElement.mockRestore();
+      createObjectURL.mockRestore();
+    }
+  });
+
+  it("preserves video sprite dimensions when lazy frame data resizes the texture", async () => {
     const { app, pixiMock } = await setupRouteGraphics({
       pluginsFactory: async () => {
         const { videoPlugin } =
@@ -789,7 +895,7 @@ describe("RouteGraphics public API", () => {
       expect(texture.source.height).toBe(1);
 
       Object.defineProperty(createdVideos[0], "readyState", {
-        value: 2,
+        value: window.HTMLMediaElement.HAVE_CURRENT_DATA,
         configurable: true,
       });
       Object.defineProperty(createdVideos[0], "videoWidth", {

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -338,7 +338,7 @@ describe("RouteGraphics public API", () => {
     expect(app.findElementByLabel("missing-label")).toBeNull();
   }, 15000);
 
-  it("loads video assets through metadata-ready HTML video textures", async () => {
+  it("loads video assets through lazy HTML video textures", async () => {
     const { app, pixiMock } = await setupRouteGraphics();
     const createdVideos = [];
     const createObjectURL = vi
@@ -353,15 +353,15 @@ describe("RouteGraphics public API", () => {
         if (tagName === "video") {
           createdVideos.push(element);
           Object.defineProperty(element, "readyState", {
-            value: window.HTMLMediaElement.HAVE_METADATA,
+            value: 0,
             configurable: true,
           });
           Object.defineProperty(element, "videoWidth", {
-            value: 1280,
+            value: 0,
             configurable: true,
           });
           Object.defineProperty(element, "videoHeight", {
-            value: 720,
+            value: 0,
             configurable: true,
           });
           element.load = vi.fn();
@@ -414,14 +414,20 @@ describe("RouteGraphics public API", () => {
     const bufferVideoTexture = pixiMock.Assets.cache.set.mock.calls.find(
       ([key]) => key === "bufferVideo",
     )?.[1];
-    expect(bufferVideoTexture.source.width).toBe(1280);
-    expect(bufferVideoTexture.source.height).toBe(720);
+    expect(bufferVideoTexture.source.width).toBe(1);
+    expect(bufferVideoTexture.source.height).toBe(1);
     expect(bufferVideoTexture.source.alphaMode).toBe("premultiplied-alpha");
     expect(bufferVideoTexture.source.update).not.toHaveBeenCalled();
     expect(pixiMock.detectVideoAlphaMode).toHaveBeenCalled();
     expect(createdVideos).toHaveLength(2);
     expect(
       createdVideos.every((video) => video.crossOrigin === "anonymous"),
+    ).toBe(true);
+    expect(createdVideos.every((video) => video.preload === "metadata")).toBe(
+      true,
+    );
+    expect(
+      createdVideos.every((video) => video.load.mock.calls.length === 1),
     ).toBe(true);
     expect(
       createdVideos.every((video) => {
@@ -549,8 +555,8 @@ describe("RouteGraphics public API", () => {
     ]);
   });
 
-  it("surfaces media element diagnostics for multiple video load failures", async () => {
-    const { app } = await setupRouteGraphics();
+  it("does not reject video asset preload when browser defers media readiness", async () => {
+    const { app, pixiMock } = await setupRouteGraphics();
     const createdVideos = [];
     const createObjectURL = vi
       .spyOn(URL, "createObjectURL")
@@ -592,7 +598,6 @@ describe("RouteGraphics public API", () => {
         return element;
       });
 
-    let thrownError;
     try {
       await app.loadAssets({
         introVideo: {
@@ -604,34 +609,24 @@ describe("RouteGraphics public API", () => {
           type: "video/mp4",
         },
       });
-    } catch (error) {
-      thrownError = error;
     } finally {
       createElement.mockRestore();
       createObjectURL.mockRestore();
     }
 
     expect(createdVideos).toHaveLength(2);
-    expect(thrownError?.message).toContain(
-      'Could not load 2 assets: video "introVideo", video "outroVideo".',
-    );
-    expect(thrownError?.message).toContain(
-      'video "introVideo": Video element failed to load (code=4, message=No supported source was found, networkState=3, readyState=0, src=blob:http://route-graphics/video).',
-    );
-    expect(thrownError?.details?.failures).toEqual([
+    expect(pixiMock.Assets.cache.set).toHaveBeenCalledWith(
+      "introVideo",
       expect.objectContaining({
-        assetKey: "introVideo",
-        assetKind: "video",
-        cause:
-          'Failed to load video asset "introVideo" (code=4, message=No supported source was found, networkState=3, readyState=0, src=blob:http://route-graphics/video).',
+        source: expect.any(Object),
       }),
+    );
+    expect(pixiMock.Assets.cache.set).toHaveBeenCalledWith(
+      "outroVideo",
       expect.objectContaining({
-        assetKey: "outroVideo",
-        assetKind: "video",
-        cause:
-          'Failed to load video asset "outroVideo" (code=4, message=No supported source was found, networkState=3, readyState=0, src=blob:http://route-graphics/video).',
+        source: expect.any(Object),
       }),
-    ]);
+    );
   });
 
   it("updates the visible stage background graphic color", async () => {

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -707,6 +707,104 @@ describe("RouteGraphics public API", () => {
     );
   });
 
+  it("completes render when a lazy video fails after being tracked", async () => {
+    const eventHandler = vi.fn();
+    const { app } = await setupRouteGraphics({
+      initOptions: {
+        eventHandler,
+      },
+      pluginsFactory: async () => {
+        const { videoPlugin } =
+          await import("../src/plugins/elements/video/index.js");
+
+        return {
+          elements: [videoPlugin],
+          animations: [],
+          audio: [],
+        };
+      },
+    });
+    const createdVideos = [];
+    const originalHTMLVideoElement = globalThis.HTMLVideoElement;
+    Object.defineProperty(globalThis, "HTMLVideoElement", {
+      value: window.HTMLVideoElement,
+      configurable: true,
+    });
+    const createObjectURL = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:http://route-graphics/video");
+    const originalCreateElement = document.createElement.bind(document);
+    const createElement = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tagName, ...args) => {
+        const element = originalCreateElement(tagName, ...args);
+
+        if (tagName === "video") {
+          createdVideos.push(element);
+          Object.defineProperty(element, "readyState", {
+            value: 0,
+            configurable: true,
+          });
+          Object.defineProperty(element, "videoWidth", {
+            value: 0,
+            configurable: true,
+          });
+          Object.defineProperty(element, "videoHeight", {
+            value: 0,
+            configurable: true,
+          });
+          element.load = vi.fn();
+          element.pause = vi.fn();
+          element.play = vi.fn();
+        }
+
+        return element;
+      });
+
+    try {
+      await app.loadAssets({
+        introVideo: {
+          buffer: new Uint8Array([1, 2, 3]).buffer,
+          type: "video/mp4",
+        },
+      });
+
+      app.render({
+        id: "failed-video-state",
+        elements: [
+          {
+            id: "intro",
+            type: "video",
+            x: 0,
+            y: 0,
+            width: 320,
+            height: 180,
+            src: "introVideo",
+          },
+        ],
+      });
+
+      expect(eventHandler).not.toHaveBeenCalledWith("renderComplete", {
+        id: "failed-video-state",
+        aborted: false,
+      });
+
+      createdVideos[0].dispatchEvent(new window.Event("error"));
+
+      expect(eventHandler).toHaveBeenCalledWith("renderComplete", {
+        id: "failed-video-state",
+        aborted: false,
+      });
+    } finally {
+      Object.defineProperty(globalThis, "HTMLVideoElement", {
+        value: originalHTMLVideoElement,
+        configurable: true,
+      });
+      createElement.mockRestore();
+      createObjectURL.mockRestore();
+    }
+  });
+
   it("updates lazy video texture when first mounted after frame data is ready", async () => {
     const { app, pixiMock } = await setupRouteGraphics({
       pluginsFactory: async () => {

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -231,11 +231,31 @@ const createPixiModuleMock = () => {
     defaultFilterVert: "void main() {}",
     Texture: class MockTexture {
       static EMPTY = {};
+
+      constructor(options = {}) {
+        this.source = options.source;
+      }
+
       static from() {
         return {
           source: { resource: { width: 1, height: 1 } },
           destroy: vi.fn(),
         };
+      }
+
+      once() {
+        return this;
+      }
+    },
+    VideoSource: class MockVideoSource {
+      constructor(options = {}) {
+        Object.assign(this, options);
+        this.destroyed = false;
+        this.update = vi.fn();
+      }
+
+      once() {
+        return this;
       }
     },
     Rectangle: class MockRectangle {},

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -338,7 +338,7 @@ describe("RouteGraphics public API", () => {
     expect(app.findElementByLabel("missing-label")).toBeNull();
   }, 15000);
 
-  it("loads video assets through an early-ready HTML video texture", async () => {
+  it("loads video assets through metadata-ready HTML video textures", async () => {
     const { app, pixiMock } = await setupRouteGraphics();
     const createdVideos = [];
     const createObjectURL = vi
@@ -353,7 +353,7 @@ describe("RouteGraphics public API", () => {
         if (tagName === "video") {
           createdVideos.push(element);
           Object.defineProperty(element, "readyState", {
-            value: window.HTMLMediaElement.HAVE_CURRENT_DATA,
+            value: window.HTMLMediaElement.HAVE_METADATA,
             configurable: true,
           });
           Object.defineProperty(element, "videoWidth", {
@@ -414,7 +414,10 @@ describe("RouteGraphics public API", () => {
     const bufferVideoTexture = pixiMock.Assets.cache.set.mock.calls.find(
       ([key]) => key === "bufferVideo",
     )?.[1];
+    expect(bufferVideoTexture.source.width).toBe(1280);
+    expect(bufferVideoTexture.source.height).toBe(720);
     expect(bufferVideoTexture.source.alphaMode).toBe("premultiplied-alpha");
+    expect(bufferVideoTexture.source.update).not.toHaveBeenCalled();
     expect(pixiMock.detectVideoAlphaMode).toHaveBeenCalled();
     expect(createdVideos).toHaveLength(2);
     expect(

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -59,6 +59,9 @@ const createRouteGraphics = () => {
   const getVideoTextureDimension = (value) =>
     Number.isFinite(value) && value > 0 ? value : 1;
 
+  const hasVideoDimensions = (video) =>
+    video.videoWidth > 0 && video.videoHeight > 0;
+
   const syncVideoTextureSourceSize = (source, video) => {
     if (
       source.width === video.videoWidth &&
@@ -99,11 +102,17 @@ const createRouteGraphics = () => {
     }
 
     let frameId;
+    let videoFrameCallbackId;
     let lastUpdateTime = 0;
     const frameIntervalMS = 1000 / VIDEO_TEXTURE_UPDATE_FPS;
 
-    const updateSource = () => {
-      if (source.destroyed || !isRenderableVideoFrameReady(video)) {
+    const updateSource = ({ force = false } = {}) => {
+      if (
+        source.destroyed ||
+        (force
+          ? !hasVideoDimensions(video)
+          : !isRenderableVideoFrameReady(video))
+      ) {
         return false;
       }
 
@@ -119,8 +128,48 @@ const createRouteGraphics = () => {
       }
     };
 
+    const cancelVideoFrameCallback = () => {
+      if (
+        videoFrameCallbackId !== undefined &&
+        typeof video.cancelVideoFrameCallback === "function"
+      ) {
+        video.cancelVideoFrameCallback(videoFrameCallbackId);
+      }
+
+      videoFrameCallbackId = undefined;
+    };
+
+    const updateSourceFromVideoFrame = () => {
+      updateSource({ force: true });
+    };
+
+    const scheduleVideoFrameCallback = () => {
+      if (
+        videoFrameCallbackId !== undefined ||
+        typeof video.requestVideoFrameCallback !== "function"
+      ) {
+        return false;
+      }
+
+      videoFrameCallbackId = video.requestVideoFrameCallback(() => {
+        videoFrameCallbackId = undefined;
+        updateSourceFromVideoFrame();
+
+        if (!video.paused && !video.ended && !source.destroyed) {
+          scheduleVideoFrameCallback();
+        }
+      });
+
+      return true;
+    };
+
+    const updateSourceFromMediaEvent = () => {
+      updateSource();
+    };
+
     const stop = () => {
       cancelFrame();
+      cancelVideoFrameCallback();
       updateSource();
     };
 
@@ -141,6 +190,10 @@ const createRouteGraphics = () => {
     const start = () => {
       updateSource();
 
+      if (scheduleVideoFrameCallback()) {
+        return;
+      }
+
       if (frameId === undefined) {
         lastUpdateTime = 0;
         frameId = window.requestAnimationFrame(tick);
@@ -149,13 +202,16 @@ const createRouteGraphics = () => {
 
     const cleanup = () => {
       cancelFrame();
+      cancelVideoFrameCallback();
       video.removeEventListener("play", start);
       video.removeEventListener("playing", start);
       video.removeEventListener("pause", stop);
       video.removeEventListener("ended", stop);
-      video.removeEventListener("loadeddata", updateSource);
-      video.removeEventListener("canplay", updateSource);
-      video.removeEventListener("seeked", updateSource);
+      video.removeEventListener("loadeddata", updateSourceFromMediaEvent);
+      video.removeEventListener("canplay", updateSourceFromMediaEvent);
+      video.removeEventListener("canplaythrough", updateSourceFromMediaEvent);
+      video.removeEventListener("seeked", updateSourceFromMediaEvent);
+      video.removeEventListener("timeupdate", updateSourceFromMediaEvent);
       clearManagedVideoSprites(source);
       source.__routeGraphicsVideoTextureRuntime = undefined;
     };
@@ -164,14 +220,17 @@ const createRouteGraphics = () => {
     video.addEventListener("playing", start);
     video.addEventListener("pause", stop);
     video.addEventListener("ended", stop);
-    video.addEventListener("loadeddata", updateSource);
-    video.addEventListener("canplay", updateSource);
-    video.addEventListener("seeked", updateSource);
+    video.addEventListener("loadeddata", updateSourceFromMediaEvent);
+    video.addEventListener("canplay", updateSourceFromMediaEvent);
+    video.addEventListener("canplaythrough", updateSourceFromMediaEvent);
+    video.addEventListener("seeked", updateSourceFromMediaEvent);
+    video.addEventListener("timeupdate", updateSourceFromMediaEvent);
     source.once("destroy", cleanup);
     texture.once("destroy", cleanup);
 
     source.__routeGraphicsVideoTextureRuntime = {
       cleanup,
+      requestUpdate: updateSource,
     };
     updateSource();
   };

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -23,6 +23,11 @@ import { isDeepEqual } from "./util/isDeepEqual.js";
 import { createInputDomBridge } from "./util/inputDomBridge.js";
 import { buildAnimationContinuityPlan } from "./plugins/animations/planAnimations.js";
 import { cleanupParticlesInTree } from "./plugins/elements/particles/particleRuntime.js";
+import {
+  captureManagedVideoSpriteSizes,
+  clearManagedVideoSprites,
+  restoreManagedVideoSpriteSizes,
+} from "./plugins/elements/video/managedVideoTextureSizing.js";
 
 /**
  * @typedef {import('./types.js').RouteGraphicsInitOptions} RouteGraphicsInitOptions
@@ -62,7 +67,10 @@ const createRouteGraphics = () => {
       return;
     }
 
+    const spriteSizes = captureManagedVideoSpriteSizes(source);
+
     source.resize?.(video.videoWidth, video.videoHeight);
+    restoreManagedVideoSpriteSizes(spriteSizes);
   };
 
   const createVideoTextureSource = (video, alphaMode) =>
@@ -148,6 +156,7 @@ const createRouteGraphics = () => {
       video.removeEventListener("loadeddata", updateSource);
       video.removeEventListener("canplay", updateSource);
       video.removeEventListener("seeked", updateSource);
+      clearManagedVideoSprites(source);
       source.__routeGraphicsVideoTextureRuntime = undefined;
     };
 

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -41,11 +41,32 @@ import { cleanupParticlesInTree } from "./plugins/elements/particles/particleRun
 const createRouteGraphics = () => {
   const VIDEO_TEXTURE_UPDATE_FPS = 30;
 
+  const isRenderableVideoFrameReady = (video) => {
+    const haveCurrentData = window.HTMLMediaElement?.HAVE_CURRENT_DATA ?? 2;
+
+    return (
+      video.readyState >= haveCurrentData &&
+      video.videoWidth > 0 &&
+      video.videoHeight > 0
+    );
+  };
+
+  const syncVideoTextureSourceSize = (source, video) => {
+    if (
+      source.width === video.videoWidth &&
+      source.height === video.videoHeight
+    ) {
+      return;
+    }
+
+    source.resize?.(video.videoWidth, video.videoHeight);
+  };
+
   const createVideoTextureSource = (video, alphaMode) =>
     new VideoSource({
       resource: video,
-      width: video.videoWidth || undefined,
-      height: video.videoHeight || undefined,
+      width: video.videoWidth,
+      height: video.videoHeight,
       autoLoad: false,
       autoPlay: false,
       alphaMode,
@@ -71,16 +92,24 @@ const createRouteGraphics = () => {
     const frameIntervalMS = 1000 / VIDEO_TEXTURE_UPDATE_FPS;
 
     const updateSource = () => {
-      if (!source.destroyed) {
-        source.update();
+      if (source.destroyed || !isRenderableVideoFrameReady(video)) {
+        return false;
       }
+
+      syncVideoTextureSourceSize(source, video);
+      source.update();
+      return true;
     };
 
-    const stop = () => {
+    const cancelFrame = () => {
       if (frameId !== undefined) {
         window.cancelAnimationFrame(frameId);
         frameId = undefined;
       }
+    };
+
+    const stop = () => {
+      cancelFrame();
       updateSource();
     };
 
@@ -108,11 +137,13 @@ const createRouteGraphics = () => {
     };
 
     const cleanup = () => {
-      stop();
+      cancelFrame();
       video.removeEventListener("play", start);
       video.removeEventListener("playing", start);
       video.removeEventListener("pause", stop);
       video.removeEventListener("ended", stop);
+      video.removeEventListener("loadeddata", updateSource);
+      video.removeEventListener("canplay", updateSource);
       video.removeEventListener("seeked", updateSource);
       source.__routeGraphicsVideoTextureRuntime = undefined;
     };
@@ -121,6 +152,8 @@ const createRouteGraphics = () => {
     video.addEventListener("playing", start);
     video.addEventListener("pause", stop);
     video.addEventListener("ended", stop);
+    video.addEventListener("loadeddata", updateSource);
+    video.addEventListener("canplay", updateSource);
     video.addEventListener("seeked", updateSource);
     source.once("destroy", cleanup);
     texture.once("destroy", cleanup);
@@ -506,9 +539,7 @@ const createRouteGraphics = () => {
 
   const waitForVideoReady = (video, key) =>
     new Promise((resolve, reject) => {
-      const haveCurrentData = window.HTMLMediaElement?.HAVE_CURRENT_DATA ?? 2;
-
-      if (video.readyState >= haveCurrentData) {
+      if (isRenderableVideoFrameReady(video)) {
         resolve();
         return;
       }
@@ -516,11 +547,17 @@ const createRouteGraphics = () => {
       let timeoutId;
       const cleanup = () => {
         window.clearTimeout(timeoutId);
+        video.removeEventListener("loadedmetadata", onReady);
         video.removeEventListener("loadeddata", onReady);
         video.removeEventListener("canplay", onReady);
+        video.removeEventListener("canplaythrough", onReady);
         video.removeEventListener("error", onError);
       };
       const onReady = () => {
+        if (!isRenderableVideoFrameReady(video)) {
+          return;
+        }
+
         cleanup();
         resolve();
       };
@@ -548,8 +585,10 @@ const createRouteGraphics = () => {
         reject(new Error(`Timed out loading video asset "${key}".`));
       }, 5000);
 
-      video.addEventListener("loadeddata", onReady, { once: true });
-      video.addEventListener("canplay", onReady, { once: true });
+      video.addEventListener("loadedmetadata", onReady);
+      video.addEventListener("loadeddata", onReady);
+      video.addEventListener("canplay", onReady);
+      video.addEventListener("canplaythrough", onReady);
       video.addEventListener("error", onError, { once: true });
     });
 

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -5,6 +5,7 @@ import {
   Texture,
   Rectangle,
   VideoSource,
+  detectVideoAlphaMode,
 } from "pixi.js";
 import "@pixi/unsafe-eval";
 import { createAudioStage } from "./AudioStage.js";
@@ -40,14 +41,14 @@ import { cleanupParticlesInTree } from "./plugins/elements/particles/particleRun
 const createRouteGraphics = () => {
   const VIDEO_TEXTURE_UPDATE_FPS = 30;
 
-  const createVideoTextureSource = (video) =>
+  const createVideoTextureSource = (video, alphaMode) =>
     new VideoSource({
       resource: video,
       width: video.videoWidth || undefined,
       height: video.videoHeight || undefined,
       autoLoad: false,
       autoPlay: false,
-      alphaMode: "premultiply-alpha-on-upload",
+      alphaMode,
       crossorigin: "anonymous",
       muted: false,
       playsinline: true,
@@ -571,8 +572,9 @@ const createRouteGraphics = () => {
 
     await ready;
 
+    const alphaMode = await detectVideoAlphaMode();
     const texture = new Texture({
-      source: createVideoTextureSource(video),
+      source: createVideoTextureSource(video, alphaMode),
     });
     configureManagedVideoTextureUpdates(texture);
     Assets.cache.set(key, texture);

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -602,11 +602,14 @@ const createRouteGraphics = () => {
     video.preload = "auto";
     video.playsInline = true;
     video.setAttribute("playsinline", "");
+    video.setAttribute("webkit-playsinline", "");
+    const sourceElement = document.createElement("source");
+    sourceElement.src = sourceUrl;
     if (typeof mimeType === "string" && mimeType.length > 0) {
-      video.type = mimeType;
+      sourceElement.type = mimeType;
     }
     const ready = waitForVideoReady(video, key);
-    video.src = sourceUrl;
+    video.appendChild(sourceElement);
     video.load();
 
     await ready;

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -41,16 +41,6 @@ import { cleanupParticlesInTree } from "./plugins/elements/particles/particleRun
 const createRouteGraphics = () => {
   const VIDEO_TEXTURE_UPDATE_FPS = 30;
 
-  const hasVideoMetadata = (video) => {
-    const haveMetadata = window.HTMLMediaElement?.HAVE_METADATA ?? 1;
-
-    return (
-      video.readyState >= haveMetadata &&
-      video.videoWidth > 0 &&
-      video.videoHeight > 0
-    );
-  };
-
   const isRenderableVideoFrameReady = (video) => {
     const haveCurrentData = window.HTMLMediaElement?.HAVE_CURRENT_DATA ?? 2;
 
@@ -60,6 +50,9 @@ const createRouteGraphics = () => {
       video.videoHeight > 0
     );
   };
+
+  const getVideoTextureDimension = (value) =>
+    Number.isFinite(value) && value > 0 ? value : 1;
 
   const syncVideoTextureSourceSize = (source, video) => {
     if (
@@ -75,8 +68,8 @@ const createRouteGraphics = () => {
   const createVideoTextureSource = (video, alphaMode) =>
     new VideoSource({
       resource: video,
-      width: video.videoWidth,
-      height: video.videoHeight,
+      width: getVideoTextureDimension(video.videoWidth),
+      height: getVideoTextureDimension(video.videoHeight),
       autoLoad: false,
       autoPlay: false,
       alphaMode,
@@ -584,61 +577,6 @@ const createRouteGraphics = () => {
     videoSourceUrls.clear();
   };
 
-  const waitForVideoReady = (video, key) =>
-    new Promise((resolve, reject) => {
-      if (hasVideoMetadata(video)) {
-        resolve();
-        return;
-      }
-
-      let timeoutId;
-      const cleanup = () => {
-        window.clearTimeout(timeoutId);
-        video.removeEventListener("loadedmetadata", onReady);
-        video.removeEventListener("loadeddata", onReady);
-        video.removeEventListener("canplay", onReady);
-        video.removeEventListener("canplaythrough", onReady);
-        video.removeEventListener("error", onError);
-      };
-      const onReady = () => {
-        if (!hasVideoMetadata(video)) {
-          return;
-        }
-
-        cleanup();
-        resolve();
-      };
-      const onError = () => {
-        cleanup();
-        const details = [
-          video.error?.code ? `code=${video.error.code}` : null,
-          video.error?.message ? `message=${video.error.message}` : null,
-          `networkState=${video.networkState}`,
-          `readyState=${video.readyState}`,
-          video.currentSrc ? `src=${video.currentSrc}` : null,
-        ]
-          .filter(Boolean)
-          .join(", ");
-
-        reject(
-          new Error(
-            `Failed to load video asset "${key}"${details ? ` (${details})` : ""}.`,
-          ),
-        );
-      };
-
-      timeoutId = window.setTimeout(() => {
-        cleanup();
-        reject(new Error(`Timed out loading video asset "${key}".`));
-      }, 5000);
-
-      video.addEventListener("loadedmetadata", onReady);
-      video.addEventListener("loadeddata", onReady);
-      video.addEventListener("canplay", onReady);
-      video.addEventListener("canplaythrough", onReady);
-      video.addEventListener("error", onError, { once: true });
-    });
-
   const loadVideoTexture = async ({ key, sourceUrl, mimeType }) => {
     if (Assets.cache.has(key)) {
       return Assets.cache.get(key);
@@ -646,7 +584,7 @@ const createRouteGraphics = () => {
 
     const video = document.createElement("video");
     video.crossOrigin = "anonymous";
-    video.preload = "auto";
+    video.preload = "metadata";
     video.playsInline = true;
     video.setAttribute("playsinline", "");
     video.setAttribute("webkit-playsinline", "");
@@ -655,11 +593,8 @@ const createRouteGraphics = () => {
     if (typeof mimeType === "string" && mimeType.length > 0) {
       sourceElement.type = mimeType;
     }
-    const ready = waitForVideoReady(video, key);
     video.appendChild(sourceElement);
     video.load();
-
-    await ready;
 
     const alphaMode = await detectVideoAlphaMode();
     const texture = new Texture({

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -355,6 +355,21 @@ const createRouteGraphics = () => {
     return match?.[1];
   };
 
+  const getVideoElementCauseMessage = (causeMessage) => {
+    if (/Timed out loading video asset/i.test(causeMessage)) {
+      return "Timed out while loading video metadata.";
+    }
+
+    if (!/Failed to load video asset/i.test(causeMessage)) {
+      return undefined;
+    }
+
+    const details = causeMessage.match(/\((.*)\)\.?$/)?.[1];
+    return details
+      ? `Video element failed to load (${details}).`
+      : "Video element failed to load.";
+  };
+
   const getFriendlyCauseMessage = ({ category, phase, error }) => {
     if (error?.rootCauseMessage) {
       return error.rootCauseMessage;
@@ -392,7 +407,10 @@ const createRouteGraphics = () => {
     }
 
     if (category === "video") {
-      return "Unsupported, damaged, or inaccessible video file.";
+      return (
+        getVideoElementCauseMessage(causeMessage) ??
+        "Unsupported, damaged, or inaccessible video file."
+      );
     }
 
     if (category === "texture" && phase === "image bitmap creation") {
@@ -500,6 +518,25 @@ const createRouteGraphics = () => {
     return `${visibleNames.join(", ")}${suffix}`;
   };
 
+  const formatAssetFailureCauses = (failures) => {
+    const maxVisibleFailures = 3;
+    const visibleCauses = failures
+      .slice(0, maxVisibleFailures)
+      .map((failure) => {
+        const name = formatAssetFailureName(failure);
+        const cause =
+          failure?.rootCauseMessage ||
+          failure?.details?.cause ||
+          getErrorMessage(failure);
+
+        return `${name}: ${truncateErrorValue(cause)}`;
+      });
+    const hiddenCount = failures.length - visibleCauses.length;
+    const suffix = hiddenCount > 0 ? `, and ${hiddenCount} more` : "";
+
+    return `${visibleCauses.join("; ")}${suffix}`;
+  };
+
   const throwAssetLoadFailures = (settledResults) => {
     const failures = settledResults
       .filter((result) => result.status === "rejected")
@@ -513,7 +550,7 @@ const createRouteGraphics = () => {
       throw failures[0];
     }
 
-    const rootCauseMessage = "Check that the files exist and are supported.";
+    const rootCauseMessage = formatAssetFailureCauses(failures);
     const message = `Could not load ${failures.length} assets: ${formatAssetFailureNames(failures)}. ${rootCauseMessage}`;
     const aggregateError = new AggregateError(failures, message);
 

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -1,4 +1,11 @@
-import { Application, Assets, Graphics, Texture, Rectangle } from "pixi.js";
+import {
+  Application,
+  Assets,
+  Graphics,
+  Texture,
+  Rectangle,
+  VideoSource,
+} from "pixi.js";
 import "@pixi/unsafe-eval";
 import { createAudioStage } from "./AudioStage.js";
 import parseElements from "./plugins/elements/parseElements.js";
@@ -31,6 +38,98 @@ import { cleanupParticlesInTree } from "./plugins/elements/particles/particleRun
  */
 
 const createRouteGraphics = () => {
+  const VIDEO_TEXTURE_UPDATE_FPS = 30;
+
+  const createVideoTextureSource = (video) =>
+    new VideoSource({
+      resource: video,
+      width: video.videoWidth || undefined,
+      height: video.videoHeight || undefined,
+      autoLoad: false,
+      autoPlay: false,
+      alphaMode: "premultiply-alpha-on-upload",
+      crossorigin: "anonymous",
+      muted: false,
+      playsinline: true,
+    });
+
+  const configureManagedVideoTextureUpdates = (texture) => {
+    const source = texture?.source;
+    const video = source?.resource;
+
+    if (!(video instanceof HTMLVideoElement)) {
+      return;
+    }
+
+    if (source.__routeGraphicsVideoTextureRuntime) {
+      return;
+    }
+
+    let frameId;
+    let lastUpdateTime = 0;
+    const frameIntervalMS = 1000 / VIDEO_TEXTURE_UPDATE_FPS;
+
+    const updateSource = () => {
+      if (!source.destroyed) {
+        source.update();
+      }
+    };
+
+    const stop = () => {
+      if (frameId !== undefined) {
+        window.cancelAnimationFrame(frameId);
+        frameId = undefined;
+      }
+      updateSource();
+    };
+
+    const tick = (time) => {
+      frameId = undefined;
+      if (video.paused || video.ended || source.destroyed) {
+        return;
+      }
+
+      if (time - lastUpdateTime >= frameIntervalMS) {
+        lastUpdateTime = time;
+        updateSource();
+      }
+
+      frameId = window.requestAnimationFrame(tick);
+    };
+
+    const start = () => {
+      updateSource();
+
+      if (frameId === undefined) {
+        lastUpdateTime = 0;
+        frameId = window.requestAnimationFrame(tick);
+      }
+    };
+
+    const cleanup = () => {
+      stop();
+      video.removeEventListener("play", start);
+      video.removeEventListener("playing", start);
+      video.removeEventListener("pause", stop);
+      video.removeEventListener("ended", stop);
+      video.removeEventListener("seeked", updateSource);
+      source.__routeGraphicsVideoTextureRuntime = undefined;
+    };
+
+    video.addEventListener("play", start);
+    video.addEventListener("playing", start);
+    video.addEventListener("pause", stop);
+    video.addEventListener("ended", stop);
+    video.addEventListener("seeked", updateSource);
+    source.once("destroy", cleanup);
+    texture.once("destroy", cleanup);
+
+    source.__routeGraphicsVideoTextureRuntime = {
+      cleanup,
+    };
+    updateSource();
+  };
+
   const assertAnimationPlaybackMode = (mode) => {
     if (mode !== "auto" && mode !== "manual") {
       throw new Error(
@@ -472,7 +571,10 @@ const createRouteGraphics = () => {
 
     await ready;
 
-    const texture = Texture.from(video);
+    const texture = new Texture({
+      source: createVideoTextureSource(video),
+    });
+    configureManagedVideoTextureUpdates(texture);
     Assets.cache.set(key, texture);
 
     return texture;

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -41,6 +41,16 @@ import { cleanupParticlesInTree } from "./plugins/elements/particles/particleRun
 const createRouteGraphics = () => {
   const VIDEO_TEXTURE_UPDATE_FPS = 30;
 
+  const hasVideoMetadata = (video) => {
+    const haveMetadata = window.HTMLMediaElement?.HAVE_METADATA ?? 1;
+
+    return (
+      video.readyState >= haveMetadata &&
+      video.videoWidth > 0 &&
+      video.videoHeight > 0
+    );
+  };
+
   const isRenderableVideoFrameReady = (video) => {
     const haveCurrentData = window.HTMLMediaElement?.HAVE_CURRENT_DATA ?? 2;
 
@@ -539,7 +549,7 @@ const createRouteGraphics = () => {
 
   const waitForVideoReady = (video, key) =>
     new Promise((resolve, reject) => {
-      if (isRenderableVideoFrameReady(video)) {
+      if (hasVideoMetadata(video)) {
         resolve();
         return;
       }
@@ -554,7 +564,7 @@ const createRouteGraphics = () => {
         video.removeEventListener("error", onError);
       };
       const onReady = () => {
-        if (!isRenderableVideoFrameReady(video)) {
+        if (!hasVideoMetadata(video)) {
           return;
         }
 

--- a/src/plugins/elements/video/addVideo.js
+++ b/src/plugins/elements/video/addVideo.js
@@ -13,7 +13,10 @@ import {
   hasShaderProgressUpdateAnimation,
   syncShaderFilters,
 } from "../util/shaderFilterEffect.js";
-import { registerManagedVideoSprite } from "./managedVideoTextureSizing.js";
+import {
+  registerManagedVideoSprite,
+  requestManagedVideoTextureUpdate,
+} from "./managedVideoTextureSizing.js";
 
 /**
  * Add video element to the stage
@@ -70,9 +73,9 @@ export const addVideo = ({
     completionTracker,
   });
 
-  queueDeferredVideoPlay(renderContext, video);
-
   parent.addChild(sprite);
+  requestManagedVideoTextureUpdate(sprite);
+  queueDeferredVideoPlay(renderContext, video);
 
   dispatchLiveAnimations({
     animations,

--- a/src/plugins/elements/video/addVideo.js
+++ b/src/plugins/elements/video/addVideo.js
@@ -13,6 +13,7 @@ import {
   hasShaderProgressUpdateAnimation,
   syncShaderFilters,
 } from "../util/shaderFilterEffect.js";
+import { registerManagedVideoSprite } from "./managedVideoTextureSizing.js";
 
 /**
  * Add video element to the stage
@@ -48,6 +49,7 @@ export const addVideo = ({
   sprite.y = Math.round(y);
   sprite.width = Math.round(width);
   sprite.height = Math.round(height);
+  registerManagedVideoSprite(sprite);
   sprite.alpha = alpha ?? 1;
   const shouldForceBlur = hasBlurUpdateAnimation(animations, id);
   syncBlurEffect(sprite, element.blur, { force: shouldForceBlur });

--- a/src/plugins/elements/video/addVideo.js
+++ b/src/plugins/elements/video/addVideo.js
@@ -46,6 +46,7 @@ export const addVideo = ({
   sprite.label = id;
   sprite.zIndex = zIndex;
   sprite._videoEndedListener = undefined;
+  sprite._videoErrorListener = undefined;
   sprite._playbackStateVersion = null;
 
   sprite.x = Math.round(x);

--- a/src/plugins/elements/video/deleteVideo.js
+++ b/src/plugins/elements/video/deleteVideo.js
@@ -1,4 +1,5 @@
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import { unregisterManagedVideoSprite } from "./managedVideoTextureSizing.js";
 
 /**
  * Delete video element
@@ -29,6 +30,7 @@ export const deleteVideo = ({
         }
         video.pause();
       }
+      unregisterManagedVideoSprite(videoElement);
       parent.removeChild(videoElement);
       videoElement.destroy();
     }

--- a/src/plugins/elements/video/deleteVideo.js
+++ b/src/plugins/elements/video/deleteVideo.js
@@ -1,4 +1,5 @@
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import { clearVideoPlaybackTracking } from "./playbackTracking.js";
 import { unregisterManagedVideoSprite } from "./managedVideoTextureSizing.js";
 
 /**
@@ -25,9 +26,7 @@ export const deleteVideo = ({
       }
       const video = videoElement.texture.source.resource;
       if (video) {
-        if (videoElement._videoEndedListener) {
-          video.removeEventListener("ended", videoElement._videoEndedListener);
-        }
+        clearVideoPlaybackTracking({ videoElement, video });
         video.pause();
       }
       unregisterManagedVideoSprite(videoElement);

--- a/src/plugins/elements/video/managedVideoTextureSizing.js
+++ b/src/plugins/elements/video/managedVideoTextureSizing.js
@@ -1,0 +1,95 @@
+const MANAGED_VIDEO_SPRITES_KEY = "__routeGraphicsManagedVideoSprites";
+
+const getManagedVideoSpriteSet = (source) => {
+  if (!source) {
+    return null;
+  }
+
+  if (!source[MANAGED_VIDEO_SPRITES_KEY]) {
+    source[MANAGED_VIDEO_SPRITES_KEY] = new Set();
+  }
+
+  return source[MANAGED_VIDEO_SPRITES_KEY];
+};
+
+export const registerManagedVideoSprite = (sprite) => {
+  const source = sprite?.texture?.source;
+  const sprites = getManagedVideoSpriteSet(source);
+
+  if (!sprites) {
+    return;
+  }
+
+  sprites.add(sprite);
+
+  if (typeof sprite.once === "function") {
+    sprite.once("destroyed", () => {
+      source?.[MANAGED_VIDEO_SPRITES_KEY]?.delete(sprite);
+    });
+  }
+};
+
+export const unregisterManagedVideoSprite = (
+  sprite,
+  source = sprite?.texture?.source,
+) => {
+  source?.[MANAGED_VIDEO_SPRITES_KEY]?.delete(sprite);
+};
+
+export const clearManagedVideoSprites = (source) => {
+  const sprites = source?.[MANAGED_VIDEO_SPRITES_KEY];
+
+  if (sprites) {
+    sprites.clear();
+  }
+
+  if (source) {
+    source[MANAGED_VIDEO_SPRITES_KEY] = undefined;
+  }
+};
+
+export const captureManagedVideoSpriteSizes = (source) => {
+  const sprites = source?.[MANAGED_VIDEO_SPRITES_KEY];
+
+  if (!sprites?.size) {
+    return null;
+  }
+
+  const sizes = new Map();
+
+  for (const sprite of sprites) {
+    if (!sprite || sprite.destroyed || sprite.texture?.source !== source) {
+      sprites.delete(sprite);
+      continue;
+    }
+
+    const width = sprite.width;
+    const height = sprite.height;
+
+    if (Number.isFinite(width) && Number.isFinite(height)) {
+      sizes.set(sprite, { width, height });
+    }
+  }
+
+  return sizes.size > 0 ? sizes : null;
+};
+
+export const restoreManagedVideoSpriteSizes = (sizes) => {
+  if (!sizes) {
+    return;
+  }
+
+  for (const [sprite, size] of sizes) {
+    if (!sprite || sprite.destroyed) {
+      continue;
+    }
+
+    if (Number.isFinite(size.width)) {
+      sprite.width = size.width;
+    }
+
+    if (Number.isFinite(size.height)) {
+      sprite.height = size.height;
+    }
+  }
+};

--- a/src/plugins/elements/video/managedVideoTextureSizing.js
+++ b/src/plugins/elements/video/managedVideoTextureSizing.js
@@ -29,6 +29,12 @@ export const registerManagedVideoSprite = (sprite) => {
   }
 };
 
+export const requestManagedVideoTextureUpdate = (sprite) => {
+  const runtime = sprite?.texture?.source?.__routeGraphicsVideoTextureRuntime;
+
+  runtime?.requestUpdate?.();
+};
+
 export const unregisterManagedVideoSprite = (
   sprite,
   source = sprite?.texture?.source,

--- a/src/plugins/elements/video/playbackTracking.js
+++ b/src/plugins/elements/video/playbackTracking.js
@@ -1,6 +1,13 @@
-const hasVideoPlaybackCompleted = (video) => {
+const hasVideoPlaybackSettled = (video) => {
   if (!video) return true;
   if (video.ended) return true;
+  if (video.error) return true;
+  if (
+    typeof video.NETWORK_NO_SOURCE === "number" &&
+    video.networkState === video.NETWORK_NO_SOURCE
+  ) {
+    return true;
+  }
 
   return (
     Number.isFinite(video.duration) &&
@@ -14,8 +21,13 @@ export const clearVideoPlaybackTracking = ({ videoElement, video }) => {
     video.removeEventListener("ended", videoElement._videoEndedListener);
   }
 
+  if (video && videoElement?._videoErrorListener) {
+    video.removeEventListener("error", videoElement._videoErrorListener);
+  }
+
   if (videoElement) {
     videoElement._videoEndedListener = undefined;
+    videoElement._videoErrorListener = undefined;
     videoElement._playbackStateVersion = null;
   }
 };
@@ -32,18 +44,20 @@ export const syncVideoPlaybackTracking = ({
     return;
   }
 
-  if (hasVideoPlaybackCompleted(video)) {
+  if (hasVideoPlaybackSettled(video)) {
     return;
   }
 
   const playbackStateVersion = completionTracker.getVersion();
   completionTracker.track(playbackStateVersion);
 
-  const onEnded = () => {
+  const completePlayback = () => {
     completionTracker.complete(playbackStateVersion);
   };
 
-  video.addEventListener("ended", onEnded);
-  videoElement._videoEndedListener = onEnded;
+  video.addEventListener("ended", completePlayback);
+  video.addEventListener("error", completePlayback);
+  videoElement._videoEndedListener = completePlayback;
+  videoElement._videoErrorListener = completePlayback;
   videoElement._playbackStateVersion = playbackStateVersion;
 };

--- a/src/plugins/elements/video/updateVideo.js
+++ b/src/plugins/elements/video/updateVideo.js
@@ -20,6 +20,10 @@ import {
   resetShaderFilterProgress,
   syncShaderFilters,
 } from "../util/shaderFilterEffect.js";
+import {
+  registerManagedVideoSprite,
+  unregisterManagedVideoSprite,
+} from "./managedVideoTextureSizing.js";
 
 /**
  * Update video element
@@ -77,6 +81,7 @@ export const updateVideo = ({
 
     if (srcChanged) {
       const oldVideo = activeVideo;
+      const oldSource = videoElement.texture?.source;
       clearVideoPlaybackTracking({
         videoElement,
         video: oldVideo,
@@ -88,6 +93,8 @@ export const updateVideo = ({
 
       const newTexture = Texture.from(nextElement.src);
       videoElement.texture = newTexture;
+      unregisterManagedVideoSprite(videoElement, oldSource);
+      registerManagedVideoSprite(videoElement);
       activeVideo = newTexture.source.resource;
 
       activeVideo.muted = false;

--- a/src/plugins/elements/video/updateVideo.js
+++ b/src/plugins/elements/video/updateVideo.js
@@ -22,6 +22,7 @@ import {
 } from "../util/shaderFilterEffect.js";
 import {
   registerManagedVideoSprite,
+  requestManagedVideoTextureUpdate,
   unregisterManagedVideoSprite,
 } from "./managedVideoTextureSizing.js";
 
@@ -101,6 +102,7 @@ export const updateVideo = ({
       activeVideo.pause();
       activeVideo.currentTime = 0;
       currentSrc = nextElement.src;
+      requestManagedVideoTextureUpdate(videoElement);
     }
 
     syncVideoPlaybackTracking({


### PR DESCRIPTION
## Summary
- bump route-graphics to 1.24.1
- create video textures with an explicit Pixi VideoSource configured not to autoplay while preloading
- drive video texture uploads from playback events/requestAnimationFrame so WebKitGTK updates frames instead of freezing on the first frame
- update the public API Pixi mock for the new VideoSource path

## Validation
- bunx prettier --check src/RouteGraphics.js spec/RouteGraphics.publicApi.spec.js package.json
- bun run build
- bun run test
- push hook: bunx prettier --check src; vitest run
- manual: confirmed through routevn-creator using local route-graphics build on Linux