### PR TITLE
feat(text-revealing): add reveal sound stop timing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/pages/docs/nodes/text-revealing.md
+++ b/playground/pages/docs/nodes/text-revealing.md
@@ -31,6 +31,7 @@ Try it in the [Playground](/playground/?template=text-revealing).
 | `initialRevealedCharacters` | number                               | No                  | `0`            | Leading characters to paint as already revealed before the animation starts.                                                    |
 | `revealEffect`              | `typewriter` \| `softWipe` \| `none` | No                  | `typewriter`   | `softWipe` reveals pre-laid-out text with a soft left-to-right mask, one laid-out line at a time. `none` renders instantly.     |
 | `softWipe`                  | object                               | No                  | see below      | Parameters used when `revealEffect: softWipe`.                                                                                  |
+| `revealSound`               | object                               | No                  | -              | Sound played while text reveals. By default, it stops at the end of the active loop iteration.                                  |
 | `indicator`                 | object                               | No                  | -              | Revealing/complete visual config + offset. Supports static images and spritesheets.                                             |
 | `complete`                  | object                               | No                  | -              | Parsed and kept in computed node.                                                                                               |
 
@@ -104,6 +105,25 @@ Spritesheet indicator visuals use the same `src`, `atlas`, `clips`, and `playbac
 | `easing`      | `linear` \| `easeOutCubic` | `linear` |
 | `lineOverlap` | number `0..0.95`           | `0`      |
 | `lineDelay`   | number                     | `0`      |
+
+### `revealSound`
+
+| Field        | Type                     | Default   | Notes                                                                                      |
+| ------------ | ------------------------ | --------- | ------------------------------------------------------------------------------------------ |
+| `src`        | string                   | -         | Required audio asset alias or URL.                                                         |
+| `volume`     | number                   | `100`     | Volume from `0` to `100`.                                                                  |
+| `loop`       | boolean                  | `true`    | Loops the sound while text is revealing.                                                   |
+| `stopTiming` | `loopEnd` \| `immediate` | `loopEnd` | `loopEnd` finishes the active loop iteration; `immediate` interrupts playback immediately. |
+
+Abort, update, and deletion always stop the reveal sound immediately. The finishing audio tail does not delay `renderComplete`.
+
+```yaml
+revealSound:
+  src: typing-loop
+  volume: 70
+  loop: true
+  stopTiming: loopEnd
+```
 
 ## Behavior Notes
 

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -239,6 +239,44 @@ describe("AudioStage graph rendering", () => {
     expect(findCurrentSound(stage, "sfx").gainNode.gain.value).toBe(1);
   });
 
+  it("finishes direct audio at its active loop end", async () => {
+    const { stage, context } = await setupAudioStage();
+
+    stage.add({ id: "typing", url: "voice-blip", loop: true });
+    stage.tick();
+
+    const source = context.sources[0];
+    expect(source.loop).toBe(true);
+
+    stage.finish("typing");
+    stage.tick();
+
+    expect(source.loop).toBe(false);
+    expect(source.stop).not.toHaveBeenCalled();
+    expect(stage.getById("typing")).toBeUndefined();
+    expect(findSound(stage, "typing")?.finishing).toBe(true);
+
+    source.onended();
+
+    expect(findSound(stage, "typing")).toBeUndefined();
+  });
+
+  it("stops a finishing direct sound before reusing its id", async () => {
+    const { stage, context } = await setupAudioStage();
+
+    stage.add({ id: "typing", url: "voice-blip", loop: true });
+    stage.tick();
+    const finishingSource = context.sources[0];
+
+    stage.finish("typing");
+    stage.add({ id: "typing", url: "voice-blip", loop: true });
+    stage.tick();
+
+    expect(finishingSource.stop).toHaveBeenCalled();
+    expect(context.sources).toHaveLength(2);
+    expect(context.sources[1].loop).toBe(true);
+  });
+
   it("resumes a suspended audio context before playback starts", async () => {
     const { stage, context } = await setupAudioStage();
     context.state = "suspended";

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -277,6 +277,22 @@ describe("AudioStage graph rendering", () => {
     expect(context.sources[1].loop).toBe(true);
   });
 
+  it("stops rather than defers a finishing sound in a suspended context", async () => {
+    const { stage, context } = await setupAudioStage();
+    context.state = "suspended";
+    context.resume.mockRejectedValue(new Error("autoplay blocked"));
+
+    stage.add({ id: "typing", url: "voice-blip", loop: true });
+    stage.tick();
+    await flushPromises();
+
+    const source = context.sources[0];
+    stage.finish("typing");
+
+    expect(source.stop).toHaveBeenCalled();
+    expect(findSound(stage, "typing")).toBeUndefined();
+  });
+
   it("resumes a suspended audio context before playback starts", async () => {
     const { stage, context } = await setupAudioStage();
     context.state = "suspended";

--- a/spec/elements/textRevealingRuntime.revealSound.spec.js
+++ b/spec/elements/textRevealingRuntime.revealSound.spec.js
@@ -2,7 +2,10 @@ import { Container } from "pixi.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { parseTextRevealing } from "../../src/plugins/elements/text-revealing/parseTextRevealing.js";
-import { runTextReveal } from "../../src/plugins/elements/text-revealing/textRevealingRuntime.js";
+import {
+  clearTextRevealingContainer,
+  runTextReveal,
+} from "../../src/plugins/elements/text-revealing/textRevealingRuntime.js";
 
 const createCompletionTracker = () => ({
   getVersion: () => 0,
@@ -51,7 +54,7 @@ describe("runTextReveal revealSound", () => {
     vi.useRealTimers();
   });
 
-  it("lets the active typewriter sound playback finish on completion by default", async () => {
+  it("keeps the finishing typewriter sound cancellable after completion", async () => {
     const container = new Container();
     const audioStage = createAudioStage();
     const element = createElement({
@@ -88,6 +91,12 @@ describe("runTextReveal revealSound", () => {
       expect.stringContaining("line-1"),
     );
     expect(audioStage.remove).not.toHaveBeenCalled();
+
+    clearTextRevealingContainer(container);
+
+    expect(audioStage.remove).toHaveBeenCalledWith(
+      expect.stringContaining("line-1"),
+    );
   });
 
   it("can stop the typewriter sound immediately on completion", async () => {
@@ -218,5 +227,11 @@ describe("runTextReveal revealSound", () => {
       expect.stringContaining("line-1"),
     );
     expect(audioStage.remove).not.toHaveBeenCalled();
+
+    clearTextRevealingContainer(container);
+
+    expect(audioStage.remove).toHaveBeenCalledWith(
+      expect.stringContaining("line-1"),
+    );
   });
 });

--- a/spec/elements/textRevealingRuntime.revealSound.spec.js
+++ b/spec/elements/textRevealingRuntime.revealSound.spec.js
@@ -13,6 +13,7 @@ const createCompletionTracker = () => ({
 const createAudioStage = () => ({
   add: vi.fn(),
   remove: vi.fn(),
+  finish: vi.fn(),
   tick: vi.fn(),
 });
 
@@ -50,7 +51,7 @@ describe("runTextReveal revealSound", () => {
     vi.useRealTimers();
   });
 
-  it("plays a configured loop while typewriter text is revealing and stops on completion", async () => {
+  it("lets the active typewriter sound playback finish on completion by default", async () => {
     const container = new Container();
     const audioStage = createAudioStage();
     const element = createElement({
@@ -83,9 +84,40 @@ describe("runTextReveal revealSound", () => {
     await vi.runAllTimersAsync();
     await reveal;
 
+    expect(audioStage.finish).toHaveBeenCalledWith(
+      expect.stringContaining("line-1"),
+    );
+    expect(audioStage.remove).not.toHaveBeenCalled();
+  });
+
+  it("can stop the typewriter sound immediately on completion", async () => {
+    const container = new Container();
+    const audioStage = createAudioStage();
+    const element = createElement({
+      revealSound: {
+        src: "voice-blip",
+        stopTiming: "immediate",
+      },
+    });
+
+    const reveal = runTextReveal({
+      container,
+      element,
+      completionTracker: createCompletionTracker(),
+      animationBus: { dispatch: vi.fn() },
+      zIndex: 0,
+      signal: new AbortController().signal,
+      app: { audioStage },
+      playback: "autoplay",
+    });
+
+    await vi.runAllTimersAsync();
+    await reveal;
+
     expect(audioStage.remove).toHaveBeenCalledWith(
       expect.stringContaining("line-1"),
     );
+    expect(audioStage.finish).not.toHaveBeenCalled();
   });
 
   it("stops typewriter reveal sound when the reveal is aborted", async () => {
@@ -113,6 +145,7 @@ describe("runTextReveal revealSound", () => {
     expect(audioStage.remove).toHaveBeenCalledWith(
       expect.stringContaining("line-1"),
     );
+    expect(audioStage.finish).not.toHaveBeenCalled();
   });
 
   it("does not play sound for paused initial or instant reveal renders", async () => {
@@ -144,6 +177,7 @@ describe("runTextReveal revealSound", () => {
 
     expect(audioStage.add).not.toHaveBeenCalled();
     expect(audioStage.remove).not.toHaveBeenCalled();
+    expect(audioStage.finish).not.toHaveBeenCalled();
   });
 
   it("plays soft-wipe reveal sound until the animation completes", async () => {
@@ -180,8 +214,9 @@ describe("runTextReveal revealSound", () => {
 
     startAction.payload.onComplete();
 
-    expect(audioStage.remove).toHaveBeenCalledWith(
+    expect(audioStage.finish).toHaveBeenCalledWith(
       expect.stringContaining("line-1"),
     );
+    expect(audioStage.remove).not.toHaveBeenCalled();
   });
 });

--- a/spec/parser/parseTextRevealing.revealSound.spec.js
+++ b/spec/parser/parseTextRevealing.revealSound.spec.js
@@ -30,16 +30,18 @@ describe("parseTextRevealing revealSound", () => {
       src: "voice-blip",
       volume: 100,
       loop: true,
+      stopTiming: "loopEnd",
     });
   });
 
-  it("preserves object volume and loop overrides", () => {
+  it("preserves object volume, loop, and stop timing overrides", () => {
     const parsed = parseTextRevealing({
       state: createState({
         revealSound: {
           src: "voice-blip",
           volume: 45,
           loop: false,
+          stopTiming: "immediate",
         },
       }),
     });
@@ -48,6 +50,7 @@ describe("parseTextRevealing revealSound", () => {
       src: "voice-blip",
       volume: 45,
       loop: false,
+      stopTiming: "immediate",
     });
   });
 
@@ -83,5 +86,18 @@ describe("parseTextRevealing revealSound", () => {
         }),
       }),
     ).toThrow("Input Error: revealSound.loop must be a boolean.");
+
+    expect(() =>
+      parseTextRevealing({
+        state: createState({
+          revealSound: {
+            src: "voice-blip",
+            stopTiming: "later",
+          },
+        }),
+      }),
+    ).toThrow(
+      "Input Error: revealSound.stopTiming must be one of loopEnd, immediate.",
+    );
   });
 });

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -412,6 +412,9 @@ const createSoundInstance = ({ sound, channelNode, internalId }) => {
     gainNode,
     pannerNode,
     source: null,
+    sourceEnded: false,
+    onSourceEnded: null,
+    finishing: false,
     playbackRateTransition: null,
     pendingTimeoutId: null,
     cleanupTimeoutId: null,
@@ -446,6 +449,16 @@ const createSourceForSound = (sound) => {
   sound.playbackRateTransition = null;
 
   connect(source, sound.gainNode);
+
+  sound.sourceEnded = false;
+  source.onended = () => {
+    if (sound.source !== source) {
+      return;
+    }
+
+    sound.sourceEnded = true;
+    sound.onSourceEnded?.();
+  };
 
   const offset = sound.startAt ?? 0;
   const duration =
@@ -549,6 +562,8 @@ const stopSource = (sound, delayMs = 0) => {
 };
 
 const cleanupSound = (sound) => {
+  sound.onSourceEnded = null;
+
   if (sound.pendingTimeoutId !== null) {
     clearTimeout(sound.pendingTimeoutId);
     sound.pendingTimeoutId = null;
@@ -862,6 +877,9 @@ export const createAudioStage = () => {
   const removeSoundInstance = (instance, effects, inheritedDuration = 0) => {
     if (!instance) return 0;
 
+    instance.finishing = false;
+    instance.onSourceEnded = null;
+
     const volumeTransition = getTransitionPhase(
       effects,
       instance.id,
@@ -909,6 +927,36 @@ export const createAudioStage = () => {
     }, duration);
 
     return duration;
+  };
+
+  const finishSoundInstance = (instance) => {
+    if (!instance || instance.finishing) {
+      return;
+    }
+
+    instance.finishing = true;
+    instance.loop = false;
+
+    const cleanupFinishedSound = () => {
+      if (!instance.finishing) {
+        return;
+      }
+
+      instance.finishing = false;
+      instance.onSourceEnded = null;
+      cleanupSound(instance);
+      if (sounds.get(instance.internalId) === instance) {
+        sounds.delete(instance.internalId);
+      }
+    };
+
+    if (!instance.source || instance.sourceEnded) {
+      cleanupFinishedSound();
+      return;
+    }
+
+    instance.source.loop = false;
+    instance.onSourceEnded = cleanupFinishedSound;
   };
 
   const updateSoundInstance = ({ instance, sound, effects }) => {
@@ -1144,6 +1192,11 @@ export const createAudioStage = () => {
   };
 
   const add = (element) => {
+    const existingInstance = sounds.get(`direct:${element.id}`);
+    if (existingInstance?.finishing) {
+      removeSoundInstance(existingInstance, [], 0);
+    }
+
     const audio = {
       id: element.id,
       type: "sound",
@@ -1187,6 +1240,19 @@ export const createAudioStage = () => {
     }
   };
 
+  const finish = (id) => {
+    const internalId = `direct:${id}`;
+    const instance = sounds.get(internalId);
+    debugAudio("direct finish", {
+      id,
+      hadAudio: directAudios.has(id),
+      hadInstance: Boolean(instance),
+    });
+    directAudios.delete(id);
+    currentSoundKeyById.delete(id);
+    finishSoundInstance(instance);
+  };
+
   const getById = (id) => directAudios.get(id);
 
   const resume = () => resumeAudioContext(getAudioContext());
@@ -1227,7 +1293,11 @@ export const createAudioStage = () => {
     }
 
     for (const [internalId, instance] of sounds) {
-      if (internalId.startsWith("direct:") && !directAudios.has(instance.id)) {
+      if (
+        internalId.startsWith("direct:") &&
+        !directAudios.has(instance.id) &&
+        !instance.finishing
+      ) {
         removeSoundInstance(instance, [], 0);
         currentSoundKeyById.delete(instance.id);
       }
@@ -1253,6 +1323,7 @@ export const createAudioStage = () => {
   return {
     add,
     remove,
+    finish,
     getById,
     resume,
     tick,

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -950,7 +950,11 @@ export const createAudioStage = () => {
       }
     };
 
-    if (!instance.source || instance.sourceEnded) {
+    if (
+      !instance.source ||
+      instance.sourceEnded ||
+      getAudioContext().state !== "running"
+    ) {
       cleanupFinishedSound();
       return;
     }

--- a/src/plugins/elements/text-revealing/parseTextRevealing.js
+++ b/src/plugins/elements/text-revealing/parseTextRevealing.js
@@ -28,6 +28,9 @@ const INDICATOR_VISUAL_KINDS = ["image", "spritesheet"];
 const INDICATOR_VISUAL_KIND_SET = new Set(INDICATOR_VISUAL_KINDS);
 const DEFAULT_REVEAL_SOUND_VOLUME = 100;
 const DEFAULT_REVEAL_SOUND_LOOP = true;
+const DEFAULT_REVEAL_SOUND_STOP_TIMING = "loopEnd";
+const REVEAL_SOUND_STOP_TIMINGS = ["loopEnd", "immediate"];
+const REVEAL_SOUND_STOP_TIMING_SET = new Set(REVEAL_SOUND_STOP_TIMINGS);
 
 export const normalizeFuriganaPlacement = (placement, path) => {
   if (placement === undefined) {
@@ -148,6 +151,22 @@ const normalizeRevealSoundLoop = (loop, path) => {
   throw new Error(`Input Error: ${path}.loop must be a boolean.`);
 };
 
+const normalizeRevealSoundStopTiming = (stopTiming, path) => {
+  if (stopTiming === undefined) {
+    return DEFAULT_REVEAL_SOUND_STOP_TIMING;
+  }
+
+  if (REVEAL_SOUND_STOP_TIMING_SET.has(stopTiming)) {
+    return stopTiming;
+  }
+
+  throw new Error(
+    `Input Error: ${path}.stopTiming must be one of ${REVEAL_SOUND_STOP_TIMINGS.join(
+      ", ",
+    )}.`,
+  );
+};
+
 export const normalizeRevealSound = (revealSound, path = "revealSound") => {
   if (revealSound === undefined || revealSound === null) {
     return null;
@@ -165,6 +184,7 @@ export const normalizeRevealSound = (revealSound, path = "revealSound") => {
     src: revealSound.src,
     volume: normalizeRevealSoundVolume(revealSound.volume, path),
     loop: normalizeRevealSoundLoop(revealSound.loop, path),
+    stopTiming: normalizeRevealSoundStopTiming(revealSound.stopTiming, path),
   };
 };
 

--- a/src/plugins/elements/text-revealing/textRevealingRuntime.js
+++ b/src/plugins/elements/text-revealing/textRevealingRuntime.js
@@ -188,17 +188,26 @@ const startTextRevealSound = ({ app, element }) => {
     directAudio: app.audioStage.getById?.(soundId) ?? null,
   });
 
-  return () => {
+  return ({ completed = false } = {}) => {
     if (stopped) {
       return;
     }
 
     stopped = true;
+    const finishPlayback =
+      completed && (revealSound.stopTiming ?? "loopEnd") === "loopEnd";
     debugRevealSound("stop", {
       elementId: element.id,
       soundId,
       src: revealSound.src,
+      finishPlayback,
     });
+
+    if (finishPlayback && typeof app.audioStage.finish === "function") {
+      app.audioStage.finish(soundId);
+      return;
+    }
+
     app.audioStage.remove(soundId);
     app.audioStage.tick?.();
   };
@@ -1398,7 +1407,7 @@ const runSoftWipeReveal = ({
     finalized = true;
 
     unregisterTextRevealRuntime(container, finalizeCleanup);
-    stopRevealSound();
+    stopRevealSound({ completed });
 
     lineMasks.forEach((lineMask) => {
       if (lineMask.line.container.mask === lineMask.sprite) {
@@ -1611,8 +1620,10 @@ export const runTextReveal = async ({
       const stopRevealSound = shouldPlayRevealSound
         ? startTextRevealSound({ app, element })
         : () => {};
-      const cleanupRevealSound = () => {
-        stopRevealSound();
+      const cleanupRevealSound = ({
+        completed: revealCompleted = false,
+      } = {}) => {
+        stopRevealSound({ completed: revealCompleted });
       };
 
       if (shouldPlayRevealSound) {
@@ -1629,7 +1640,9 @@ export const runTextReveal = async ({
           snapshot: nextSnapshot,
         });
       } finally {
-        cleanupRevealSound();
+        cleanupRevealSound({
+          completed: completed && !signal?.aborted && !container.destroyed,
+        });
         unregisterTextRevealRuntime(container, cleanupRevealSound);
       }
     }

--- a/src/plugins/elements/text-revealing/textRevealingRuntime.js
+++ b/src/plugins/elements/text-revealing/textRevealingRuntime.js
@@ -164,7 +164,7 @@ const startTextRevealSound = ({ app, element }) => {
 
   const soundId = getTextRevealSoundId(element);
   const volume = normalizeVolume(revealSound.volume, 100);
-  let stopped = false;
+  let stopState = "active";
 
   debugRevealSound("start", {
     elementId: element.id,
@@ -189,13 +189,18 @@ const startTextRevealSound = ({ app, element }) => {
   });
 
   return ({ completed = false } = {}) => {
-    if (stopped) {
-      return;
+    if (stopState === "stopped") {
+      return false;
     }
 
-    stopped = true;
+    if (stopState === "finishing" && completed) {
+      return true;
+    }
+
     const finishPlayback =
-      completed && (revealSound.stopTiming ?? "loopEnd") === "loopEnd";
+      stopState === "active" &&
+      completed &&
+      (revealSound.stopTiming ?? "loopEnd") === "loopEnd";
     debugRevealSound("stop", {
       elementId: element.id,
       soundId,
@@ -204,12 +209,15 @@ const startTextRevealSound = ({ app, element }) => {
     });
 
     if (finishPlayback && typeof app.audioStage.finish === "function") {
+      stopState = "finishing";
       app.audioStage.finish(soundId);
-      return;
+      return true;
     }
 
+    stopState = "stopped";
     app.audioStage.remove(soundId);
     app.audioStage.tick?.();
+    return false;
   };
 };
 
@@ -1406,8 +1414,10 @@ const runSoftWipeReveal = ({
 
     finalized = true;
 
-    unregisterTextRevealRuntime(container, finalizeCleanup);
-    stopRevealSound({ completed });
+    const hasFinishingSound = stopRevealSound({ completed });
+    if (!hasFinishingSound) {
+      unregisterTextRevealRuntime(container, finalizeCleanup);
+    }
 
     lineMasks.forEach((lineMask) => {
       if (lineMask.line.container.mask === lineMask.sprite) {
@@ -1433,6 +1443,11 @@ const runSoftWipeReveal = ({
   };
 
   const finalizeCleanup = () => {
+    if (finalized) {
+      stopRevealSound();
+      return;
+    }
+
     animationBus.dispatch({
       type: "CANCEL",
       id: animationId,
@@ -1623,7 +1638,7 @@ export const runTextReveal = async ({
       const cleanupRevealSound = ({
         completed: revealCompleted = false,
       } = {}) => {
-        stopRevealSound({ completed: revealCompleted });
+        return stopRevealSound({ completed: revealCompleted });
       };
 
       if (shouldPlayRevealSound) {
@@ -1640,10 +1655,12 @@ export const runTextReveal = async ({
           snapshot: nextSnapshot,
         });
       } finally {
-        cleanupRevealSound({
+        const hasFinishingSound = cleanupRevealSound({
           completed: completed && !signal?.aborted && !container.destroyed,
         });
-        unregisterTextRevealRuntime(container, cleanupRevealSound);
+        if (!hasFinishingSound) {
+          unregisterTextRevealRuntime(container, cleanupRevealSound);
+        }
       }
     }
 

--- a/src/schemas/elements/text-revealing.element.yaml
+++ b/src/schemas/elements/text-revealing.element.yaml
@@ -274,6 +274,11 @@ properties:
         type: boolean
         description: Whether the reveal sound loops until the reveal finishes
         default: true
+      stopTiming:
+        type: string
+        enum: [loopEnd, immediate]
+        description: When to stop the reveal sound after the text reveal completes. loopEnd finishes the active loop iteration; immediate interrupts playback. Abort, update, and deletion always stop immediately.
+        default: loopEnd
   textStyle:
     "$ref": "#/$def/textStyle"
   complete:

--- a/src/types.js
+++ b/src/types.js
@@ -584,6 +584,7 @@
  * @property {string} revealSound.src - Source alias or URL for the reveal sound
  * @property {number} [revealSound.volume=100] - Reveal sound volume where 0 is muted and 100 is full volume
  * @property {boolean} [revealSound.loop=true] - Whether the reveal sound loops until revealing finishes
+ * @property {'loopEnd' | 'immediate'} [revealSound.stopTiming='loopEnd'] - When to stop after revealing completes; loopEnd finishes the active iteration while immediate interrupts playback
  * @typedef {ComputedNode & TextRevealingComputedProps} TextRevealingComputedNode
  */
 

--- a/vt/specs/textrevealing/text-revealing-reveal-sound-stop-timing.yaml
+++ b/vt/specs/textrevealing/text-revealing-reveal-sound-stop-timing.yaml
@@ -1,0 +1,60 @@
+---
+title: Text Revealing - Reveal Sound Stop Timing
+description: Manual audio fixture comparing loopEnd and immediate reveal-sound stop timing.
+skipScreenshot: true
+specs:
+  - state 1 is silent so pressing n or clicking Next starts audio from a user gesture
+  - state 2 should loop message-display1 while the text reveals, then finish the active loop iteration without starting another
+  - state 3 resets to silence before the next case
+  - state 4 should loop message-display1 while the text reveals, then interrupt it immediately when the final character appears
+  - state 5 is silent
+---
+states:
+  - id: reveal-sound-stop-timing-ready
+    elements: []
+  - id: reveal-sound-loop-end
+    elements:
+      - id: reveal-sound-loop-end-line
+        type: text-revealing
+        x: 80
+        "y": 120
+        width: 620
+        speed: 12
+        revealEffect: typewriter
+        revealSound:
+          src: message-display1
+          volume: 70
+          loop: true
+          stopTiming: loopEnd
+        content:
+          - text: "loopEnd finishes the active sound iteration."
+            textStyle:
+              fontSize: 30
+              fill: "#FFFFFF"
+              fontFamily: Arial
+              lineHeight: 1.35
+  - id: reveal-sound-stop-timing-reset
+    elements: []
+  - id: reveal-sound-immediate
+    elements:
+      - id: reveal-sound-immediate-line
+        type: text-revealing
+        x: 80
+        "y": 120
+        width: 620
+        speed: 12
+        revealEffect: typewriter
+        revealSound:
+          src: message-display1
+          volume: 70
+          loop: true
+          stopTiming: immediate
+        content:
+          - text: "immediate interrupts the sound on the final character."
+            textStyle:
+              fontSize: 30
+              fill: "#FFFFFF"
+              fontFamily: Arial
+              lineHeight: 1.35
+  - id: reveal-sound-stop-timing-finished
+    elements: []

--- a/vt/specs/textrevealing/text-revealing-reveal-sound.yaml
+++ b/vt/specs/textrevealing/text-revealing-reveal-sound.yaml
@@ -1,10 +1,10 @@
 ---
 title: Text Revealing - Reveal Sound
-description: Manual fixture for text-revealing revealSound playback. The configured sound should loop while text is actively revealing and stop when the reveal completes.
+description: Manual fixture for text-revealing revealSound playback. The configured sound should loop while text is actively revealing, finish its active playback, and then stop when the reveal completes.
 specs:
   - revealSound should use object config with src, volume, and loop
   - sound should start when the typewriter reveal begins
-  - sound should stop after the text finishes revealing
+  - sound should finish its active playback after the text finishes revealing, then stop without starting another loop
 steps:
   - action: screenshot
   - action: keypress
@@ -36,6 +36,7 @@ states:
           src: message-display1
           volume: 70
           loop: true
+          stopTiming: loopEnd
         indicator:
           revealing:
             src: circle-red


### PR DESCRIPTION
## Summary
- add `revealSound.stopTiming` with `loopEnd` as the default and `immediate` as the opt-out
- let completed reveal sounds finish their active loop iteration while keeping abort, update, and deletion cleanup immediate
- keep loop-end tails cancellable until source completion and discard suspended-context sources instead of deferring stale playback
- add parser, runtime, and audio-stage coverage, including safe cleanup and same-ID reuse
- add VT coverage for both `loopEnd` and `immediate` behavior
- document the interface and bump the feature version to `1.28.0`

## Testing
- `bunx vitest run` — 87 files, 677 tests passed
- `bunx prettier --check ...`
- `bunx oxlint ...`
- `bun run vt:generate` — 235 files generated, including `text-revealing-reveal-sound-stop-timing.html`