### PR TITLE
fix: harden shared asset lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,16 @@ await app.unloadAssets(["circle-red", "bgm-1"]);
 
 `unloadAssets()` removes renderer cache entries and releases texture, video,
 audio, and font resources owned by that Route Graphics instance. Unknown or
-already-unloaded keys are ignored, and released keys can be loaded again.
+already-unloaded keys are ignored, shared resources remain alive until their
+last Route Graphics consumer unloads them, and released keys can be loaded
+again.
 
 The event handler also receives `rendererContextLost` and
 `rendererContextRestored` lifecycle events. Fallback UI should live outside the
 renderer so it remains available while the graphics context is unavailable.
+WebGPU device loss emits `rendererContextLost`; because a lost WebGPU device is
+not restorable, consumers must recreate the Route Graphics instance rather than
+wait for `rendererContextRestored`.
 
 For complete usage details, go to:
 

--- a/docs/api-naming.md
+++ b/docs/api-naming.md
@@ -125,6 +125,9 @@ Event names are semantic Route Graphics events, not native input events.
 - These are renderer lifecycle events, not element interaction events.
 - Consumers should use them to show renderer-independent fallback UI and
   rebuild renderer-owned assets.
+- WebGL can emit both events. WebGPU device loss emits `rendererContextLost`,
+  but a lost WebGPU device cannot be restored; recreate the Route Graphics
+  instance instead of waiting for `rendererContextRestored`.
 - Browser-native names such as `webglcontextlost` and `webglcontextrestored`
   remain internal implementation details.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -10,9 +10,31 @@ const createMockBounds = (width, height) => ({
   },
 });
 
