### PR TITLE
fix(text): keep rich hover text position stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/elements/addTextRichContent.spec.js
+++ b/spec/elements/addTextRichContent.spec.js
@@ -69,6 +69,63 @@ describe("text rich content", () => {
     expect(line.children[1].style.fontWeight).toBe("bold");
   });
 
+  it("keeps parsed rich-text line height stable for ratio-based hover styles", () => {
+    const parent = new Container();
+    const element = parseText({
+      state: {
+        id: "rich-text-hover",
+        type: "text",
+        x: 240,
+        y: 120,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        alpha: 1,
+        content: [{ text: "Menu item" }],
+        textStyle: {
+          fontSize: 36,
+          fontFamily: "Arial",
+          fontWeight: "700",
+          lineHeight: 1.5,
+          fill: "#FFFFFF",
+        },
+        hover: {
+          textStyle: {
+            fontSize: 36,
+            fontFamily: "Arial",
+            fontWeight: "400",
+            lineHeight: 1.5,
+            fill: "#D9D9D9",
+          },
+        },
+      },
+    });
+
+    addText({
+      ...createSharedParams(),
+      parent,
+      element,
+      zIndex: 0,
+    });
+
+    const text = parent.getChildByLabel("rich-text-hover");
+    const getTextPart = () => text.children[0].children[0];
+    const initialY = text.y;
+
+    expect(getTextPart().style.lineHeight).toBe(54);
+
+    text.emit("pointerover");
+
+    expect(getTextPart().style.fontWeight).toBe("400");
+    expect(getTextPart().style.lineHeight).toBe(54);
+    expect(text.y).toBe(initialY);
+
+    text.emit("pointerout");
+
+    expect(getTextPart().style.fontWeight).toBe("700");
+    expect(getTextPart().style.lineHeight).toBe(54);
+    expect(text.y).toBe(initialY);
+  });
+
   it("updates between plain and rich text display objects", () => {
     const parent = new Container();
     const shared = createSharedParams();

--- a/spec/elements/textHoverLayout.spec.js
+++ b/spec/elements/textHoverLayout.spec.js
@@ -79,7 +79,7 @@ describe("text hover layout", () => {
     expect(text.style.padding).toBe(18);
   });
 
-  it("keeps the text anchor stable when hover styles change text metrics", () => {
+  it("keeps the vertical text position stable when hover styles change text metrics", () => {
     const parent = new Container();
     const shared = createSharedParams();
     const element = parseText({
@@ -116,17 +116,17 @@ describe("text hover layout", () => {
 
     const text = parent.getChildByLabel("text-hover-layout");
     const beforeHoverAnchorX = text.x + text.width * 0.5;
-    const beforeHoverAnchorY = text.y + text.height * 0.5;
+    const beforeHoverY = text.y;
 
     text.emit("pointerover");
 
     expect(text.x + text.width * 0.5).toBeCloseTo(beforeHoverAnchorX, 4);
-    expect(text.y + text.height * 0.5).toBeCloseTo(beforeHoverAnchorY, 4);
+    expect(text.y).toBeCloseTo(beforeHoverY, 4);
 
     text.emit("pointerout");
 
     expect(text.x + text.width * 0.5).toBeCloseTo(beforeHoverAnchorX, 4);
-    expect(text.y + text.height * 0.5).toBeCloseTo(beforeHoverAnchorY, 4);
+    expect(text.y).toBeCloseTo(beforeHoverY, 4);
   });
 
   it("keeps hover and click textStyle states working together", () => {
@@ -515,7 +515,7 @@ describe("text hover layout", () => {
     );
   });
 
-  it("keeps a fixed-width box anchor stable when hover styles change text metrics", () => {
+  it("keeps fixed-width alignment and vertical position stable when hover styles change text metrics", () => {
     const parent = new Container();
     const shared = createSharedParams();
     const element = parseText({
@@ -554,7 +554,7 @@ describe("text hover layout", () => {
     });
 
     const text = parent.getChildByLabel("text-fixed-width-hover-layout");
-    const getBoxCenter = () => {
+    const getBoxPosition = () => {
       const offset = getHorizontalOffset(
         element.width,
         text.width,
@@ -562,21 +562,19 @@ describe("text hover layout", () => {
       );
       return {
         x: text.x - offset + element.width * 0.5,
-        y: text.y + text.height * 0.5,
+        y: text.y,
       };
     };
 
-    const beforeHoverAnchor = getBoxCenter();
+    const beforeHoverPosition = getBoxPosition();
 
     text.emit("pointerover");
 
-    expect(getBoxCenter().x).toBeCloseTo(beforeHoverAnchor.x, 4);
-    expect(getBoxCenter().y).toBeCloseTo(beforeHoverAnchor.y, 4);
+    expect(getBoxPosition()).toEqual(beforeHoverPosition);
 
     text.emit("pointerout");
 
-    expect(getBoxCenter().x).toBeCloseTo(beforeHoverAnchor.x, 4);
-    expect(getBoxCenter().y).toBeCloseTo(beforeHoverAnchor.y, 4);
+    expect(getBoxPosition()).toEqual(beforeHoverPosition);
   });
 
   it("keeps fixed-width aligned text stable when only shadow metrics change", () => {

--- a/spec/elements/textHoverLayout.spec.js
+++ b/spec/elements/textHoverLayout.spec.js
@@ -79,7 +79,7 @@ describe("text hover layout", () => {
     expect(text.style.padding).toBe(18);
   });
 
-  it("keeps the vertical text position stable when hover styles change text metrics", () => {
+  it("keeps the text anchor stable when hover styles change text metrics", () => {
     const parent = new Container();
     const shared = createSharedParams();
     const element = parseText({
@@ -116,17 +116,17 @@ describe("text hover layout", () => {
 
     const text = parent.getChildByLabel("text-hover-layout");
     const beforeHoverAnchorX = text.x + text.width * 0.5;
-    const beforeHoverY = text.y;
+    const beforeHoverAnchorY = text.y + text.height * 0.5;
 
     text.emit("pointerover");
 
     expect(text.x + text.width * 0.5).toBeCloseTo(beforeHoverAnchorX, 4);
-    expect(text.y).toBeCloseTo(beforeHoverY, 4);
+    expect(text.y + text.height * 0.5).toBeCloseTo(beforeHoverAnchorY, 4);
 
     text.emit("pointerout");
 
     expect(text.x + text.width * 0.5).toBeCloseTo(beforeHoverAnchorX, 4);
-    expect(text.y).toBeCloseTo(beforeHoverY, 4);
+    expect(text.y + text.height * 0.5).toBeCloseTo(beforeHoverAnchorY, 4);
   });
 
   it("keeps hover and click textStyle states working together", () => {
@@ -515,7 +515,7 @@ describe("text hover layout", () => {
     );
   });
 
-  it("keeps fixed-width alignment and vertical position stable when hover styles change text metrics", () => {
+  it("keeps a fixed-width box anchor stable when hover styles change text metrics", () => {
     const parent = new Container();
     const shared = createSharedParams();
     const element = parseText({
@@ -554,7 +554,7 @@ describe("text hover layout", () => {
     });
 
     const text = parent.getChildByLabel("text-fixed-width-hover-layout");
-    const getBoxPosition = () => {
+    const getBoxCenter = () => {
       const offset = getHorizontalOffset(
         element.width,
         text.width,
@@ -562,19 +562,21 @@ describe("text hover layout", () => {
       );
       return {
         x: text.x - offset + element.width * 0.5,
-        y: text.y,
+        y: text.y + text.height * 0.5,
       };
     };
 
-    const beforeHoverPosition = getBoxPosition();
+    const beforeHoverAnchor = getBoxCenter();
 
     text.emit("pointerover");
 
-    expect(getBoxPosition()).toEqual(beforeHoverPosition);
+    expect(getBoxCenter().x).toBeCloseTo(beforeHoverAnchor.x, 4);
+    expect(getBoxCenter().y).toBeCloseTo(beforeHoverAnchor.y, 4);
 
     text.emit("pointerout");
 
-    expect(getBoxPosition()).toEqual(beforeHoverPosition);
+    expect(getBoxCenter().x).toBeCloseTo(beforeHoverAnchor.x, 4);
+    expect(getBoxCenter().y).toBeCloseTo(beforeHoverAnchor.y, 4);
   });
 
   it("keeps fixed-width aligned text stable when only shadow metrics change", () => {

--- a/src/plugins/elements/text/richTextDisplay.js
+++ b/src/plugins/elements/text/richTextDisplay.js
@@ -1,7 +1,7 @@
 import { Container, Rectangle, Text, TextStyle } from "pixi.js";
-import { mergeTextStyle } from "../../../util/mergeTextStyle.js";
 import { toPixiTextStyle } from "../../../util/toPixiTextStyle.js";
 import { DEFAULT_TEXT_STYLE } from "../../../types.js";
+import { resolveInteractiveTextStyle } from "./textLayout.js";
 
 const RICH_TEXT_DISPLAY = Symbol("routeGraphicsRichTextDisplay");
 
@@ -37,7 +37,7 @@ const createTextObject = ({ text, style, x, y }) =>
   });
 
 const applyOverrideStyle = (style, overrideStyle) =>
-  overrideStyle ? mergeTextStyle(style, overrideStyle) : style;
+  overrideStyle ? resolveInteractiveTextStyle(style, overrideStyle) : style;
 
 export const isRichTextComputedNode = (element) =>
   Array.isArray(element?.content);

--- a/src/plugins/elements/text/textLayout.js
+++ b/src/plugins/elements/text/textLayout.js
@@ -66,6 +66,16 @@ const getMeasuredWidth = (textElement) => {
   return textElement.width;
 };
 
+const getMeasuredHeight = (textElement) => {
+  const layoutState = textElement[TEXT_LAYOUT_STATE];
+
+  if (typeof layoutState?.measuredHeight === "number") {
+    return layoutState.measuredHeight;
+  }
+
+  return textElement.height;
+};
+
 const setTextLayoutState = (textElement, textComputedNode, measurements) => {
   const fixedWidth = Boolean(textComputedNode.__fixedWidth);
   const runtimeMeasurements =
@@ -153,7 +163,7 @@ const getLineHeightRatio = (style) => {
   return style.lineHeight / style.fontSize;
 };
 
-const resolveInteractiveTextStyle = (baseStyle, overrideStyle) => {
+export const resolveInteractiveTextStyle = (baseStyle, overrideStyle) => {
   if (!overrideStyle) return baseStyle;
 
   const resolvedStyle = mergeTextStyle(baseStyle, overrideStyle);
@@ -193,6 +203,9 @@ export const applyInteractiveTextStyle = (
   );
   const boxPositionX = textElement.x - currentOffsetX;
   const anchorPositionX = boxPositionX + layoutWidth * anchorRatios.x;
+  const anchorPositionY =
+    textElement.y + getMeasuredHeight(textElement) * anchorRatios.y;
+
   applyTextStyle(textElement, resolvedStyle);
 
   const nextMeasurements = getRuntimeTextLayout(textElement, resolvedStyle);
@@ -206,6 +219,7 @@ export const applyInteractiveTextStyle = (
 
   textElement.x =
     anchorPositionX - nextLayoutWidth * anchorRatios.x + nextOffsetX;
+  textElement.y = anchorPositionY - nextMeasurements.height * anchorRatios.y;
   textElement[TEXT_LAYOUT_STATE] = {
     ...(textElement[TEXT_LAYOUT_STATE] ?? {}),
     layoutWidth: nextLayoutWidth,

--- a/src/plugins/elements/text/textLayout.js
+++ b/src/plugins/elements/text/textLayout.js
@@ -66,16 +66,6 @@ const getMeasuredWidth = (textElement) => {
   return textElement.width;
 };
 
-const getMeasuredHeight = (textElement) => {
-  const layoutState = textElement[TEXT_LAYOUT_STATE];
-
-  if (typeof layoutState?.measuredHeight === "number") {
-    return layoutState.measuredHeight;
-  }
-
-  return textElement.height;
-};
-
 const setTextLayoutState = (textElement, textComputedNode, measurements) => {
   const fixedWidth = Boolean(textComputedNode.__fixedWidth);
   const runtimeMeasurements =
@@ -203,9 +193,6 @@ export const applyInteractiveTextStyle = (
   );
   const boxPositionX = textElement.x - currentOffsetX;
   const anchorPositionX = boxPositionX + layoutWidth * anchorRatios.x;
-  const anchorPositionY =
-    textElement.y + getMeasuredHeight(textElement) * anchorRatios.y;
-
   applyTextStyle(textElement, resolvedStyle);
 
   const nextMeasurements = getRuntimeTextLayout(textElement, resolvedStyle);
@@ -219,7 +206,6 @@ export const applyInteractiveTextStyle = (
 
   textElement.x =
     anchorPositionX - nextLayoutWidth * anchorRatios.x + nextOffsetX;
-  textElement.y = anchorPositionY - nextMeasurements.height * anchorRatios.y;
   textElement[TEXT_LAYOUT_STATE] = {
     ...(textElement[TEXT_LAYOUT_STATE] ?? {}),
     layoutWidth: nextLayoutWidth,

--- a/vt/reference/textbasicevent/event-rich-textstyle-hover-position-01.webp
+++ b/vt/reference/textbasicevent/event-rich-textstyle-hover-position-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d1c6bea5eac20ea0764936f5b1507285e5b04f6900bb2d0481bf78afb2411f2
+size 3826

--- a/vt/reference/textbasicevent/event-rich-textstyle-hover-position-02.webp
+++ b/vt/reference/textbasicevent/event-rich-textstyle-hover-position-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d1c6bea5eac20ea0764936f5b1507285e5b04f6900bb2d0481bf78afb2411f2
+size 3826

--- a/vt/reference/textbasicevent/event-rich-textstyle-hover-position-03.webp
+++ b/vt/reference/textbasicevent/event-rich-textstyle-hover-position-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51c2f2812549a207832f9bf22eb3f9dffd66a4c59534451a31f27eb390a6aec3
+size 4044

--- a/vt/reference/textbasicevent/event-rich-textstyle-hover-position-04.webp
+++ b/vt/reference/textbasicevent/event-rich-textstyle-hover-position-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d1c6bea5eac20ea0764936f5b1507285e5b04f6900bb2d0481bf78afb2411f2
+size 3826

--- a/vt/reference/textbasicevent/event-textstyle-hover-position-01.webp
+++ b/vt/reference/textbasicevent/event-textstyle-hover-position-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac74097bc8ac6781efbf0f4d85f201c7a2749bd0e4206e89e8207a072d4fc5bb
+size 4406

--- a/vt/reference/textbasicevent/event-textstyle-hover-position-02.webp
+++ b/vt/reference/textbasicevent/event-textstyle-hover-position-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac74097bc8ac6781efbf0f4d85f201c7a2749bd0e4206e89e8207a072d4fc5bb
+size 4406

--- a/vt/reference/textbasicevent/event-textstyle-hover-position-03.webp
+++ b/vt/reference/textbasicevent/event-textstyle-hover-position-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f58d1946d9e4ce9c31831ac97ac4568f0663551d8dae6c2639ba887400cac86
+size 6106

--- a/vt/reference/textbasicevent/event-textstyle-hover-position-03.webp
+++ b/vt/reference/textbasicevent/event-textstyle-hover-position-03.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1f58d1946d9e4ce9c31831ac97ac4568f0663551d8dae6c2639ba887400cac86
-size 6106
+oid sha256:3794c50d6e711abad68ec71172ea9dbacb012e63762f52c8e8894426c51843fc
+size 6356

--- a/vt/reference/textbasicevent/event-textstyle-hover-position-04.webp
+++ b/vt/reference/textbasicevent/event-textstyle-hover-position-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac74097bc8ac6781efbf0f4d85f201c7a2749bd0e4206e89e8207a072d4fc5bb
+size 4406

--- a/vt/specs/textbasicevent/event-rich-textstyle-hover-position.yaml
+++ b/vt/specs/textbasicevent/event-rich-textstyle-hover-position.yaml
@@ -1,9 +1,9 @@
 ---
-title: Anchored Text Position on Hover
-description: Verifies that interactive font metric changes preserve the configured text anchor; visible text and geometry guides are intentional because text placement is the behavior under test.
+title: Rich Text Position on Hover
+description: Verifies that a fully resolved hover text style keeps parsed rich-text line metrics and visual placement stable.
 specs:
-  - anchored text should stay centered on its configured position when hover changes font size
-  - horizontal anchor alignment should remain stable when hover changes text width
+  - ratio-based hover line height should remain normalized to pixels
+  - changing font weight and fill should not shift rich text vertically
   - pointer out should restore the base style without moving the text
 steps:
   - action: move
@@ -27,36 +27,39 @@ steps:
 ---
 states:
   - elements:
-      - id: horizontal-anchor-guide
+      - id: top-guide
         type: rect
         x: 180
-        "y": 159
+        "y": 129
         width: 360
         height: 2
         fill: "#737373"
       - id: anchor-guide
         type: rect
         x: 359
-        "y": 112
+        "y": 104
         width: 2
-        height: 120
+        height: 112
         fill: "#4D4D4D"
-      - id: anchored-hover-text
+      - id: rich-hover-text
         type: text
         x: 360
         "y": 160
         anchorX: 0.5
         anchorY: 0.5
-        content: Anchored hover text
+        content:
+          - text: Rich hover text
         textStyle:
           fontFamily: Arial
           fontSize: 40
-          lineHeight: 1.2
+          fontWeight: "700"
+          lineHeight: 1.5
           fill: "#A6A6A6"
         hover:
           cursor: pointer
           textStyle:
             fontFamily: Arial
-            fontSize: 52
-            lineHeight: 1.2
+            fontSize: 40
+            fontWeight: "400"
+            lineHeight: 1.5
             fill: "#FFFFFF"

--- a/vt/specs/textbasicevent/event-textstyle-hover-position.yaml
+++ b/vt/specs/textbasicevent/event-textstyle-hover-position.yaml
@@ -1,0 +1,62 @@
+---
+title: Anchored Text Position on Hover
+description: Verifies that interactive font metric changes do not move a text element vertically; visible text and geometry guides are intentional because text placement is the behavior under test.
+specs:
+  - anchored text should keep the same top position when hover changes font size
+  - horizontal anchor alignment should remain stable when hover changes text width
+  - pointer out should restore the base style without moving the text
+steps:
+  - action: move
+    x: 20
+    "y": 20
+  - action: wait
+    ms: 50
+  - action: screenshot
+  - action: move
+    x: 360
+    "y": 160
+  - action: wait
+    ms: 50
+  - action: screenshot
+  - action: move
+    x: 20
+    "y": 20
+  - action: wait
+    ms: 50
+  - action: screenshot
+---
+states:
+  - elements:
+      - id: top-guide
+        type: rect
+        x: 180
+        "y": 136
+        width: 360
+        height: 2
+        fill: "#737373"
+      - id: anchor-guide
+        type: rect
+        x: 359
+        "y": 112
+        width: 2
+        height: 120
+        fill: "#4D4D4D"
+      - id: anchored-hover-text
+        type: text
+        x: 360
+        "y": 160
+        anchorX: 0.5
+        anchorY: 0.5
+        content: Anchored hover text
+        textStyle:
+          fontFamily: Arial
+          fontSize: 40
+          lineHeight: 1.2
+          fill: "#A6A6A6"
+        hover:
+          cursor: pointer
+          textStyle:
+            fontFamily: Arial
+            fontSize: 52
+            lineHeight: 1.2
+            fill: "#FFFFFF"


### PR DESCRIPTION
## Summary
- normalize ratio-based interactive line height before applying hover, click, and right-click styles to rich text
- preserve the existing `anchorY` contract when an interactive style intentionally changes text metrics
- add plain-anchor and client-style rich-text VT coverage, and bump route-graphics to 1.27.1

## Root cause
RouteVN Creator projects layout text through Route Graphics rich content so segment font weights are preserved. Parsing converts the base line height ratio to pixels (`36 * 1.5 = 54`), but the rich-text interaction path merged the fully resolved hover resource directly into Pixi and replaced `54` with the raw `1.5` ratio. That collapsed line metrics and visibly shifted the text on hover.

The previous fix only changed plain Pixi text positioning and violated nonzero `anchorY` semantics; this update restores that contract and fixes the rich-text metric normalization instead.

## Testing
- `bunx vitest run --maxWorkers=4` (87 files, 673 tests)
- `bun run lint`
- `bun run build`
- focused plain + rich hover VT report (8 images, 0 mismatches)
- RouteVN Creator rich-text projection tests (3 tests)