### PR TITLE
Fix plain text font weight rendering

### DIFF
--- a/spec/util/applyTextStyle.spec.js
+++ b/spec/util/applyTextStyle.spec.js
@@ -1,0 +1,17 @@
+import { Text } from "pixi.js";
+import { describe, expect, it } from "vitest";
+import applyTextStyle from "../../src/util/applyTextStyle.js";
+
+describe("applyTextStyle", () => {
+  it("applies font weight and font style to plain text", () => {
+    const text = new Text();
+
+    applyTextStyle(text, {
+      fontWeight: "700",
+      fontStyle: "italic",
+    });
+
+    expect(text.style.fontWeight).toBe("700");
+    expect(text.style.fontStyle).toBe("italic");
+  });
+});

--- a/src/types.js
+++ b/src/types.js
@@ -858,6 +858,7 @@ export const DEFAULT_TEXT_STYLE = {
  * @property {string} fill - The fill color of the text
  * @property {number} fontSize - The font family of the text
  * @property {string} fontWeight - The font weight of the text
+ * @property {string} fontStyle - The font style of the text
  * @property {number} lineHeight - The line height of the text
  * @property {number} wordWrapWidth - Wrap width
  * @property {boolean} wordWrap - Whether to word wrap

--- a/src/util/applyTextStyle.js
+++ b/src/util/applyTextStyle.js
@@ -6,6 +6,10 @@ export default (element, style) => {
     fill: style?.fill ?? DEFAULT_TEXT_STYLE.fill,
     fontFamily: style?.fontFamily ?? DEFAULT_TEXT_STYLE.fontFamily,
     fontSize: style?.fontSize ?? DEFAULT_TEXT_STYLE.fontSize,
+    ...(style?.fontWeight !== undefined
+      ? { fontWeight: style.fontWeight }
+      : {}),
+    ...(style?.fontStyle !== undefined ? { fontStyle: style.fontStyle } : {}),
     align: style?.align ?? DEFAULT_TEXT_STYLE.align,
     lineHeight: style?.lineHeight ?? DEFAULT_TEXT_STYLE.lineHeight,
     wordWrap: style?.wordWrap ?? DEFAULT_TEXT_STYLE.wordWrap,

--- a/vt/reference/textrevealing/duplicate-text-after-sibling-sprite-rerender-01.webp
+++ b/vt/reference/textrevealing/duplicate-text-after-sibling-sprite-rerender-01.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c294100a1ed628bdaf0889da31486dbe489b303fe0aace0f6af8120317f19854
-size 8692
+oid sha256:c4c62740c9c8ee3057e30f4acb0de1dd28f676beefc0ea08d54d24628a085cbe
+size 9128

--- a/vt/reference/textrevealing/duplicate-text-after-sibling-sprite-rerender-02.webp
+++ b/vt/reference/textrevealing/duplicate-text-after-sibling-sprite-rerender-02.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57a6377c36b775f728d92e8a34caa04355ff6c961ff0f7c6ef784bef3968aace
-size 9158
+oid sha256:dc1baf298d74302ba21b3e21d215535dd0c8ea73656e09b3682109353dca7454
+size 9604

--- a/vt/reference/textrevealing/duplicate-text-after-sibling-sprite-rerender-03.webp
+++ b/vt/reference/textrevealing/duplicate-text-after-sibling-sprite-rerender-03.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c294100a1ed628bdaf0889da31486dbe489b303fe0aace0f6af8120317f19854
-size 8692
+oid sha256:c4c62740c9c8ee3057e30f4acb0de1dd28f676beefc0ea08d54d24628a085cbe
+size 9128


### PR DESCRIPTION
## Summary

- preserve explicit fontWeight and fontStyle when applying styles to plain Pixi text
- document fontStyle in the public TextStyle type
- add a regression test covering both properties
- leave the package version unchanged

## Validation

- bunx vitest run spec/util/applyTextStyle.spec.js spec/util/toPixiTextStyle.spec.js spec/elements/addTextRichContent.spec.js spec/elements/textHoverLayout.spec.js
- bun run lint
- bun run build

The full local suite passed 610 of 627 tests. The remaining failures are unrelated environment checks: 13 existing font-metric snapshot differences and 4 CLI tests requiring a local Playwright Chromium binary.