### PR TITLE
feat: add explicit asset lifecycle APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ app.render({
 `createAssetBufferManager()` may keep image and video assets as direct source
 URLs when possible, while audio and font assets remain buffer-backed.
 
+Assets loaded by an app instance can be released after no rendered or
+transitioning element still references them:
+
+```javascript
+await app.unloadAssets(["circle-red", "bgm-1"]);
+```
+
+`unloadAssets()` removes renderer cache entries and releases texture, video,
+audio, and font resources owned by that Route Graphics instance. Unknown or
+already-unloaded keys are ignored, and released keys can be loaded again.
+
+The event handler also receives `rendererContextLost` and
+`rendererContextRestored` lifecycle events. Fallback UI should live outside the
+renderer so it remains available while the graphics context is unavailable.
+
 For complete usage details, go to:
 
 - [Getting Started](http://route-graphics.routevn.com/docs/introduction/getting-started/)

--- a/docs/api-naming.md
+++ b/docs/api-naming.md
@@ -63,6 +63,8 @@ The public semantic event names are:
 - `keydown`
 - `keyup`
 - `renderComplete`
+- `rendererContextLost`
+- `rendererContextRestored`
 
 These are the names Route Graphics consumers should listen for in `eventHandler`.
 
@@ -115,6 +117,16 @@ Event names are semantic Route Graphics events, not native input events.
 
 - Fired when the current render has finished all tracked asynchronous work.
 - This is a lifecycle event, not an element interaction event.
+
+### `rendererContextLost` / `rendererContextRestored`
+
+- Fired when the active renderer loses or restores the graphics context needed
+  to present frames.
+- These are renderer lifecycle events, not element interaction events.
+- Consumers should use them to show renderer-independent fallback UI and
+  rebuild renderer-owned assets.
+- Browser-native names such as `webglcontextlost` and `webglcontextrestored`
+  remain internal implementation details.
 
 ## Config Shape
 
@@ -314,6 +326,8 @@ Platform differences should be handled by the runtime adapter, not pushed into c
 ### Render lifecycle
 
 - `renderComplete`
+- `rendererContextLost`
+- `rendererContextRestored`
 
 ## Authoring Rules
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.24.2",
+  "version": "1.25.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -258,10 +258,16 @@ const createPixiModuleMock = () => {
     Assets: {
       registerPlugin: vi.fn(),
       load: vi.fn(),
+      unload: vi.fn(async (key) => {
+        const asset = assetCache.get(key);
+        assetCache.delete(key);
+        asset?.destroy?.(true);
+      }),
       cache: {
         has: vi.fn((key) => assetCache.has(key)),
         get: vi.fn((key) => assetCache.get(key)),
         set: vi.fn((key, value) => assetCache.set(key, value)),
+        remove: vi.fn((key) => assetCache.delete(key)),
       },
     },
     detectVideoAlphaMode: vi.fn().mockResolvedValue("premultiplied-alpha"),
@@ -307,9 +313,9 @@ const createPixiModuleMock = () => {
           assetCache.get(source) ??
           new MockTexture({
             source: {
-              resource: { width: 1, height: 1 },
-              width: 1,
-              height: 1,
+              resource: source,
+              width: source?.width ?? 1,
+              height: source?.height ?? 1,
             },
           })
         );
@@ -353,6 +359,7 @@ const setupRouteGraphics = async ({
   audioAsset = {
     load: vi.fn(),
     getAsset: vi.fn(),
+    unload: vi.fn(),
   },
 } = {}) => {
   const pixiMock = createPixiModuleMock();
@@ -409,6 +416,8 @@ describe("RouteGraphics public API", () => {
   afterEach(() => {
     currentApp?.destroy();
     currentApp = null;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     vi.resetModules();
   });
 
@@ -418,6 +427,127 @@ describe("RouteGraphics public API", () => {
     expect(() => app.findElementByLabel("missing-label")).not.toThrow();
     expect(app.findElementByLabel("missing-label")).toBeNull();
   }, 15000);
+
+  it("unloads and reloads buffer-backed textures", async () => {
+    const { app, pixiMock } = await setupRouteGraphics();
+    const firstBitmap = { width: 8, height: 6, close: vi.fn() };
+    const secondBitmap = { width: 8, height: 6, close: vi.fn() };
+    const createImageBitmap = vi
+      .fn()
+      .mockResolvedValueOnce(firstBitmap)
+      .mockResolvedValueOnce(secondBitmap);
+    vi.stubGlobal("createImageBitmap", createImageBitmap);
+    const asset = {
+      buffer: new Uint8Array([1, 2, 3]).buffer,
+      type: "image/png",
+    };
+
+    await app.loadAssets({ portrait: asset });
+    const firstTexture = pixiMock.Assets.cache.get("portrait");
+
+    await expect(
+      app.unloadAssets(["portrait", "portrait", "missing"]),
+    ).resolves.toEqual(["portrait"]);
+    expect(pixiMock.Assets.cache.remove).toHaveBeenCalledWith("portrait");
+    expect(firstTexture.destroy).toHaveBeenCalledWith(true);
+    expect(firstBitmap.close).toHaveBeenCalledTimes(1);
+    expect(pixiMock.Assets.cache.has("portrait")).toBe(false);
+
+    await app.loadAssets({ portrait: asset });
+
+    expect(createImageBitmap).toHaveBeenCalledTimes(2);
+    expect(pixiMock.Assets.cache.get("portrait")).not.toBe(firstTexture);
+  });
+
+  it("uses Pixi asset unloading for URL-backed textures", async () => {
+    const { app, pixiMock } = await setupRouteGraphics();
+    const resource = { close: vi.fn() };
+    const texture = {
+      source: { resource },
+      destroy: vi.fn(),
+    };
+    pixiMock.Assets.load.mockImplementation(async ({ alias }) => {
+      pixiMock.Assets.cache.set(alias, texture);
+      return texture;
+    });
+
+    await app.loadAssets({
+      background: {
+        source: "url",
+        url: "https://cdn.example.test/background.png",
+        type: "image/png",
+      },
+    });
+    await expect(app.unloadAssets(["background"])).resolves.toEqual([
+      "background",
+    ]);
+
+    expect(pixiMock.Assets.unload).toHaveBeenCalledWith("background");
+    expect(texture.destroy).toHaveBeenCalledWith(true);
+    expect(resource.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("unloads audio and font assets", async () => {
+    const audioAsset = {
+      load: vi.fn().mockResolvedValue({ decoded: true }),
+      getAsset: vi.fn(),
+      unload: vi.fn(),
+    };
+    const { app } = await setupRouteGraphics({ audioAsset });
+    const fontFace = { load: vi.fn().mockResolvedValue(undefined) };
+    const FontFaceMock = vi.fn(function FontFaceMock() {
+      return fontFace;
+    });
+    const fontSet = {
+      add: vi.fn(),
+      delete: vi.fn(),
+    };
+    vi.stubGlobal("FontFace", FontFaceMock);
+    Object.defineProperty(document, "fonts", {
+      value: fontSet,
+      configurable: true,
+    });
+    vi.spyOn(URL, "createObjectURL").mockReturnValue(
+      "blob:http://route-graphics/font",
+    );
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+
+    try {
+      await app.loadAssets({
+        click: {
+          buffer: new Uint8Array([1, 2, 3]).buffer,
+          type: "audio/mpeg",
+        },
+        dialogueFont: {
+          buffer: new Uint8Array([4, 5, 6]).buffer,
+          type: "font/woff2",
+        },
+      });
+
+      await expect(
+        app.unloadAssets(["click", "dialogueFont"]),
+      ).resolves.toEqual(["click", "dialogueFont"]);
+      expect(audioAsset.unload).toHaveBeenCalledWith("click");
+      expect(fontSet.delete).toHaveBeenCalledWith(fontFace);
+    } finally {
+      delete document.fonts;
+    }
+  });
+
+  it("emits WebGL context lifecycle events", async () => {
+    const eventHandler = vi.fn();
+    const { app } = await setupRouteGraphics({
+      initOptions: { eventHandler },
+    });
+    const lostEvent = new Event("webglcontextlost", { cancelable: true });
+
+    app.canvas.dispatchEvent(lostEvent);
+    app.canvas.dispatchEvent(new Event("webglcontextrestored"));
+
+    expect(lostEvent.defaultPrevented).toBe(true);
+    expect(eventHandler).toHaveBeenCalledWith("rendererContextLost", {});
+    expect(eventHandler).toHaveBeenCalledWith("rendererContextRestored", {});
+  });
 
   it("loads video assets through lazy HTML video textures", async () => {
     const { app, pixiMock } = await setupRouteGraphics();
@@ -521,6 +651,55 @@ describe("RouteGraphics public API", () => {
         );
       }),
     ).toBe(true);
+  });
+
+  it("unloads video textures and revokes buffer source URLs", async () => {
+    const { app, pixiMock } = await setupRouteGraphics();
+    let video;
+    const createObjectURL = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:http://route-graphics/video-unload");
+    const revokeObjectURL = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {});
+    const originalCreateElement = document.createElement.bind(document);
+    const createElement = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tagName, ...args) => {
+        const element = originalCreateElement(tagName, ...args);
+        if (tagName === "video") {
+          video = element;
+          element.load = vi.fn();
+          element.pause = vi.fn();
+        }
+        return element;
+      });
+
+    try {
+      await app.loadAssets({
+        cutscene: {
+          buffer: new Uint8Array([1, 2, 3]).buffer,
+          type: "video/mp4",
+        },
+      });
+      const texture = pixiMock.Assets.cache.get("cutscene");
+
+      await expect(app.unloadAssets(["cutscene"])).resolves.toEqual([
+        "cutscene",
+      ]);
+
+      expect(video.pause).toHaveBeenCalledTimes(1);
+      expect(video.querySelector("source")).toBeNull();
+      expect(texture.destroy).toHaveBeenCalledWith(true);
+      expect(pixiMock.Assets.cache.remove).toHaveBeenCalledWith("cutscene");
+      expect(revokeObjectURL).toHaveBeenCalledWith(
+        "blob:http://route-graphics/video-unload",
+      );
+    } finally {
+      createElement.mockRestore();
+      createObjectURL.mockRestore();
+      revokeObjectURL.mockRestore();
+    }
   });
 
   it("awaits audio asset decoding during loadAssets", async () => {

--- a/spec/audio/audioAsset.spec.js
+++ b/spec/audio/audioAsset.spec.js
@@ -74,6 +74,53 @@ describe("AudioAsset", () => {
     expect(AudioAsset.getAsset("click")).toBe(decodedBuffer);
   });
 
+  it("unloads decoded audio and permits the key to be loaded again", async () => {
+    const { AudioAsset, context, decodedBuffer } = await setupAudioAsset();
+    const arrayBuffer = new Uint8Array([1, 2, 3]).buffer;
+
+    await AudioAsset.load("click", arrayBuffer);
+
+    expect(AudioAsset.unload("click")).toBe(true);
+    expect(AudioAsset.getAsset("click")).toBeUndefined();
+    expect(AudioAsset.unload("click")).toBe(false);
+
+    await expect(AudioAsset.load("click", arrayBuffer)).resolves.toBe(
+      decodedBuffer,
+    );
+    expect(context.decodeAudioData).toHaveBeenCalledTimes(2);
+    expect(AudioAsset.getAsset("click")).toBe(decodedBuffer);
+  });
+
+  it("does not repopulate the cache when an in-flight decode is unloaded", async () => {
+    vi.resetModules();
+
+    let resolveDecode;
+    const decodedBuffer = { decoded: true };
+    const context = {
+      decodeAudioData: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveDecode = () => resolve(decodedBuffer);
+          }),
+      ),
+    };
+    window.AudioContext = vi.fn(function AudioContextMock() {
+      return context;
+    });
+    window.webkitAudioContext = undefined;
+    const { AudioAsset } = await import("../../src/AudioAsset.js");
+    const loadPromise = AudioAsset.load(
+      "voice-line",
+      new Uint8Array([1, 2, 3]).buffer,
+    );
+
+    expect(AudioAsset.unload("voice-line")).toBe(true);
+    resolveDecode();
+    await expect(loadPromise).resolves.toBe(decodedBuffer);
+
+    expect(AudioAsset.getAsset("voice-line")).toBeUndefined();
+  });
+
   it("rejects decode failures with asset context and root cause", async () => {
     vi.resetModules();
 

--- a/src/AudioAsset.js
+++ b/src/AudioAsset.js
@@ -39,20 +39,25 @@ const load = (key, arrayBuffer) => {
     return;
   }
 
-  loadingAssets[key] = getAudioContext()
+  const loadPromise = getAudioContext()
     .decodeAudioData(arrayBuffer)
     .then((audioBuffer) => {
-      loadedAssets[key] = audioBuffer;
+      if (loadingAssets[key] === loadPromise) {
+        loadedAssets[key] = audioBuffer;
+      }
       return audioBuffer;
     })
     .catch((error) => {
       throw createAudioDecodeError(key, error);
     })
     .finally(() => {
-      delete loadingAssets[key];
+      if (loadingAssets[key] === loadPromise) {
+        delete loadingAssets[key];
+      }
     });
 
-  return loadingAssets[key];
+  loadingAssets[key] = loadPromise;
+  return loadPromise;
 };
 
 const getAsset = (url) => {
@@ -60,7 +65,15 @@ const getAsset = (url) => {
   return arrayBuffer;
 };
 
+const unload = (key) => {
+  const hadAsset = !!loadedAssets[key] || !!loadingAssets[key];
+  delete loadedAssets[key];
+  delete loadingAssets[key];
+  return hadAsset;
+};
+
 export const AudioAsset = {
   load,
   getAsset,
+  unload,
 };

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -340,6 +340,24 @@ const createRouteGraphics = () => {
   let canvasContextMenuListener;
 
   /**
+   * @type {(event: Event) => void | undefined}
+   */
+  let canvasWebglContextLostListener;
+
+  /**
+   * @type {(event: Event) => void | undefined}
+   */
+  let canvasWebglContextRestoredListener;
+
+  /**
+   * Assets created by this Route Graphics instance and eligible for explicit
+   * unload. Cache entries owned by another instance are intentionally not
+   * claimed when encountered.
+   * @type {Map<string, { category: string, value?: unknown, managedByAssets?: boolean }>}
+   */
+  const loadedAssetRecords = new Map();
+
+  /**
    * Video source URLs created or attached in loadAssets; revokable blob URLs
    * are cleaned up on destroy.
    * @type {Map<string, { url: string, revokable: boolean }>}
@@ -636,13 +654,82 @@ const createRouteGraphics = () => {
     });
   };
 
+  const revokeVideoSourceUrl = (key) => {
+    const value = videoSourceUrls.get(key);
+    if (value?.revokable === true && typeof value?.url === "string") {
+      URL.revokeObjectURL(value.url);
+    }
+    videoSourceUrls.delete(key);
+  };
+
   const revokeVideoBlobUrls = () => {
-    for (const value of videoSourceUrls.values()) {
-      if (value?.revokable === true && typeof value?.url === "string") {
-        URL.revokeObjectURL(value.url);
+    for (const key of videoSourceUrls.keys()) {
+      revokeVideoSourceUrl(key);
+    }
+  };
+
+  const recordLoadedAsset = (key, record) => {
+    loadedAssetRecords.set(key, record);
+    return record.value;
+  };
+
+  const releaseTextureResource = (resource) => {
+    const isVideoElement =
+      resource?.nodeName === "VIDEO" ||
+      (typeof HTMLVideoElement !== "undefined" &&
+        resource instanceof HTMLVideoElement);
+    if (isVideoElement) {
+      resource.pause();
+      resource.removeAttribute("src");
+      resource.querySelectorAll("source").forEach((source) => source.remove());
+      resource.load();
+      return;
+    }
+
+    if (typeof resource?.close === "function") {
+      resource.close();
+    }
+  };
+
+  const unloadTextureRecord = async (key, record) => {
+    const texture = record.value;
+    const resource = texture?.source?.resource;
+
+    if (record.managedByAssets === true) {
+      await Assets.unload(key);
+    } else {
+      if (Assets.cache.has(key)) {
+        Assets.cache.remove(key);
+      }
+      if (!texture?.destroyed) {
+        texture?.destroy?.(true);
       }
     }
-    videoSourceUrls.clear();
+
+    releaseTextureResource(resource);
+  };
+
+  const unloadAsset = async (key) => {
+    const record = loadedAssetRecords.get(key);
+    if (!record) {
+      return false;
+    }
+
+    if (record.category === "audio") {
+      AudioAsset.unload(key);
+    } else if (record.category === "font") {
+      document.fonts?.delete?.(record.value);
+    } else if (record.category === "texture" || record.category === "video") {
+      await unloadTextureRecord(key, record);
+      if (record.category === "video") {
+        revokeVideoSourceUrl(key);
+      }
+    }
+
+    if (loadedAssetRecords.get(key) === record) {
+      loadedAssetRecords.delete(key);
+    }
+    return true;
   };
 
   const loadVideoTexture = async ({ key, sourceUrl, mimeType }) => {
@@ -947,6 +1034,28 @@ const createRouteGraphics = () => {
         event.preventDefault();
       };
       app.canvas.addEventListener("contextmenu", canvasContextMenuListener);
+      canvasWebglContextLostListener = (event) => {
+        event.preventDefault();
+        const payload = {};
+        if (
+          typeof event.statusMessage === "string" &&
+          event.statusMessage.length > 0
+        ) {
+          payload.statusMessage = event.statusMessage;
+        }
+        eventHandler?.("rendererContextLost", payload);
+      };
+      canvasWebglContextRestoredListener = () => {
+        eventHandler?.("rendererContextRestored", {});
+      };
+      app.canvas.addEventListener(
+        "webglcontextlost",
+        canvasWebglContextLostListener,
+      );
+      app.canvas.addEventListener(
+        "webglcontextrestored",
+        canvasWebglContextRestoredListener,
+      );
 
       backgroundGraphic = new Graphics();
       backgroundGraphic.label = "__route_graphics_background__";
@@ -1022,6 +1131,20 @@ const createRouteGraphics = () => {
         );
         canvasContextMenuListener = undefined;
       }
+      if (canvasWebglContextLostListener && app?.canvas) {
+        app.canvas.removeEventListener(
+          "webglcontextlost",
+          canvasWebglContextLostListener,
+        );
+        canvasWebglContextLostListener = undefined;
+      }
+      if (canvasWebglContextRestoredListener && app?.canvas) {
+        app.canvas.removeEventListener(
+          "webglcontextrestored",
+          canvasWebglContextRestoredListener,
+        );
+        canvasWebglContextRestoredListener = undefined;
+      }
       app?.inputDomBridge?.destroy?.();
       keyboardManager?.destroy();
       clearPendingSounds();
@@ -1091,8 +1214,16 @@ const createRouteGraphics = () => {
               asset,
             },
             async () => {
+              const existingRecord = loadedAssetRecords.get(key);
+              if (existingRecord?.category === "audio") {
+                return existingRecord.value;
+              }
               assertAssetBuffer(asset, "Audio");
-              return AudioAsset.load(key, asset.buffer);
+              const audioBuffer = await AudioAsset.load(key, asset.buffer);
+              return recordLoadedAsset(key, {
+                category: "audio",
+                value: audioBuffer,
+              });
             },
           ),
         });
@@ -1109,6 +1240,10 @@ const createRouteGraphics = () => {
               asset,
             },
             async () => {
+              const existingRecord = loadedAssetRecords.get(key);
+              if (existingRecord?.category === "font") {
+                return existingRecord.value;
+              }
               assertAssetBuffer(asset, "Font");
               const blob = new Blob([asset.buffer], { type: asset.type });
               const url = URL.createObjectURL(blob);
@@ -1117,6 +1252,10 @@ const createRouteGraphics = () => {
               try {
                 await fontFace.load();
                 document.fonts.add(fontFace);
+                return recordLoadedAsset(key, {
+                  category: "font",
+                  value: fontFace,
+                });
               } finally {
                 URL.revokeObjectURL(url);
               }
@@ -1139,14 +1278,23 @@ const createRouteGraphics = () => {
               asset,
             },
             async () => {
+              const existingRecord = loadedAssetRecords.get(key);
+              if (existingRecord?.category === "texture") {
+                return existingRecord.value;
+              }
               if (Assets.cache.has(key)) {
                 return Assets.cache.get(key);
               }
 
               if (asset?.source === "url" && typeof asset?.url === "string") {
-                return Assets.load({
+                const texture = await Assets.load({
                   alias: key,
                   src: asset.url,
+                });
+                return recordLoadedAsset(key, {
+                  category: "texture",
+                  value: texture,
+                  managedByAssets: true,
                 });
               }
 
@@ -1159,7 +1307,11 @@ const createRouteGraphics = () => {
               // directly from the cache instead of attempting a relative URL fetch.
               Assets.cache.set(key, texture);
 
-              return texture;
+              return recordLoadedAsset(key, {
+                category: "texture",
+                value: texture,
+                managedByAssets: false,
+              });
             },
           ),
         }),
@@ -1178,6 +1330,10 @@ const createRouteGraphics = () => {
               asset,
             },
             async () => {
+              const existingRecord = loadedAssetRecords.get(key);
+              if (existingRecord?.category === "video") {
+                return existingRecord.value;
+              }
               if (Assets.cache.has(key)) {
                 return Assets.cache.get(key);
               }
@@ -1199,10 +1355,15 @@ const createRouteGraphics = () => {
               });
 
               try {
-                return await loadVideoTexture({
+                const texture = await loadVideoTexture({
                   key,
                   sourceUrl,
                   mimeType: asset?.type,
+                });
+                return recordLoadedAsset(key, {
+                  category: "video",
+                  value: texture,
+                  managedByAssets: false,
                 });
               } catch (error) {
                 videoSourceUrls.delete(key);
@@ -1230,12 +1391,72 @@ const createRouteGraphics = () => {
         .filter(Boolean);
     },
 
+    /**
+     * Unload assets previously created by this Route Graphics instance.
+     * Unknown or already-unloaded keys are ignored.
+     * @param {string[]} assetIds
+     * @returns {Promise<string[]>} Asset IDs successfully unloaded
+     */
+    unloadAssets: async (assetIds) => {
+      if (!Array.isArray(assetIds)) {
+        throw new Error("assetIds must be an array");
+      }
+
+      const uniqueAssetIds = Array.from(
+        new Set(
+          assetIds.filter(
+            (assetId) => typeof assetId === "string" && assetId.length > 0,
+          ),
+        ),
+      );
+      const unloadedAssetIds = [];
+      const failures = [];
+
+      for (const assetId of uniqueAssetIds) {
+        try {
+          if (await unloadAsset(assetId)) {
+            unloadedAssetIds.push(assetId);
+          }
+        } catch (cause) {
+          const error = new Error(`Could not unload asset "${assetId}".`, {
+            cause,
+          });
+          error.details = {
+            assetKey: assetId,
+            phase: "unload",
+            cause: getErrorMessage(cause),
+          };
+          failures.push(error);
+        }
+      }
+
+      if (failures.length === 1) {
+        throw failures[0];
+      }
+      if (failures.length > 1) {
+        throw new AggregateError(
+          failures,
+          `Could not unload ${failures.length} assets.`,
+        );
+      }
+
+      return unloadedAssetIds;
+    },
+
     loadAudioAssets: async (urls) => {
       return Promise.all(
         urls.map(async (url) => {
+          const existingRecord = loadedAssetRecords.get(url);
+          if (existingRecord?.category === "audio") {
+            return existingRecord.value;
+          }
           const response = await fetch(url);
           const arrayBuffer = await response.arrayBuffer();
-          return AudioAsset.load(url, arrayBuffer);
+          const audioBuffer = await AudioAsset.load(url, arrayBuffer);
+          return recordLoadedAsset(url, {
+            category: "audio",
+            value: audioBuffer,
+          });
         }),
       );
     },


### PR DESCRIPTION
## Summary
- add per-instance `unloadAssets(assetIds)` support for textures, videos, audio, and fonts, with safe reload behavior
- emit renderer-agnostic context loss and restoration lifecycle events
- document the lifecycle contract and bump the feature version to `1.25.0`
- add focused public API and audio cache regression coverage

## Validation
- `bun run lint`
- `TMPDIR=/tmp/route-graphics-vitest bunx vitest run --no-file-parallelism` (85 files, 612 tests)
- pre-push `bun run test` (85 files, 612 tests)
- `bun run build`
- Chromium smoke test: buffer texture load/unload/reload plus a real `WEBGL_lose_context` loss/restore cycle
