### PR TITLE
fix: apply volume to hover sounds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/elements/eventSemantics.spec.js
+++ b/spec/elements/eventSemantics.spec.js
@@ -67,6 +67,8 @@ describe("event semantics", () => {
         alpha: 1,
         fill: "#FFFFFF",
         hover: {
+          soundSrc: "rect-hover.mp3",
+          soundVolume: 25,
           payload: { source: "hover" },
         },
         click: {
@@ -114,6 +116,12 @@ describe("event semantics", () => {
     expect(eventHandler.mock.calls[4][1]).toMatchObject({
       _event: { id: "rect-1" },
       direction: "down",
+    });
+    expect(shared.app.audioStage.add).toHaveBeenCalledWith({
+      id: expect.stringMatching(/^hover-/),
+      url: "rect-hover.mp3",
+      loop: false,
+      volume: 0.25,
     });
   });
 
@@ -269,7 +277,11 @@ describe("event semantics", () => {
         width: 120,
         height: 120,
         alpha: 1,
-        hover: { payload: { source: "hover" } },
+        hover: {
+          soundSrc: "sprite-hover.mp3",
+          soundVolume: 40,
+          payload: { source: "hover" },
+        },
         click: { payload: { source: "click" } },
         rightClick: { payload: { source: "rightClick" } },
         scrollUp: { payload: { direction: "up" } },
@@ -305,6 +317,12 @@ describe("event semantics", () => {
     expect(eventHandler.mock.calls[4][1]).toMatchObject({
       _event: { id: "sprite-1" },
       direction: "down",
+    });
+    expect(shared.app.audioStage.add).toHaveBeenCalledWith({
+      id: expect.stringMatching(/^hover-/),
+      url: "sprite-hover.mp3",
+      loop: false,
+      volume: 0.4,
     });
   });
 
@@ -401,7 +419,11 @@ describe("event semantics", () => {
           fill: "#FFFFFF",
           fontFamily: "Arial",
         },
-        hover: { payload: { source: "hover" } },
+        hover: {
+          soundSrc: "text-hover.mp3",
+          soundVolume: 55,
+          payload: { source: "hover" },
+        },
         click: { payload: { source: "click" } },
         rightClick: { payload: { source: "rightClick" } },
         scrollUp: { payload: { direction: "up" } },
@@ -437,6 +459,12 @@ describe("event semantics", () => {
     expect(eventHandler.mock.calls[4][1]).toMatchObject({
       _event: { id: "text-1" },
       direction: "down",
+    });
+    expect(shared.app.audioStage.add).toHaveBeenCalledWith({
+      id: expect.stringMatching(/^hover-/),
+      url: "text-hover.mp3",
+      loop: false,
+      volume: 0.55,
     });
   });
 
@@ -501,7 +529,11 @@ describe("event semantics", () => {
         height: 200,
         alpha: 1,
         children: [],
-        hover: { payload: { source: "hover" } },
+        hover: {
+          soundSrc: "container-hover.mp3",
+          soundVolume: 70,
+          payload: { source: "hover" },
+        },
         click: { payload: { source: "click" } },
         rightClick: { payload: { source: "rightClick" } },
         scrollUp: { payload: { direction: "up" } },
@@ -530,6 +562,12 @@ describe("event semantics", () => {
     expect(eventHandler.mock.calls[4][1]).toMatchObject({
       _event: { id: "container-1" },
       direction: "down",
+    });
+    expect(shared.app.audioStage.add).toHaveBeenCalledWith({
+      id: expect.stringMatching(/^hover-/),
+      url: "container-hover.mp3",
+      loop: false,
+      volume: 0.7,
     });
   });
 
@@ -591,6 +629,10 @@ describe("event semantics", () => {
         max: 100,
         step: 1,
         initialValue: 0,
+        hover: {
+          soundSrc: "slider-hover.mp3",
+          soundVolume: 85,
+        },
         change: {
           payload: { source: "drag" },
         },
@@ -598,6 +640,7 @@ describe("event semantics", () => {
     });
 
     const slider = parent.getChildByLabel("slider-1");
+    slider.emit("pointerover");
     slider.emit("pointerdown", { global: { x: 280, y: 110 } });
     slider.emit("globalpointermove", { global: { x: 290, y: 110 } });
     slider.emit("pointerup");
@@ -611,6 +654,12 @@ describe("event semantics", () => {
       source: "drag",
     });
     expect(eventHandler.mock.calls[0][1]._event.value).toBeTypeOf("number");
+    expect(shared.app.audioStage.add).toHaveBeenCalledWith({
+      id: expect.stringMatching(/^hover-/),
+      url: "slider-hover.mp3",
+      loop: false,
+      volume: 0.85,
+    });
   });
 
   it("keyboard manager emits keydown and keyup payloads for registered keys", () => {

--- a/spec/elements/updateRect.spec.js
+++ b/spec/elements/updateRect.spec.js
@@ -537,4 +537,65 @@ describe("updateRect", () => {
       }),
     );
   });
+
+  it("applies hover sound volume after rebinding interactions", () => {
+    const parent = new Container();
+    const rectElement = new Graphics();
+    const audioStage = { add: vi.fn() };
+    rectElement.label = "rect-1";
+    parent.addChild(rectElement);
+    const prevElement = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 0,
+        y: 0,
+        width: 120,
+        height: 80,
+        fill: "#737373",
+        alpha: 1,
+      },
+    });
+    const nextElement = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 0,
+        y: 0,
+        width: 120,
+        height: 80,
+        fill: "#737373",
+        alpha: 1,
+        hover: {
+          soundSrc: "hover.mp3",
+          soundVolume: 45,
+        },
+      },
+    });
+
+    updateRect({
+      app: { audioStage },
+      parent,
+      prevElement,
+      nextElement,
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker: {
+        getVersion: () => 0,
+        track: () => {},
+        complete: () => {},
+      },
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    rectElement.emit("pointerover");
+
+    expect(audioStage.add).toHaveBeenCalledWith({
+      id: expect.stringMatching(/^hover-/),
+      url: "hover.mp3",
+      loop: false,
+      volume: 0.45,
+    });
+  });
 });

--- a/spec/elements/updateSprite.spec.js
+++ b/spec/elements/updateSprite.spec.js
@@ -370,4 +370,74 @@ describe("updateSprite", () => {
     expect(spriteElement.y).toBe(280);
     expect(spriteElement.rotation).toBeCloseTo(Math.PI / 4);
   });
+
+  it("applies hover sound volume after rebinding interactions", () => {
+    const listeners = new Map();
+    const audioStage = { add: vi.fn() };
+    const spriteElement = {
+      label: "sprite-1",
+      texture: { src: "sprite" },
+      x: 0,
+      y: 0,
+      width: 80,
+      height: 60,
+      alpha: 1,
+      rotation: 0,
+      pivot: {
+        set: vi.fn(),
+      },
+      scale: {
+        x: 1,
+        y: 1,
+      },
+      zIndex: 0,
+      removeAllListeners: vi.fn(),
+      on: vi.fn((name, listener) => {
+        listeners.set(name, listener);
+      }),
+    };
+    const prevElement = {
+      id: "sprite-1",
+      type: "sprite",
+      src: "sprite",
+      x: 0,
+      y: 0,
+      width: 80,
+      height: 60,
+      alpha: 1,
+    };
+
+    updateSprite({
+      app: { audioStage },
+      parent: {
+        children: [spriteElement],
+      },
+      prevElement,
+      nextElement: {
+        ...prevElement,
+        hover: {
+          soundSrc: "hover.mp3",
+          soundVolume: 35,
+        },
+      },
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker: {
+        getVersion: () => 0,
+        track: () => {},
+        complete: () => {},
+      },
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    listeners.get("pointerover")();
+
+    expect(audioStage.add).toHaveBeenCalledWith({
+      id: expect.stringMatching(/^hover-/),
+      url: "hover.mp3",
+      loop: false,
+      volume: 0.35,
+    });
+  });
 });

--- a/spec/parser/parseCommonObject.test.yaml
+++ b/spec/parser/parseCommonObject.test.yaml
@@ -20,6 +20,7 @@ in:
     height: 29
     hover:
       soundSrc: sound-1
+      soundVolume: 25
       cursor: cursor-1
       payload:
         prop1: "44"
@@ -41,6 +42,7 @@ out:
   alpha: 1
   hover:
     soundSrc: sound-1
+    soundVolume: 25
     cursor: cursor-1
     payload:
       prop1: "44"
@@ -153,6 +155,7 @@ in:
     height: 60
     hover:
       soundSrc: hover-sound
+      soundVolume: 25
       cursor: pointer
       payload:
         hoverAction: true
@@ -168,6 +171,7 @@ out:
   alpha: 1
   hover:
     soundSrc: hover-sound
+    soundVolume: 25
     cursor: pointer
     payload:
       hoverAction: true

--- a/spec/parser/parseContainer.test.yaml
+++ b/spec/parser/parseContainer.test.yaml
@@ -1334,6 +1334,7 @@ in:
         inheritToChildren: true
         cursor: pointer
         soundSrc: hover-sound
+        soundVolume: 70
         payload:
           type: hover
       click:
@@ -1371,6 +1372,7 @@ out:
     inheritToChildren: true
     cursor: pointer
     soundSrc: hover-sound
+    soundVolume: 70
     payload:
       type: hover
   click:

--- a/spec/parser/parseSlider.test.yaml
+++ b/spec/parser/parseSlider.test.yaml
@@ -33,6 +33,7 @@ in:
         barSrc: file:bar-hover
         inactiveBarSrc: file:track-hover
         soundSrc: sound-1
+        soundVolume: 85
         cursor: cursor-1
         payload:
           prop1: "44"
@@ -63,6 +64,7 @@ out:
     barSrc: file:bar-hover
     inactiveBarSrc: file:track-hover
     soundSrc: sound-1
+    soundVolume: 85
     cursor: cursor-1
     payload:
       prop1: "44"

--- a/spec/parser/parseSprite.test.yaml
+++ b/spec/parser/parseSprite.test.yaml
@@ -30,6 +30,7 @@ in:
       rotation: 45
       hover:
         soundSrc: sound-1
+        soundVolume: 40
         cursor: cursor-1
         payload:
           prop1: "44"
@@ -61,6 +62,7 @@ out:
   src: file:circle-red
   hover:
     soundSrc: sound-1
+    soundVolume: 40
     cursor: cursor-1
     payload:
       prop1: "44"

--- a/src/plugins/elements/container/util/bindContainerInteractions.js
+++ b/src/plugins/elements/container/util/bindContainerInteractions.js
@@ -136,7 +136,8 @@ export const bindContainerInteractions = ({
   }
 
   if (hoverEvents) {
-    const { cursor, soundSrc, payload, inheritToChildren } = hoverEvents;
+    const { cursor, soundSrc, soundVolume, payload, inheritToChildren } =
+      hoverEvents;
 
     const overListener = (event) => {
       if (isWithinContainer(container, event?.relatedTarget)) {
@@ -162,6 +163,7 @@ export const bindContainerInteractions = ({
           id: `hover-${Date.now()}`,
           url: soundSrc,
           loop: false,
+          volume: normalizeVolume(soundVolume),
         });
       if (inheritToChildren) {
         setTreeInheritedHover({ root: container, isHovered: true });

--- a/src/plugins/elements/rect/addRect.js
+++ b/src/plugins/elements/rect/addRect.js
@@ -88,7 +88,7 @@ export const addRect = ({
   const dragEvent = element?.drag;
 
   if (hoverEvents) {
-    const { cursor, soundSrc, payload } = hoverEvents;
+    const { cursor, soundSrc, soundVolume, payload } = hoverEvents;
     rect.eventMode = "static";
 
     const overListener = () => {
@@ -105,6 +105,7 @@ export const addRect = ({
           id: `hover-${Date.now()}`,
           url: soundSrc,
           loop: false,
+          volume: normalizeVolume(soundVolume),
         });
     };
 

--- a/src/plugins/elements/rect/updateRect.js
+++ b/src/plugins/elements/rect/updateRect.js
@@ -108,7 +108,7 @@ export const updateRect = ({
       const dragEvents = nextElement?.drag;
 
       if (hoverEvents) {
-        const { cursor, soundSrc, payload } = hoverEvents;
+        const { cursor, soundSrc, soundVolume, payload } = hoverEvents;
         rectElement.eventMode = "static";
 
         const overListener = () => {
@@ -125,6 +125,7 @@ export const updateRect = ({
               id: `hover-${Date.now()}`,
               url: soundSrc,
               loop: false,
+              volume: normalizeVolume(soundVolume),
             });
         };
 

--- a/src/plugins/elements/slider/sliderRuntime.js
+++ b/src/plugins/elements/slider/sliderRuntime.js
@@ -3,6 +3,7 @@ import {
   clearInheritedHoverTarget,
   createHoverStateController,
 } from "../util/hoverInheritance.js";
+import { normalizeVolume } from "../../../util/normalizeVolume.js";
 
 const BAR_PADDING = 0;
 const DEFAULT_TEXTURE_SIZE = 16;
@@ -701,6 +702,7 @@ export const bindSliderInteractions = ({
         id: `hover-${Date.now()}`,
         url: hover.soundSrc,
         loop: false,
+        volume: normalizeVolume(hover.soundVolume),
       });
     }
   };

--- a/src/plugins/elements/sprite/addSprite.js
+++ b/src/plugins/elements/sprite/addSprite.js
@@ -91,7 +91,7 @@ export const addSprite = ({
   };
 
   if (hoverEvents) {
-    const { cursor, soundSrc, payload } = hoverEvents;
+    const { cursor, soundSrc, soundVolume, payload } = hoverEvents;
     sprite.eventMode = "static";
     hoverController = createHoverStateController({
       displayObject: sprite,
@@ -113,6 +113,7 @@ export const addSprite = ({
           id: `hover-${Date.now()}`,
           url: soundSrc,
           loop: false,
+          volume: normalizeVolume(soundVolume),
         });
     };
 

--- a/src/plugins/elements/sprite/updateSprite.js
+++ b/src/plugins/elements/sprite/updateSprite.js
@@ -127,7 +127,7 @@ export const updateSprite = ({
     };
 
     if (hoverEvents) {
-      const { cursor, soundSrc, payload } = hoverEvents;
+      const { cursor, soundSrc, soundVolume, payload } = hoverEvents;
       spriteElement.eventMode = "static";
       hoverController = createHoverStateController({
         displayObject: spriteElement,
@@ -149,6 +149,7 @@ export const updateSprite = ({
             id: `hover-${Date.now()}`,
             url: soundSrc,
             loop: false,
+            volume: normalizeVolume(soundVolume),
           });
       };
 

--- a/src/plugins/elements/text/textInteractions.js
+++ b/src/plugins/elements/text/textInteractions.js
@@ -63,7 +63,7 @@ export const bindTextInteractions = ({
   };
 
   if (hoverEvents) {
-    const { cursor, soundSrc, payload } = hoverEvents;
+    const { cursor, soundSrc, soundVolume, payload } = hoverEvents;
 
     displayObject.eventMode = "static";
     hoverController = createHoverStateController({
@@ -86,6 +86,7 @@ export const bindTextInteractions = ({
           id: `hover-${Date.now()}`,
           url: soundSrc,
           loop: false,
+          volume: normalizeVolume(soundVolume),
         });
     };
 

--- a/src/schemas/elements/container.computed.yaml
+++ b/src/schemas/elements/container.computed.yaml
@@ -169,6 +169,12 @@ properties:
       soundSrc:
         type: string
         description: source of sound to be played when hovering over the container
+      soundVolume:
+        type: number
+        description: Volume. 0 means muted. 100 means original full volume.
+        minimum: 0
+        maximum: 100
+        default: 100
       cursor:
         type: string
         description: CSS cursor style when hovering over the container

--- a/src/schemas/elements/container.element.yaml
+++ b/src/schemas/elements/container.element.yaml
@@ -211,6 +211,12 @@ properties:
       soundSrc:
         type: string
         description: source of sound to be played when hovering over the container
+      soundVolume:
+        type: number
+        description: Volume. 0 means muted. 100 means original full volume.
+        minimum: 0
+        maximum: 100
+        default: 100
       cursor:
         type: string
         description: CSS cursor style when hovering over the container

--- a/src/schemas/elements/rect.computed.yaml
+++ b/src/schemas/elements/rect.computed.yaml
@@ -165,6 +165,12 @@ properties:
       soundSrc:
         type: string
         description: source of sound to be played when hovering over the sprite
+      soundVolume:
+        type: number
+        description: Volume. 0 means muted. 100 means original full volume.
+        minimum: 0
+        maximum: 100
+        default: 100
       cursor:
         type: string
         description: CSS cursor style when hovering over the sprite

--- a/src/schemas/elements/rect.element.yaml
+++ b/src/schemas/elements/rect.element.yaml
@@ -196,6 +196,12 @@ properties:
       soundSrc:
         type: string
         description: source of sound to be played when hovering over the sprite
+      soundVolume:
+        type: number
+        description: Volume. 0 means muted. 100 means original full volume.
+        minimum: 0
+        maximum: 100
+        default: 100
       cursor:
         type: string
         description: CSS cursor style when hovering over the sprite

--- a/src/schemas/elements/slider.computed.yaml
+++ b/src/schemas/elements/slider.computed.yaml
@@ -92,6 +92,12 @@ properties:
       soundSrc:
         type: string
         description: URL of sound to play when hovering over the slider
+      soundVolume:
+        type: number
+        description: Volume. 0 means muted. 100 means original full volume.
+        minimum: 0
+        maximum: 100
+        default: 100
   change:
     type: object
     description: Configuration for dragging behavior

--- a/src/schemas/elements/slider.element.yaml
+++ b/src/schemas/elements/slider.element.yaml
@@ -86,6 +86,12 @@ properties:
       soundSrc:
         type: string
         description: Source of sound to play when hovering over the slider
+      soundVolume:
+        type: number
+        description: Volume. 0 means muted. 100 means original full volume.
+        minimum: 0
+        maximum: 100
+        default: 100
   change:
     type: object
     description: Configuration for dragging behavior

--- a/src/schemas/elements/sprite.computed.yaml
+++ b/src/schemas/elements/sprite.computed.yaml
@@ -83,6 +83,12 @@ properties:
       soundSrc:
         type: string
         description: source of sound to be played when hovering over the sprite
+      soundVolume:
+        type: number
+        description: Volume. 0 means muted. 100 means original full volume.
+        minimum: 0
+        maximum: 100
+        default: 100
       cursor:
         type: string
         description: CSS cursor style when hovering over the sprite

--- a/src/schemas/elements/sprite.element.yaml
+++ b/src/schemas/elements/sprite.element.yaml
@@ -94,6 +94,12 @@ properties:
       soundSrc:
         type: string
         description: source of sound to be played when hovering over the sprite
+      soundVolume:
+        type: number
+        description: Volume. 0 means muted. 100 means original full volume.
+        minimum: 0
+        maximum: 100
+        default: 100
       cursor:
         type: string
         description: CSS cursor style when hovering over the sprite

--- a/src/schemas/elements/text.computed.yaml
+++ b/src/schemas/elements/text.computed.yaml
@@ -184,6 +184,12 @@ properties:
       soundSrc:
         type: string
         description: URL to sound file to play on hover
+      soundVolume:
+        type: number
+        description: Volume. 0 means muted. 100 means original full volume.
+        minimum: 0
+        maximum: 100
+        default: 100
       payload:
         type: object
         description: Payload for hover action event

--- a/src/schemas/elements/text.element.yaml
+++ b/src/schemas/elements/text.element.yaml
@@ -158,6 +158,12 @@ properties:
       soundSrc:
         type: string
         description: URL to sound file to play on hover
+      soundVolume:
+        type: number
+        description: Volume. 0 means muted. 100 means original full volume.
+        minimum: 0
+        maximum: 100
+        default: 100
       payload:
         type: object
         description: Payload for hover action event


### PR DESCRIPTION
## Summary
- apply configured hover sound volume for text, sprite, rect, container, and slider elements
- add hover soundVolume to element and computed schemas
- bump the package patch version to 1.28.1

## Testing
- bun run test (679 tests)
- bun run lint
- bun run build