-const createPixiModuleMock = () => {
+const createPixiModuleMock = ({ rendererOverrides = {} } = {}) => {
   let lastApplication = null;
   const assetCache = new Map();
+  const assetCacheGroups = new Map();
+  const assetValues = new Map();
+
+  const removeCachedAsset = (key) => {
+    const cacheKeys = assetCacheGroups.get(key) ?? [key];
+    cacheKeys.forEach((cacheKey) => assetCache.delete(cacheKey));
+    assetCacheGroups.delete(key);
+    assetValues.delete(key);
+  };
+
+  const setCachedAsset = (key, value) => {
+    removeCachedAsset(key);
+    const cacheKeys = Array.isArray(value)
+      ? value.map((_, index) => `${key}${index === 0 ? "" : index + 1}`)
+      : [key];
+
+    cacheKeys.forEach((cacheKey, index) => {
+      assetCache.set(cacheKey, Array.isArray(value) ? value[index] : value);
+    });
+    assetCacheGroups.set(key, cacheKeys);
+    assetValues.set(key, value);
+  };
 
   class MockDisplayObject {
     constructor(label = null) {
@@ -240,6 +262,7 @@ const createPixiModuleMock = () => {
         extract: {
           base64: vi.fn(),
         },
+        ...rendererOverrides,
       };
       this.canvas = document.createElement("canvas");
     }
@@ -259,15 +282,16 @@ const createPixiModuleMock = () => {
       registerPlugin: vi.fn(),
       load: vi.fn(),
       unload: vi.fn(async (key) => {
-        const asset = assetCache.get(key);
-        assetCache.delete(key);
-        asset?.destroy?.(true);
+        const asset = assetValues.get(key) ?? assetCache.get(key);
+        removeCachedAsset(key);
+        const assets = Array.isArray(asset) ? asset : [asset];
+        assets.forEach((value) => value?.destroy?.(true));
       }),
       cache: {
         has: vi.fn((key) => assetCache.has(key)),
         get: vi.fn((key) => assetCache.get(key)),
-        set: vi.fn((key, value) => assetCache.set(key, value)),
-        remove: vi.fn((key) => assetCache.delete(key)),
+        set: vi.fn(setCachedAsset),
+        remove: vi.fn(removeCachedAsset),
       },
     },
     detectVideoAlphaMode: vi.fn().mockResolvedValue("premultiplied-alpha"),
@@ -356,13 +380,14 @@ let currentApp = null;
 const setupRouteGraphics = async ({
   initOptions = {},
   pluginsFactory,
+  rendererOverrides,
   audioAsset = {
     load: vi.fn(),
     getAsset: vi.fn(),
     unload: vi.fn(),
   },
 } = {}) => {
-  const pixiMock = createPixiModuleMock();
+  const pixiMock = createPixiModuleMock({ rendererOverrides });
 
   vi.doMock("pixi.js", () => pixiMock);
   vi.doMock("../src/AudioStage.js", () => ({
@@ -396,7 +421,7 @@ const setupRouteGraphics = async ({
 
   currentApp = app;
 
-  return { app, pixiMock, audioAsset };
+  return { app, pixiMock, audioAsset, createRouteGraphics };
 };
 
 const getAutoAnimationTick = (pixiMock) =>
@@ -461,20 +486,21 @@ describe("RouteGraphics public API", () => {
 
   it("uses Pixi asset unloading for URL-backed textures", async () => {
     const { app, pixiMock } = await setupRouteGraphics();
+    const sourceUrl = "https://cdn.example.test/background.png";
     const resource = { close: vi.fn() };
     const texture = {
       source: { resource },
       destroy: vi.fn(),
     };
-    pixiMock.Assets.load.mockImplementation(async ({ alias }) => {
-      pixiMock.Assets.cache.set(alias, texture);
+    pixiMock.Assets.load.mockImplementation(async (url) => {
+      pixiMock.Assets.cache.set(url, texture);
       return texture;
     });
 
     await app.loadAssets({
       background: {
         source: "url",
-        url: "https://cdn.example.test/background.png",
+        url: sourceUrl,
         type: "image/png",
       },
     });
@@ -482,9 +508,332 @@ describe("RouteGraphics public API", () => {
       "background",
     ]);
 
-    expect(pixiMock.Assets.unload).toHaveBeenCalledWith("background");
+    expect(pixiMock.Assets.load).toHaveBeenCalledWith(sourceUrl);
+    expect(pixiMock.Assets.unload).toHaveBeenCalledWith(sourceUrl);
     expect(texture.destroy).toHaveBeenCalledWith(true);
     expect(resource.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains URL-backed textures shared by multiple aliases", async () => {
+    const { app, pixiMock } = await setupRouteGraphics();
+    const sourceUrl = "https://cdn.example.test/shared-background.png";
+    const resource = { close: vi.fn() };
+    const texture = {
+      source: { resource },
+      destroy: vi.fn(),
+    };
+    pixiMock.Assets.load.mockImplementation(async (url) => {
+      if (!pixiMock.Assets.cache.has(url)) {
+        pixiMock.Assets.cache.set(url, texture);
+      }
+      return pixiMock.Assets.cache.get(url);
+    });
+
+    await app.loadAssets({
+      backgroundDay: {
+        source: "url",
+        url: sourceUrl,
+        type: "image/png",
+      },
+      backgroundNight: {
+        source: "url",
+        url: sourceUrl,
+        type: "image/png",
+      },
+    });
+
+    await expect(app.unloadAssets(["backgroundDay"])).resolves.toEqual([
+      "backgroundDay",
+    ]);
+    expect(pixiMock.Assets.unload).not.toHaveBeenCalled();
+    expect(texture.destroy).not.toHaveBeenCalled();
+    expect(resource.close).not.toHaveBeenCalled();
+    expect(pixiMock.Assets.cache.get("backgroundNight")).toBe(texture);
+
+    await expect(app.unloadAssets(["backgroundNight"])).resolves.toEqual([
+      "backgroundNight",
+    ]);
+    expect(pixiMock.Assets.unload).toHaveBeenCalledTimes(1);
+    expect(pixiMock.Assets.unload).toHaveBeenCalledWith(sourceUrl);
+    expect(texture.destroy).toHaveBeenCalledWith(true);
+    expect(resource.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares ownership for relative and absolute forms of one Pixi URL", async () => {
+    const { app, pixiMock } = await setupRouteGraphics();
+    const relativeUrl = "/shared/equivalent.png";
+    const absoluteUrl = "https://cdn.example.test/shared/equivalent.png";
+    pixiMock.Assets.resolver = {
+      resolve: vi.fn(() => ({ src: absoluteUrl })),
+    };
+    const texture = {
+      source: { resource: { close: vi.fn() } },
+      destroy: vi.fn(),
+    };
+    pixiMock.Assets.load.mockImplementation(async (url) => {
+      pixiMock.Assets.cache.set(url, texture);
+      return texture;
+    });
+
+    await app.loadAssets({
+      relativeBackground: {
+        source: "url",
+        url: relativeUrl,
+        type: "image/png",
+      },
+      absoluteBackground: {
+        source: "url",
+        url: absoluteUrl,
+        type: "image/png",
+      },
+    });
+
+    expect(pixiMock.Assets.load).toHaveBeenCalledTimes(1);
+    await app.unloadAssets(["relativeBackground"]);
+    expect(pixiMock.Assets.unload).not.toHaveBeenCalled();
+    expect(texture.destroy).not.toHaveBeenCalled();
+    expect(pixiMock.Assets.cache.get("absoluteBackground")).toBe(texture);
+
+    await app.unloadAssets(["absoluteBackground"]);
+    expect(pixiMock.Assets.unload).toHaveBeenCalledTimes(1);
+    expect(texture.destroy).toHaveBeenCalledWith(true);
+  });
+
+  it("reserves URL texture ownership before a cross-instance load settles", async () => {
+    const {
+      app: firstApp,
+      pixiMock,
+      createRouteGraphics,
+    } = await setupRouteGraphics();
+    const secondApp = createRouteGraphics();
+    await secondApp.init({
+      width: 320,
+      height: 240,
+      backgroundColor: 0x000000,
+      plugins: { elements: [], animations: [], audio: [] },
+    });
+    const sourceUrl = "https://cdn.example.test/racing-background.png";
+    const texture = {
+      source: { resource: { close: vi.fn() } },
+      destroy: vi.fn(),
+    };
+    pixiMock.Assets.load.mockImplementation(async (url) => {
+      pixiMock.Assets.cache.set(url, texture);
+      return texture;
+    });
+
+    try {
+      await firstApp.loadAssets({
+        firstBackground: {
+          source: "url",
+          url: sourceUrl,
+          type: "image/png",
+        },
+      });
+
+      const secondLoadPromise = secondApp.loadAssets({
+        secondBackground: {
+          source: "url",
+          url: sourceUrl,
+          type: "image/png",
+        },
+      });
+      await expect(firstApp.unloadAssets(["firstBackground"])).resolves.toEqual(
+        ["firstBackground"],
+      );
+
+      expect(pixiMock.Assets.unload).not.toHaveBeenCalled();
+      expect(texture.destroy).not.toHaveBeenCalled();
+      await expect(secondLoadPromise).resolves.toEqual([texture]);
+      expect(pixiMock.Assets.cache.get("secondBackground")).toBe(texture);
+
+      await secondApp.unloadAssets(["secondBackground"]);
+      expect(pixiMock.Assets.unload).toHaveBeenCalledWith(sourceUrl);
+      expect(texture.destroy).toHaveBeenCalledWith(true);
+    } finally {
+      secondApp.destroy();
+    }
+  });
+
+  it("removes every logical cache key for URL texture arrays before reload", async () => {
+    const { app, pixiMock } = await setupRouteGraphics();
+    const sourceUrl = "https://cdn.example.test/characters.json";
+    const loadedTextureArrays = [];
+    pixiMock.Assets.load.mockImplementation(async (url) => {
+      const textures = [
+        {
+          source: { resource: { close: vi.fn() } },
+          destroy: vi.fn(),
+        },
+        {
+          source: { resource: { close: vi.fn() } },
+          destroy: vi.fn(),
+        },
+      ];
+      loadedTextureArrays.push(textures);
+      pixiMock.Assets.cache.set(url, textures);
+      return textures;
+    });
+    const asset = {
+      source: "url",
+      url: sourceUrl,
+      type: "application/json",
+    };
+
+    await app.loadAssets({ characters: asset });
+    expect(pixiMock.Assets.cache.get("characters")).toBe(
+      loadedTextureArrays[0][0],
+    );
+    expect(pixiMock.Assets.cache.get("characters2")).toBe(
+      loadedTextureArrays[0][1],
+    );
+
+    await app.unloadAssets(["characters"]);
+    expect(pixiMock.Assets.cache.has("characters")).toBe(false);
+    expect(pixiMock.Assets.cache.has("characters2")).toBe(false);
+    expect(loadedTextureArrays[0][0].destroy).toHaveBeenCalledWith(true);
+    expect(loadedTextureArrays[0][1].destroy).toHaveBeenCalledWith(true);
+
+    await app.loadAssets({ characters: asset });
+    expect(pixiMock.Assets.load).toHaveBeenCalledTimes(2);
+    expect(pixiMock.Assets.cache.get("characters")).toBe(
+      loadedTextureArrays[1][0],
+    );
+    expect(pixiMock.Assets.cache.get("characters2")).toBe(
+      loadedTextureArrays[1][1],
+    );
+
+    await app.unloadAssets(["characters"]);
+  });
+
+  it("reloads a URL-backed key from its new source URL", async () => {
+    const { app, pixiMock } = await setupRouteGraphics();
+    const firstUrl = "https://cdn.example.test/background.png?token=old";
+    const secondUrl = "https://cdn.example.test/background.png?token=new";
+    const loadedTextures = [];
+    pixiMock.Assets.load.mockImplementation(async (url) => {
+      const texture = {
+        source: { resource: { close: vi.fn() } },
+        destroy: vi.fn(),
+        url,
+      };
+      loadedTextures.push(texture);
+      pixiMock.Assets.cache.set(url, texture);
+      return texture;
+    });
+
+    await app.loadAssets({
+      background: { source: "url", url: firstUrl, type: "image/png" },
+    });
+    await app.unloadAssets(["background"]);
+    await app.loadAssets({
+      background: { source: "url", url: secondUrl, type: "image/png" },
+    });
+
+    expect(pixiMock.Assets.load.mock.calls.map(([url]) => url)).toEqual([
+      firstUrl,
+      secondUrl,
+    ]);
+    expect(pixiMock.Assets.unload).toHaveBeenCalledWith(firstUrl);
+    expect(loadedTextures[0].destroy).toHaveBeenCalledWith(true);
+    expect(pixiMock.Assets.cache.get("background")).toBe(loadedTextures[1]);
+
+    await app.unloadAssets(["background"]);
+  });
+
+  it("honors unload requests while a texture load is pending", async () => {
+    const { app, pixiMock } = await setupRouteGraphics();
+    let resolveImageBitmap;
+    const imageBitmap = { width: 8, height: 6, close: vi.fn() };
+    const createImageBitmap = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveImageBitmap = resolve;
+        }),
+    );
+    vi.stubGlobal("createImageBitmap", createImageBitmap);
+
+    const loadPromise = app.loadAssets({
+      portrait: {
+        buffer: new Uint8Array([1, 2, 3]).buffer,
+        type: "image/png",
+      },
+    });
+    await vi.waitFor(() => {
+      expect(createImageBitmap).toHaveBeenCalledTimes(1);
+    });
+
+    let unloadSettled = false;
+    const unloadPromise = app.unloadAssets(["portrait"]).then((result) => {
+      unloadSettled = true;
+      return result;
+    });
+    await Promise.resolve();
+    expect(unloadSettled).toBe(false);
+
+    resolveImageBitmap(imageBitmap);
+    await loadPromise;
+    await expect(unloadPromise).resolves.toEqual(["portrait"]);
+
+    const texture = pixiMock.Assets.cache.set.mock.calls.find(
+      ([key]) => key === "portrait",
+    )?.[1];
+    expect(pixiMock.Assets.cache.has("portrait")).toBe(false);
+    expect(texture.destroy).toHaveBeenCalledWith(true);
+    expect(imageBitmap.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates pending buffer texture loads across instances", async () => {
+    const {
+      app: firstApp,
+      pixiMock,
+      createRouteGraphics,
+    } = await setupRouteGraphics();
+    const secondApp = createRouteGraphics();
+    await secondApp.init({
+      width: 320,
+      height: 240,
+      backgroundColor: 0x000000,
+      plugins: { elements: [], animations: [], audio: [] },
+    });
+    let resolveImageBitmap;
+    const imageBitmap = { width: 8, height: 6, close: vi.fn() };
+    const createImageBitmap = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveImageBitmap = resolve;
+        }),
+    );
+    vi.stubGlobal("createImageBitmap", createImageBitmap);
+    const asset = {
+      buffer: new Uint8Array([1, 2, 3]).buffer,
+      type: "image/png",
+    };
+
+    try {
+      const firstLoad = firstApp.loadAssets({ portrait: asset });
+      const secondLoad = secondApp.loadAssets({ portrait: asset });
+
+      expect(createImageBitmap).toHaveBeenCalledTimes(1);
+      resolveImageBitmap(imageBitmap);
+      const [[firstTexture], [secondTexture]] = await Promise.all([
+        firstLoad,
+        secondLoad,
+      ]);
+
+      expect(firstTexture).toBe(secondTexture);
+      expect(pixiMock.Assets.cache.get("portrait")).toBe(firstTexture);
+
+      await firstApp.unloadAssets(["portrait"]);
+      expect(firstTexture.destroy).not.toHaveBeenCalled();
+      expect(pixiMock.Assets.cache.get("portrait")).toBe(firstTexture);
+
+      await secondApp.unloadAssets(["portrait"]);
+      expect(firstTexture.destroy).toHaveBeenCalledWith(true);
+      expect(imageBitmap.close).toHaveBeenCalledTimes(1);
+    } finally {
+      secondApp.destroy();
+    }
   });
 
   it("unloads audio and font assets", async () => {
@@ -534,6 +883,55 @@ describe("RouteGraphics public API", () => {
     }
   });
 
+  it("retains audio shared by separate Route Graphics instances", async () => {
+    const decodedAudio = { decoded: true };
+    let cachedAudio;
+    const audioAsset = {
+      load: vi.fn(async () => {
+        cachedAudio ??= decodedAudio;
+        return cachedAudio;
+      }),
+      getAsset: vi.fn(() => cachedAudio),
+      unload: vi.fn(() => {
+        cachedAudio = undefined;
+        return true;
+      }),
+    };
+    const { app: firstApp, createRouteGraphics } = await setupRouteGraphics({
+      audioAsset,
+    });
+    const secondApp = createRouteGraphics();
+    await secondApp.init({
+      width: 320,
+      height: 240,
+      backgroundColor: 0x000000,
+      plugins: { elements: [], animations: [], audio: [] },
+    });
+    const clickAsset = {
+      buffer: new Uint8Array([1, 2, 3]).buffer,
+      type: "audio/mpeg",
+    };
+
+    try {
+      await firstApp.loadAssets({ click: clickAsset });
+      await secondApp.loadAssets({ click: clickAsset });
+
+      await expect(firstApp.unloadAssets(["click"])).resolves.toEqual([
+        "click",
+      ]);
+      expect(audioAsset.unload).not.toHaveBeenCalled();
+      expect(audioAsset.getAsset("click")).toBe(decodedAudio);
+
+      await expect(secondApp.unloadAssets(["click"])).resolves.toEqual([
+        "click",
+      ]);
+      expect(audioAsset.unload).toHaveBeenCalledTimes(1);
+      expect(audioAsset.unload).toHaveBeenCalledWith("click");
+    } finally {
+      secondApp.destroy();
+    }
+  });
+
   it("emits WebGL context lifecycle events", async () => {
     const eventHandler = vi.fn();
     const { app } = await setupRouteGraphics({
@@ -547,6 +945,34 @@ describe("RouteGraphics public API", () => {
     expect(lostEvent.defaultPrevented).toBe(true);
     expect(eventHandler).toHaveBeenCalledWith("rendererContextLost", {});
     expect(eventHandler).toHaveBeenCalledWith("rendererContextRestored", {});
+  });
+
+  it("emits context loss from the WebGPU fallback device", async () => {
+    let resolveDeviceLost;
+    const deviceLost = new Promise((resolve) => {
+      resolveDeviceLost = resolve;
+    });
+    const eventHandler = vi.fn();
+    await setupRouteGraphics({
+      initOptions: { eventHandler },
+      rendererOverrides: {
+        gpu: {
+          device: { lost: deviceLost },
+        },
+      },
+    });
+
+    resolveDeviceLost({
+      reason: "unknown",
+      message: "The GPU process exited.",
+    });
+
+    await vi.waitFor(() => {
+      expect(eventHandler).toHaveBeenCalledWith("rendererContextLost", {
+        reason: "unknown",
+        statusMessage: "The GPU process exited.",
+      });
+    });
   });
 
   it("loads video assets through lazy HTML video textures", async () => {
@@ -606,10 +1032,9 @@ describe("RouteGraphics public API", () => {
     }
 
     expect(pixiMock.Assets.load).toHaveBeenCalledTimes(1);
-    expect(pixiMock.Assets.load).toHaveBeenCalledWith({
-      alias: "urlTexture",
-      src: "blob:http://route-graphics/texture",
-    });
+    expect(pixiMock.Assets.load).toHaveBeenCalledWith(
+      "blob:http://route-graphics/texture",
+    );
     expect(pixiMock.Assets.cache.set).toHaveBeenCalledWith(
       "bufferVideo",
       expect.objectContaining({
@@ -696,6 +1121,83 @@ describe("RouteGraphics public API", () => {
         "blob:http://route-graphics/video-unload",
       );
     } finally {
+      createElement.mockRestore();
+      createObjectURL.mockRestore();
+      revokeObjectURL.mockRestore();
+    }
+  });
+
+  it("deduplicates pending video texture setup across instances", async () => {
+    const {
+      app: firstApp,
+      pixiMock,
+      createRouteGraphics,
+    } = await setupRouteGraphics();
+    const secondApp = createRouteGraphics();
+    await secondApp.init({
+      width: 320,
+      height: 240,
+      backgroundColor: 0x000000,
+      plugins: { elements: [], animations: [], audio: [] },
+    });
+    let resolveAlphaMode;
+    pixiMock.detectVideoAlphaMode.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveAlphaMode = resolve;
+        }),
+    );
+    const createObjectURL = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:http://route-graphics/shared-video");
+    const revokeObjectURL = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {});
+    const originalCreateElement = document.createElement.bind(document);
+    const videos = [];
+    const createElement = vi
+      .spyOn(document, "createElement")
+      .mockImplementation((tagName, ...args) => {
+        const element = originalCreateElement(tagName, ...args);
+        if (tagName === "video") {
+          videos.push(element);
+          element.load = vi.fn();
+          element.pause = vi.fn();
+        }
+        return element;
+      });
+    const asset = {
+      buffer: new Uint8Array([1, 2, 3]).buffer,
+      type: "video/mp4",
+    };
+
+    try {
+      const firstLoad = firstApp.loadAssets({ cutscene: asset });
+      const secondLoad = secondApp.loadAssets({ cutscene: asset });
+
+      expect(videos).toHaveLength(1);
+      expect(pixiMock.detectVideoAlphaMode).toHaveBeenCalledTimes(1);
+      resolveAlphaMode("premultiplied-alpha");
+      const [[firstTexture], [secondTexture]] = await Promise.all([
+        firstLoad,
+        secondLoad,
+      ]);
+
+      expect(firstTexture).toBe(secondTexture);
+      expect(pixiMock.Assets.cache.get("cutscene")).toBe(firstTexture);
+
+      await firstApp.unloadAssets(["cutscene"]);
+      expect(firstTexture.destroy).not.toHaveBeenCalled();
+      expect(videos[0].pause).not.toHaveBeenCalled();
+
+      await secondApp.unloadAssets(["cutscene"]);
+      expect(firstTexture.destroy).toHaveBeenCalledWith(true);
+      expect(videos[0].pause).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURL).toHaveBeenCalledWith(
+        "blob:http://route-graphics/shared-video",
+      );
+    } finally {
+      secondApp.destroy();
       createElement.mockRestore();
       createObjectURL.mockRestore();
       revokeObjectURL.mockRestore();

--- a/spec/audio/audioAsset.spec.js
+++ b/spec/audio/audioAsset.spec.js
@@ -41,8 +41,36 @@ describe("AudioAsset", () => {
       decodedBuffer,
     );
 
-    expect(context.decodeAudioData).toHaveBeenCalledWith(arrayBuffer);
+    const decodedInput = context.decodeAudioData.mock.calls[0][0];
+    expect(decodedInput).not.toBe(arrayBuffer);
+    expect(new Uint8Array(decodedInput)).toEqual(new Uint8Array(arrayBuffer));
     expect(AudioAsset.getAsset("click")).toBe(decodedBuffer);
+  });
+
+  it("can reload a manager-owned buffer after decoders detach their input", async () => {
+    vi.resetModules();
+
+    const decodedBuffer = { decoded: true };
+    const context = {
+      decodeAudioData: vi.fn((decodeBuffer) => {
+        structuredClone(decodeBuffer, { transfer: [decodeBuffer] });
+        return Promise.resolve(decodedBuffer);
+      }),
+    };
+    window.AudioContext = vi.fn(function AudioContextMock() {
+      return context;
+    });
+    window.webkitAudioContext = undefined;
+    const { AudioAsset } = await import("../../src/AudioAsset.js");
+    const managerBuffer = new Uint8Array([1, 2, 3]).buffer;
+
+    await AudioAsset.load("click", managerBuffer);
+    expect(managerBuffer.byteLength).toBe(3);
+    AudioAsset.unload("click");
+    await AudioAsset.load("click", managerBuffer);
+
+    expect(context.decodeAudioData).toHaveBeenCalledTimes(2);
+    expect(managerBuffer.byteLength).toBe(3);
   });
 
   it("reuses an in-flight decode for duplicate load requests", async () => {

--- a/src/AudioAsset.js
+++ b/src/AudioAsset.js
@@ -39,8 +39,11 @@ const load = (key, arrayBuffer) => {
     return;
   }
 
+  // decodeAudioData may detach its input. Decode a private copy so callers can
+  // reuse manager-owned buffers after unload or application recreation.
+  const decodeBuffer = arrayBuffer.slice(0);
   const loadPromise = getAudioContext()
-    .decodeAudioData(arrayBuffer)
+    .decodeAudioData(decodeBuffer)
     .then((audioBuffer) => {
       if (loadingAssets[key] === loadPromise) {
         loadedAssets[key] = audioBuffer;

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -43,6 +43,15 @@ import {
  * @typedef {Application & ApplicationWithAudioStageOptions} ApplicationWithAudioStage
  */
 
+// Pixi's asset cache and AudioAsset are module-global. Keep ownership global as
+// well so separate Route Graphics instances and logical aliases cannot release
+// a resource that another instance still uses.
+const sharedTextureAssetOwners = new Map();
+const sharedTextureAliasOwners = new Map();
+const sharedUrlTextureAssetOwners = new Map();
+const sharedPendingTextureLoads = new Map();
+const sharedAudioAssetOwners = new Map();
+
 const createRouteGraphics = () => {
   const VIDEO_TEXTURE_UPDATE_FPS = 30;
 
@@ -350,12 +359,26 @@ const createRouteGraphics = () => {
   let canvasWebglContextRestoredListener;
 
   /**
+   * Identity token used to ignore a WebGPU device-loss promise after destroy.
+   * @type {object|undefined}
+   */
+  let webgpuDeviceLossSubscription;
+
+  /**
    * Assets created by this Route Graphics instance and eligible for explicit
-   * unload. Cache entries owned by another instance are intentionally not
-   * claimed when encountered.
-   * @type {Map<string, { category: string, value?: unknown, managedByAssets?: boolean }>}
+   * unload. Known entries owned by another Route Graphics instance are
+   * retained as shared; unrelated external cache entries remain borrowed.
+   * @type {Map<string, { category: string, value?: unknown, sharedOwnership?: object, released?: boolean }>}
    */
   const loadedAssetRecords = new Map();
+
+  /**
+   * Loads currently running for this instance, keyed by their public asset ID.
+   * unloadAssets waits for these promises so an unload request always wins a
+   * race with a pending load.
+   * @type {Map<string, Promise<unknown>>}
+   */
+  const pendingAssetLoads = new Map();
 
   /**
    * Video source URLs created or attached in loadAssets; revokable blob URLs
@@ -662,15 +685,204 @@ const createRouteGraphics = () => {
     videoSourceUrls.delete(key);
   };
 
-  const revokeVideoBlobUrls = () => {
-    for (const key of videoSourceUrls.keys()) {
-      revokeVideoSourceUrl(key);
-    }
-  };
-
   const recordLoadedAsset = (key, record) => {
     loadedAssetRecords.set(key, record);
     return record.value;
+  };
+
+  const trackAssetLoad = (key, load) => {
+    const pendingLoad = pendingAssetLoads.get(key);
+    if (pendingLoad) {
+      return pendingLoad;
+    }
+
+    let resolveLoad;
+    let rejectLoad;
+    const loadPromise = new Promise((resolve, reject) => {
+      resolveLoad = resolve;
+      rejectLoad = reject;
+    });
+
+    // Publish the operation before starting it, then invoke the loader
+    // synchronously so source-level ownership is reserved before loadAssets
+    // returns to its caller.
+    pendingAssetLoads.set(key, loadPromise);
+
+    const clearPendingLoad = () => {
+      if (pendingAssetLoads.get(key) === loadPromise) {
+        pendingAssetLoads.delete(key);
+      }
+    };
+    void loadPromise.then(clearPendingLoad, clearPendingLoad);
+
+    try {
+      Promise.resolve(load()).then(resolveLoad, rejectLoad);
+    } catch (error) {
+      rejectLoad(error);
+    }
+
+    return loadPromise;
+  };
+
+  const trackSharedTextureLoad = (identity, load) => {
+    const pendingLoad = sharedPendingTextureLoads.get(identity);
+    if (pendingLoad) {
+      return pendingLoad;
+    }
+
+    let resolveLoad;
+    let rejectLoad;
+    const loadPromise = new Promise((resolve, reject) => {
+      resolveLoad = resolve;
+      rejectLoad = reject;
+    });
+    sharedPendingTextureLoads.set(identity, loadPromise);
+
+    const clearPendingLoad = () => {
+      if (sharedPendingTextureLoads.get(identity) === loadPromise) {
+        sharedPendingTextureLoads.delete(identity);
+      }
+    };
+    void loadPromise.then(clearPendingLoad, clearPendingLoad);
+
+    try {
+      Promise.resolve(load()).then(resolveLoad, rejectLoad);
+    } catch (error) {
+      rejectLoad(error);
+    }
+
+    return loadPromise;
+  };
+
+  const retainSharedOwnership = (ownership) => {
+    ownership.referenceCount += 1;
+    return ownership;
+  };
+
+  const retainSharedAsset = ({ registry, identity, dispose }) => {
+    let ownership = registry.get(identity);
+
+    if (!ownership) {
+      ownership = {
+        registry,
+        identity,
+        referenceCount: 0,
+        dispose,
+        unregister: () => {
+          if (registry.get(identity) === ownership) {
+            registry.delete(identity);
+          }
+        },
+      };
+      registry.set(identity, ownership);
+    }
+
+    return retainSharedOwnership(ownership);
+  };
+
+  const releaseSharedAsset = async (ownership) => {
+    ownership.referenceCount -= 1;
+    if (ownership.referenceCount > 0) {
+      return;
+    }
+
+    if (ownership.onZeroReferences) {
+      await ownership.onZeroReferences();
+      return;
+    }
+
+    ownership.unregister?.();
+    await ownership.dispose?.();
+  };
+
+  const recordLoadedAudio = (key, value, { dispose } = {}) => {
+    const record = {
+      category: "audio",
+      value,
+      sharedOwnership: retainSharedAsset({
+        registry: sharedAudioAssetOwners,
+        identity: key,
+        dispose,
+      }),
+    };
+
+    return recordLoadedAsset(key, record);
+  };
+
+  const getTexturePrimaryValue = (value) =>
+    Array.isArray(value) ? value[0] : value;
+
+  const recordLoadedTexture = (
+    key,
+    record,
+    {
+      dispose,
+      ownership: reservedOwnership,
+      ownershipAlreadyRetained = false,
+      cacheAliasInstalled = false,
+    } = {},
+  ) => {
+    const ownership = reservedOwnership
+      ? ownershipAlreadyRetained
+        ? reservedOwnership
+        : retainSharedOwnership(reservedOwnership)
+      : retainSharedAsset({
+          registry: sharedTextureAssetOwners,
+          identity: record.value,
+          dispose,
+        });
+    ownership.aliasRecords ??= new Map();
+
+    let aliasRecord = ownership.aliasRecords.get(key);
+    if (!aliasRecord) {
+      aliasRecord = {
+        referenceCount: 0,
+        cacheAliasInstalled: false,
+        primaryValue: getTexturePrimaryValue(record.value),
+      };
+      ownership.aliasRecords.set(key, aliasRecord);
+    }
+    aliasRecord.referenceCount += 1;
+    if (cacheAliasInstalled) {
+      aliasRecord.cacheAliasInstalled = true;
+      aliasRecord.primaryValue = getTexturePrimaryValue(record.value);
+    }
+
+    sharedTextureAliasOwners.set(key, ownership);
+    record.sharedOwnership = ownership;
+
+    return recordLoadedAsset(key, record);
+  };
+
+  const recordSharedTextureLoadResult = (key, category, result) => {
+    const aliasOwnership = sharedTextureAliasOwners.get(key);
+    const ownership =
+      (aliasOwnership &&
+      getTexturePrimaryValue(aliasOwnership.value) ===
+        getTexturePrimaryValue(result.value)
+        ? aliasOwnership
+        : undefined) ?? sharedTextureAssetOwners.get(result.value);
+
+    if (!result.created && !ownership) {
+      return result.value;
+    }
+
+    return recordLoadedTexture(
+      key,
+      {
+        category,
+        value: ownership?.value ?? result.value,
+      },
+      ownership
+        ? {
+            ownership,
+            cacheAliasInstalled: result.cacheAliasInstalled,
+          }
+        : {
+            dispose: result.dispose,
+            cacheAliasInstalled: result.cacheAliasInstalled,
+          },
+    );
   };
 
   const releaseTextureResource = (resource) => {
@@ -691,52 +903,183 @@ const createRouteGraphics = () => {
     }
   };
 
-  const unloadTextureRecord = async (key, record) => {
-    const texture = record.value;
-    const resource = texture?.source?.resource;
+  const getTextureResources = (value) => {
+    const resources = new Set();
+    const textures = Array.isArray(value) ? value : [value];
 
-    if (record.managedByAssets === true) {
-      await Assets.unload(key);
-    } else {
-      if (Assets.cache.has(key)) {
-        Assets.cache.remove(key);
-      }
-      if (!texture?.destroyed) {
-        texture?.destroy?.(true);
+    for (const texture of textures) {
+      const resource = texture?.source?.resource;
+      if (resource) {
+        resources.add(resource);
       }
     }
 
-    releaseTextureResource(resource);
+    return resources;
+  };
+
+  const getCanonicalTextureSource = (sourceUrl) => {
+    let resolvedSource = sourceUrl;
+
+    try {
+      resolvedSource = Assets.resolver?.resolve?.(sourceUrl)?.src ?? sourceUrl;
+    } catch {
+      // Fall back to URL resolution when a custom resolver rejects an
+      // unregistered source.
+    }
+
+    try {
+      const baseUrl =
+        (typeof document !== "undefined" ? document.baseURI : undefined) ??
+        globalThis.location?.href;
+      return new URL(resolvedSource, baseUrl).href;
+    } catch {
+      return resolvedSource;
+    }
+  };
+
+  const createUrlTextureOwnership = (
+    sourceUrl,
+    sourceIdentity,
+    waitForDisposal,
+  ) => {
+    const ownership = {
+      sourceUrl,
+      sourceIdentity,
+      referenceCount: 0,
+      aliasRecords: new Map(),
+      disposing: false,
+    };
+    sharedUrlTextureAssetOwners.set(sourceIdentity, ownership);
+
+    ownership.loadPromise = (async () => {
+      if (waitForDisposal) {
+        try {
+          await waitForDisposal;
+        } catch {
+          // A successor load must run after disposal settles even if the
+          // previous caller observes a disposal failure.
+        }
+      }
+
+      const sourceWasAlreadyCached = Assets.cache.has(sourceUrl);
+      const value = await Assets.load(sourceUrl);
+      const resources = getTextureResources(value);
+
+      ownership.value = value;
+      sharedTextureAssetOwners.set(value, ownership);
+      if (!sourceWasAlreadyCached) {
+        ownership.dispose = async () => {
+          try {
+            await Assets.unload(sourceUrl);
+          } finally {
+            for (const resource of resources) {
+              releaseTextureResource(resource);
+            }
+          }
+        };
+      }
+
+      return value;
+    })();
+
+    ownership.onZeroReferences = async () => {
+      ownership.disposing = true;
+      if (
+        ownership.value !== undefined &&
+        sharedTextureAssetOwners.get(ownership.value) === ownership
+      ) {
+        sharedTextureAssetOwners.delete(ownership.value);
+      }
+
+      const disposalPromise = Promise.resolve().then(() =>
+        ownership.dispose?.(),
+      );
+      ownership.disposalPromise = disposalPromise;
+
+      try {
+        await disposalPromise;
+      } finally {
+        if (sharedUrlTextureAssetOwners.get(sourceIdentity) === ownership) {
+          sharedUrlTextureAssetOwners.delete(sourceIdentity);
+        }
+      }
+    };
+
+    return ownership;
+  };
+
+  const reserveUrlTextureOwnership = (sourceUrl) => {
+    const sourceIdentity = getCanonicalTextureSource(sourceUrl);
+    let ownership = sharedUrlTextureAssetOwners.get(sourceIdentity);
+
+    if (!ownership || ownership.disposing) {
+      ownership = createUrlTextureOwnership(
+        sourceUrl,
+        sourceIdentity,
+        ownership?.disposalPromise,
+      );
+    }
+
+    return retainSharedOwnership(ownership);
+  };
+
+  const releaseTextureRecord = async (key, record) => {
+    const ownership = record.sharedOwnership;
+    const aliasRecord = ownership.aliasRecords.get(key);
+    const remainingAliasReferences = (aliasRecord?.referenceCount ?? 1) - 1;
+
+    if (remainingAliasReferences > 0) {
+      aliasRecord.referenceCount = remainingAliasReferences;
+    } else {
+      ownership.aliasRecords.delete(key);
+      if (sharedTextureAliasOwners.get(key) === ownership) {
+        sharedTextureAliasOwners.delete(key);
+      }
+      if (
+        aliasRecord?.cacheAliasInstalled === true &&
+        Assets.cache.has(key) &&
+        Assets.cache.get(key) === aliasRecord.primaryValue
+      ) {
+        Assets.cache.remove(key);
+      }
+    }
+
+    await releaseSharedAsset(ownership);
   };
 
   const unloadAsset = async (key) => {
-    const record = loadedAssetRecords.get(key);
-    if (!record) {
-      return false;
-    }
-
-    if (record.category === "audio") {
-      AudioAsset.unload(key);
-    } else if (record.category === "font") {
-      document.fonts?.delete?.(record.value);
-    } else if (record.category === "texture" || record.category === "video") {
-      await unloadTextureRecord(key, record);
-      if (record.category === "video") {
-        revokeVideoSourceUrl(key);
+    const pendingLoad = pendingAssetLoads.get(key);
+    if (pendingLoad) {
+      try {
+        await pendingLoad;
+      } catch {
+        // A failed load did not install an asset, so there is nothing left for
+        // the racing unload request to release.
+        return false;
       }
     }
 
+    const record = loadedAssetRecords.get(key);
+    if (!record || record.released === true) {
+      return false;
+    }
+
+    record.released = true;
     if (loadedAssetRecords.get(key) === record) {
       loadedAssetRecords.delete(key);
+    }
+
+    if (record.category === "audio") {
+      await releaseSharedAsset(record.sharedOwnership);
+    } else if (record.category === "font") {
+      document.fonts?.delete?.(record.value);
+    } else if (record.category === "texture" || record.category === "video") {
+      await releaseTextureRecord(key, record);
     }
     return true;
   };
 
-  const loadVideoTexture = async ({ key, sourceUrl, mimeType }) => {
-    if (Assets.cache.has(key)) {
-      return Assets.cache.get(key);
-    }
-
+  const loadVideoTexture = async ({ sourceUrl, mimeType }) => {
     const video = document.createElement("video");
     video.crossOrigin = "anonymous";
     video.preload = "metadata";
@@ -756,7 +1099,6 @@ const createRouteGraphics = () => {
       source: createVideoTextureSource(video, alphaMode),
     });
     configureManagedVideoTextureUpdates(texture);
-    Assets.cache.set(key, texture);
 
     return texture;
   };
@@ -1057,6 +1399,39 @@ const createRouteGraphics = () => {
         canvasWebglContextRestoredListener,
       );
 
+      const webgpuDeviceLost = app.renderer?.gpu?.device?.lost;
+      if (webgpuDeviceLost && typeof webgpuDeviceLost.then === "function") {
+        const subscription = {};
+        webgpuDeviceLossSubscription = subscription;
+        void Promise.resolve(webgpuDeviceLost).then(
+          (deviceLostInfo) => {
+            if (webgpuDeviceLossSubscription !== subscription) {
+              return;
+            }
+
+            const payload = {};
+            if (
+              typeof deviceLostInfo?.reason === "string" &&
+              deviceLostInfo.reason.length > 0
+            ) {
+              payload.reason = deviceLostInfo.reason;
+            }
+            if (
+              typeof deviceLostInfo?.message === "string" &&
+              deviceLostInfo.message.length > 0
+            ) {
+              payload.statusMessage = deviceLostInfo.message;
+            }
+            eventHandler?.("rendererContextLost", payload);
+          },
+          () => {
+            // GPUDevice.lost resolves by specification. Ignore non-standard
+            // thenables that reject so lifecycle observation cannot create an
+            // unhandled rejection.
+          },
+        );
+      }
+
       backgroundGraphic = new Graphics();
       backgroundGraphic.label = "__route_graphics_background__";
       drawBackgroundGraphic(backgroundGraphic, width, height, backgroundColor);
@@ -1145,6 +1520,19 @@ const createRouteGraphics = () => {
         );
         canvasWebglContextRestoredListener = undefined;
       }
+      webgpuDeviceLossSubscription = undefined;
+
+      const ownedAssetIds = new Set([
+        ...loadedAssetRecords.keys(),
+        ...pendingAssetLoads.keys(),
+      ]);
+      for (const assetId of ownedAssetIds) {
+        void unloadAsset(assetId).catch(() => {
+          // destroy is synchronous and best-effort; explicit unloadAssets calls
+          // continue to surface disposal failures to the caller.
+        });
+      }
+
       app?.inputDomBridge?.destroy?.();
       keyboardManager?.destroy();
       clearPendingSounds();
@@ -1175,7 +1563,6 @@ const createRouteGraphics = () => {
       animationPlaybackMode = "auto";
       animationPlaybackTimeMS = null;
       backgroundGraphic = undefined;
-      revokeVideoBlobUrls();
     },
 
     /**
@@ -1206,25 +1593,32 @@ const createRouteGraphics = () => {
       Object.entries(assetsByType.audio).forEach(([key, asset]) => {
         loadJobs.push({
           includeInReturn: false,
-          promise: loadAssetWithContext(
-            {
-              key,
-              category: "audio",
-              phase: "decode",
-              asset,
-            },
-            async () => {
-              const existingRecord = loadedAssetRecords.get(key);
-              if (existingRecord?.category === "audio") {
-                return existingRecord.value;
-              }
-              assertAssetBuffer(asset, "Audio");
-              const audioBuffer = await AudioAsset.load(key, asset.buffer);
-              return recordLoadedAsset(key, {
+          promise: trackAssetLoad(key, () =>
+            loadAssetWithContext(
+              {
+                key,
                 category: "audio",
-                value: audioBuffer,
-              });
-            },
+                phase: "decode",
+                asset,
+              },
+              async () => {
+                const existingRecord = loadedAssetRecords.get(key);
+                if (existingRecord?.category === "audio") {
+                  return existingRecord.value;
+                }
+                assertAssetBuffer(asset, "Audio");
+                const audioWasAlreadyLoaded =
+                  !sharedAudioAssetOwners.has(key) &&
+                  AudioAsset.getAsset(key) !== undefined;
+                const audioBuffer = await AudioAsset.load(key, asset.buffer);
+
+                return recordLoadedAudio(key, audioBuffer, {
+                  dispose: audioWasAlreadyLoaded
+                    ? undefined
+                    : () => AudioAsset.unload(key),
+                });
+              },
+            ),
           ),
         });
       });
@@ -1232,34 +1626,36 @@ const createRouteGraphics = () => {
       Object.entries(assetsByType.font).forEach(([key, asset]) => {
         loadJobs.push({
           includeInReturn: false,
-          promise: loadAssetWithContext(
-            {
-              key,
-              category: "font",
-              phase: "font face load",
-              asset,
-            },
-            async () => {
-              const existingRecord = loadedAssetRecords.get(key);
-              if (existingRecord?.category === "font") {
-                return existingRecord.value;
-              }
-              assertAssetBuffer(asset, "Font");
-              const blob = new Blob([asset.buffer], { type: asset.type });
-              const url = URL.createObjectURL(blob);
-              // Use the key as font family name - this should match the fontFamily in text styles
-              const fontFace = new FontFace(key, `url(${url})`);
-              try {
-                await fontFace.load();
-                document.fonts.add(fontFace);
-                return recordLoadedAsset(key, {
-                  category: "font",
-                  value: fontFace,
-                });
-              } finally {
-                URL.revokeObjectURL(url);
-              }
-            },
+          promise: trackAssetLoad(key, () =>
+            loadAssetWithContext(
+              {
+                key,
+                category: "font",
+                phase: "font face load",
+                asset,
+              },
+              async () => {
+                const existingRecord = loadedAssetRecords.get(key);
+                if (existingRecord?.category === "font") {
+                  return existingRecord.value;
+                }
+                assertAssetBuffer(asset, "Font");
+                const blob = new Blob([asset.buffer], { type: asset.type });
+                const url = URL.createObjectURL(blob);
+                // Use the key as font family name - this should match the fontFamily in text styles
+                const fontFace = new FontFace(key, `url(${url})`);
+                try {
+                  await fontFace.load();
+                  document.fonts.add(fontFace);
+                  return recordLoadedAsset(key, {
+                    category: "font",
+                    value: fontFace,
+                  });
+                } finally {
+                  URL.revokeObjectURL(url);
+                }
+              },
+            ),
           ),
         });
       });
@@ -1267,52 +1663,166 @@ const createRouteGraphics = () => {
       Object.entries(assetsByType.texture).forEach(([key, asset]) =>
         loadJobs.push({
           includeInReturn: true,
-          promise: loadAssetWithContext(
-            {
-              key,
-              category: "texture",
-              phase:
-                asset?.source === "url" && typeof asset?.url === "string"
-                  ? "Pixi URL load"
-                  : "image bitmap creation",
-              asset,
-            },
-            async () => {
-              const existingRecord = loadedAssetRecords.get(key);
-              if (existingRecord?.category === "texture") {
-                return existingRecord.value;
-              }
-              if (Assets.cache.has(key)) {
-                return Assets.cache.get(key);
-              }
-
-              if (asset?.source === "url" && typeof asset?.url === "string") {
-                const texture = await Assets.load({
-                  alias: key,
-                  src: asset.url,
-                });
-                return recordLoadedAsset(key, {
-                  category: "texture",
-                  value: texture,
-                  managedByAssets: true,
-                });
-              }
-
-              assertAssetBuffer(asset, "Texture");
-              const blob = new Blob([asset.buffer], { type: asset.type });
-              const imageBitmap = await createImageBitmap(blob);
-              const texture = Texture.from(imageBitmap);
-
-              // Alias the logical asset key so Texture.from("key") resolves
-              // directly from the cache instead of attempting a relative URL fetch.
-              Assets.cache.set(key, texture);
-
-              return recordLoadedAsset(key, {
+          promise: trackAssetLoad(key, () =>
+            loadAssetWithContext(
+              {
+                key,
                 category: "texture",
-                value: texture,
-                managedByAssets: false,
-              });
-            },
+                phase:
+                  asset?.source === "url" && typeof asset?.url === "string"
+                    ? "Pixi URL load"
+                    : "image bitmap creation",
+                asset,
+              },
+              async () => {
+                const existingRecord = loadedAssetRecords.get(key);
+                if (existingRecord?.category === "texture") {
+                  return existingRecord.value;
+                }
+                if (Assets.cache.has(key)) {
+                  const cachedPrimaryValue = Assets.cache.get(key);
+                  const sourceUrl =
+                    asset?.source === "url" && typeof asset?.url === "string"
+                      ? asset.url
+                      : undefined;
+                  const sourceOwnership = sourceUrl
+                    ? sharedUrlTextureAssetOwners.get(
+                        getCanonicalTextureSource(sourceUrl),
+                      )
+                    : undefined;
+                  const sourceTransitionInProgress =
+                    sourceOwnership &&
+                    (sourceOwnership.disposing ||
+                      sourceOwnership.value === undefined);
+
+                  if (!sourceTransitionInProgress) {
+                    const aliasOwnership = sharedTextureAliasOwners.get(key);
+                    const ownership =
+                      (aliasOwnership &&
+                      getTexturePrimaryValue(aliasOwnership.value) ===
+                        cachedPrimaryValue
+                        ? aliasOwnership
+                        : undefined) ??
+                      (sourceOwnership &&
+                      getTexturePrimaryValue(sourceOwnership.value) ===
+                        cachedPrimaryValue
+                        ? sourceOwnership
+                        : undefined) ??
+                      sharedTextureAssetOwners.get(cachedPrimaryValue);
+
+                    // A cache entry owned by Route Graphics is a shared
+                    // resource, so this instance must retain it. Unknown
+                    // external entries remain borrowed and are never destroyed
+                    // by this instance.
+                    if (ownership) {
+                      return recordLoadedTexture(
+                        key,
+                        {
+                          category: "texture",
+                          value: ownership.value,
+                        },
+                        { ownership },
+                      );
+                    }
+                    return cachedPrimaryValue;
+                  }
+                }
+
+                if (asset?.source === "url" && typeof asset?.url === "string") {
+                  const sourceUrl = asset.url;
+                  const ownership = reserveUrlTextureOwnership(sourceUrl);
+                  let cacheAliasInstalled = false;
+
+                  try {
+                    // Load by URL and add the logical key only to Pixi's cache.
+                    // This avoids leaving a persistent resolver alias that
+                    // would point a later reload at an expired signed URL.
+                    const texture = await ownership.loadPromise;
+                    if (key !== sourceUrl) {
+                      Assets.cache.set(key, texture);
+                      cacheAliasInstalled = true;
+                    }
+
+                    return recordLoadedTexture(
+                      key,
+                      {
+                        category: "texture",
+                        value: texture,
+                      },
+                      {
+                        ownership,
+                        ownershipAlreadyRetained: true,
+                        cacheAliasInstalled,
+                      },
+                    );
+                  } catch (error) {
+                    if (
+                      cacheAliasInstalled &&
+                      Assets.cache.has(key) &&
+                      Assets.cache.get(key) ===
+                        getTexturePrimaryValue(ownership.value)
+                    ) {
+                      Assets.cache.remove(key);
+                    }
+                    await releaseSharedAsset(ownership);
+                    throw error;
+                  }
+                }
+
+                const result = await trackSharedTextureLoad(
+                  `texture:${key}`,
+                  async () => {
+                    if (Assets.cache.has(key)) {
+                      return {
+                        value: Assets.cache.get(key),
+                        created: false,
+                        cacheAliasInstalled: false,
+                      };
+                    }
+
+                    assertAssetBuffer(asset, "Texture");
+                    const blob = new Blob([asset.buffer], {
+                      type: asset.type,
+                    });
+                    const imageBitmap = await createImageBitmap(blob);
+                    const texture = Texture.from(imageBitmap);
+                    const dispose = () => {
+                      try {
+                        if (!texture?.destroyed) {
+                          texture?.destroy?.(true);
+                        }
+                      } finally {
+                        releaseTextureResource(imageBitmap);
+                      }
+                    };
+
+                    // An external cache writer may have won while image decode
+                    // was pending. Keep its value and discard our duplicate.
+                    if (Assets.cache.has(key)) {
+                      dispose();
+                      return {
+                        value: Assets.cache.get(key),
+                        created: false,
+                        cacheAliasInstalled: false,
+                      };
+                    }
+
+                    // Alias the logical asset key so Texture.from("key")
+                    // resolves directly from the cache instead of attempting a
+                    // relative URL fetch.
+                    Assets.cache.set(key, texture);
+                    return {
+                      value: texture,
+                      created: true,
+                      cacheAliasInstalled: true,
+                      dispose,
+                    };
+                  },
+                );
+
+                return recordSharedTextureLoadResult(key, "texture", result);
+              },
+            ),
           ),
         }),
       );
@@ -1322,57 +1832,107 @@ const createRouteGraphics = () => {
       Object.entries(assetsByType.video).forEach(([key, asset]) => {
         loadJobs.push({
           includeInReturn: true,
-          promise: loadAssetWithContext(
-            {
-              key,
-              category: "video",
-              phase: "video texture load",
-              asset,
-            },
-            async () => {
-              const existingRecord = loadedAssetRecords.get(key);
-              if (existingRecord?.category === "video") {
-                return existingRecord.value;
-              }
-              if (Assets.cache.has(key)) {
-                return Assets.cache.get(key);
-              }
-
-              if (asset?.source !== "url") {
-                assertAssetBuffer(asset, "Video");
-              }
-
-              const sourceUrl =
-                asset?.source === "url" && typeof asset?.url === "string"
-                  ? asset.url
-                  : URL.createObjectURL(
-                      new Blob([asset.buffer], { type: asset.type }),
-                    );
-              const isRevokableBlobUrl = asset?.source !== "url";
-
-              trackVideoSourceUrl(key, sourceUrl, {
-                revokable: isRevokableBlobUrl,
-              });
-
-              try {
-                const texture = await loadVideoTexture({
-                  key,
-                  sourceUrl,
-                  mimeType: asset?.type,
-                });
-                return recordLoadedAsset(key, {
-                  category: "video",
-                  value: texture,
-                  managedByAssets: false,
-                });
-              } catch (error) {
-                videoSourceUrls.delete(key);
-                if (isRevokableBlobUrl) {
-                  URL.revokeObjectURL(sourceUrl);
+          promise: trackAssetLoad(key, () =>
+            loadAssetWithContext(
+              {
+                key,
+                category: "video",
+                phase: "video texture load",
+                asset,
+              },
+              async () => {
+                const existingRecord = loadedAssetRecords.get(key);
+                if (existingRecord?.category === "video") {
+                  return existingRecord.value;
                 }
-                throw error;
-              }
-            },
+                if (Assets.cache.has(key)) {
+                  const texture = Assets.cache.get(key);
+                  if (sharedTextureAssetOwners.has(texture)) {
+                    return recordLoadedTexture(key, {
+                      category: "video",
+                      value: texture,
+                    });
+                  }
+                  return texture;
+                }
+
+                if (asset?.source !== "url") {
+                  assertAssetBuffer(asset, "Video");
+                }
+
+                const result = await trackSharedTextureLoad(
+                  `video:${key}`,
+                  async () => {
+                    if (Assets.cache.has(key)) {
+                      return {
+                        value: Assets.cache.get(key),
+                        created: false,
+                        cacheAliasInstalled: false,
+                      };
+                    }
+
+                    const sourceUrl =
+                      asset?.source === "url" && typeof asset?.url === "string"
+                        ? asset.url
+                        : URL.createObjectURL(
+                            new Blob([asset.buffer], { type: asset.type }),
+                          );
+                    const isRevokableBlobUrl = asset?.source !== "url";
+
+                    trackVideoSourceUrl(key, sourceUrl, {
+                      revokable: isRevokableBlobUrl,
+                    });
+
+                    let texture;
+                    try {
+                      texture = await loadVideoTexture({
+                        sourceUrl,
+                        mimeType: asset?.type,
+                      });
+                    } catch (error) {
+                      videoSourceUrls.delete(key);
+                      if (isRevokableBlobUrl) {
+                        URL.revokeObjectURL(sourceUrl);
+                      }
+                      throw error;
+                    }
+
+                    const resource = texture?.source?.resource;
+                    const dispose = () => {
+                      try {
+                        if (!texture?.destroyed) {
+                          texture?.destroy?.(true);
+                        }
+                        releaseTextureResource(resource);
+                      } finally {
+                        revokeVideoSourceUrl(key);
+                      }
+                    };
+
+                    // Keep a cache entry installed while video setup was
+                    // pending and discard this duplicate texture.
+                    if (Assets.cache.has(key)) {
+                      dispose();
+                      return {
+                        value: Assets.cache.get(key),
+                        created: false,
+                        cacheAliasInstalled: false,
+                      };
+                    }
+
+                    Assets.cache.set(key, texture);
+                    return {
+                      value: texture,
+                      created: true,
+                      cacheAliasInstalled: true,
+                      dispose,
+                    };
+                  },
+                );
+
+                return recordSharedTextureLoadResult(key, "video", result);
+              },
+            ),
           ),
         });
       });
@@ -1445,19 +2005,26 @@ const createRouteGraphics = () => {
 
     loadAudioAssets: async (urls) => {
       return Promise.all(
-        urls.map(async (url) => {
-          const existingRecord = loadedAssetRecords.get(url);
-          if (existingRecord?.category === "audio") {
-            return existingRecord.value;
-          }
-          const response = await fetch(url);
-          const arrayBuffer = await response.arrayBuffer();
-          const audioBuffer = await AudioAsset.load(url, arrayBuffer);
-          return recordLoadedAsset(url, {
-            category: "audio",
-            value: audioBuffer,
-          });
-        }),
+        urls.map((url) =>
+          trackAssetLoad(url, async () => {
+            const existingRecord = loadedAssetRecords.get(url);
+            if (existingRecord?.category === "audio") {
+              return existingRecord.value;
+            }
+
+            const cachedAudioBuffer = AudioAsset.getAsset(url);
+            if (cachedAudioBuffer !== undefined) {
+              return recordLoadedAudio(url, cachedAudioBuffer);
+            }
+
+            const response = await fetch(url);
+            const arrayBuffer = await response.arrayBuffer();
+            const audioBuffer = await AudioAsset.load(url, arrayBuffer);
+            return recordLoadedAudio(url, audioBuffer, {
+              dispose: () => AudioAsset.unload(url),
+            });
+          }),
+        ),
       );
     },
 


### PR DESCRIPTION
## Summary

- Retain shared texture and audio assets until their final consumer unloads.
- Coordinate pending URL, buffer, and video loads across instances, refresh URL aliases, and clean texture-array cache aliases.
- Preserve manager-owned audio buffers for reload and cover WebGL and WebGPU renderer lifecycle loss.
- Bump the package version to 1.25.1 for the corrective release.

## Verification

- bun run lint
- Oxlint: 0 warnings and 0 errors
- bun run build
- Vitest: 85 files passed, 623 tests passed

## Release

This is the corrective follow-up to v1.25.0. After merge, publish tag v1.25.1.