### PR TITLE
fix(audio): support looping channels

### DIFF
--- a/docs/audio-effects.md
+++ b/docs/audio-effects.md
@@ -126,6 +126,8 @@ First implementation rule:
   parallel and may use `startDelayMs` for scheduled sequences.
 - `loop: true` restarts the complete child schedule after every child sound has
   finished. Looping channels cannot contain child sounds with `loop: true`.
+- Changing a channel from `loop: true` to `loop: false` cancels child sounds
+  that have not started yet and lets already-playing child sounds finish.
 
 ### Sounds
 

--- a/docs/audio-effects.md
+++ b/docs/audio-effects.md
@@ -102,6 +102,7 @@ type: audio-channel
 volume: 80
 muted: false
 pan: 0
+loop: false
 children: []
 ```
 
@@ -114,6 +115,7 @@ Fields:
 | `volume`   | number          | `100`    | Local channel volume, `0` to `100`             |
 | `muted`    | boolean         | `false`  | Forces this channel's effective output to zero |
 | `pan`      | number          | `0`      | Stereo pan, `-1` left to `1` right             |
+| `loop`     | boolean         | `false`  | Repeats the complete child schedule            |
 | `children` | sound[]         | `[]`     | Sound nodes owned by this channel              |
 
 First implementation rule:
@@ -122,6 +124,8 @@ First implementation rule:
 - nested `audio-channel` nodes are invalid until explicitly supported.
 - child array order does not control playback order; sounds are mixed in
   parallel and may use `startDelayMs` for scheduled sequences.
+- `loop: true` restarts the complete child schedule after every child sound has
+  finished. Looping channels cannot contain child sounds with `loop: true`.
 
 ### Sounds
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -280,6 +280,48 @@ describe("AudioStage graph rendering", () => {
     expect(stage._inspect().channels.get("music").loop).toBe(true);
   });
 
+  it("finishes active channel sounds without playing the rest of the schedule when looping is disabled", async () => {
+    const { stage, context } = await setupAudioStage();
+    const loopingAudio = [
+      {
+        id: "music",
+        type: "audio-channel",
+        loop: true,
+        children: [
+          { id: "current", type: "sound", src: "current" },
+          {
+            id: "next",
+            type: "sound",
+            src: "next",
+            startDelayMs: 100,
+          },
+        ],
+      },
+    ];
+    const finishingAudio = [
+      {
+        ...loopingAudio[0],
+        loop: false,
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: loopingAudio });
+    const activeSource = context.sources[0];
+
+    stage.renderGraph({
+      prevAudio: loopingAudio,
+      nextAudio: finishingAudio,
+    });
+
+    expect(findCurrentSound(stage, "next").pendingTimeoutId).toBeNull();
+    expect(activeSource.stop).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    activeSource.onended();
+
+    expect(context.sources).toHaveLength(1);
+  });
+
   it("sanitizes direct audio defaults across repeated ticks", async () => {
     const { stage } = await setupAudioStage();
 

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -216,6 +216,70 @@ describe("AudioStage graph rendering", () => {
     expect(music.pannerNode.connect).toHaveBeenCalledWith(context.destination);
   });
 
+  it("restarts a looping channel only after its complete delayed schedule finishes", async () => {
+    const { stage, context } = await setupAudioStage();
+
+    stage.renderGraph({
+      nextAudio: [
+        {
+          id: "music",
+          type: "audio-channel",
+          loop: true,
+          children: [
+            { id: "intro", type: "sound", src: "intro" },
+            {
+              id: "outro",
+              type: "sound",
+              src: "outro",
+              startDelayMs: 100,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(context.sources).toHaveLength(1);
+    context.sources[0].onended();
+    expect(context.sources).toHaveLength(1);
+
+    vi.advanceTimersByTime(100);
+    expect(context.sources).toHaveLength(2);
+    context.sources[1].onended();
+
+    expect(context.sources).toHaveLength(3);
+    expect(findCurrentSound(stage, "outro").pendingTimeoutId).not.toBeNull();
+
+    vi.advanceTimersByTime(100);
+    expect(context.sources).toHaveLength(4);
+    expect(context.sources[0].disconnect).toHaveBeenCalled();
+    expect(context.sources[1].disconnect).toHaveBeenCalled();
+  });
+
+  it("can enable channel looping after the current schedule has finished", async () => {
+    const { stage, context } = await setupAudioStage();
+    const firstAudio = [
+      {
+        id: "music",
+        type: "audio-channel",
+        children: [{ id: "theme", type: "sound", src: "theme" }],
+      },
+    ];
+    const loopingAudio = [
+      {
+        ...firstAudio[0],
+        loop: true,
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: firstAudio });
+    context.sources[0].onended();
+
+    stage.renderGraph({ prevAudio: firstAudio, nextAudio: loopingAudio });
+
+    expect(context.sources).toHaveLength(2);
+    expect(stage._inspect().channels.get("music").loop).toBe(true);
+  });
+
   it("sanitizes direct audio defaults across repeated ticks", async () => {
     const { stage } = await setupAudioStage();
 

--- a/spec/util/normalizeAudio.spec.js
+++ b/spec/util/normalizeAudio.spec.js
@@ -34,6 +34,7 @@ describe("normalizeAudioRenderState", () => {
         volume: 80,
         muted: false,
         pan: 0,
+        loop: false,
       },
     ]);
     expect(result.sounds).toEqual([
@@ -106,6 +107,36 @@ describe("normalizeAudioRenderState", () => {
         },
       ]),
     ).toThrow("audio[0].volume must be a number");
+  });
+
+  it("normalizes channel loop and rejects incompatible child loops", () => {
+    const result = flattenAudioNodes([
+      {
+        id: "music",
+        type: "audio-channel",
+        loop: true,
+        children: [{ id: "intro", type: "sound", src: "intro" }],
+      },
+    ]);
+
+    expect(result.channels[0].loop).toBe(true);
+
+    expect(() =>
+      flattenAudioNodes([
+        {
+          id: "music",
+          type: "audio-channel",
+          loop: true,
+          children: [{ id: "intro", type: "sound", src: "intro", loop: true }],
+        },
+      ]),
+    ).toThrow(
+      "audio[0].children[0].loop cannot be true when audio[0].loop is true",
+    );
+
+    expect(() =>
+      flattenAudioNodes([{ id: "music", type: "audio-channel", loop: "yes" }]),
+    ).toThrow("audio[0].loop must be a boolean");
   });
 
   it("rejects duplicate IDs across nodes and effects", () => {

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -417,6 +417,7 @@ const createSoundInstance = ({ sound, channelNode, internalId }) => {
     onSourceEnded: null,
     finishing: false,
     playbackRateTransition: null,
+    playbackPending: false,
     pendingTimeoutId: null,
     cleanupTimeoutId: null,
     playRequestId: 0,
@@ -502,6 +503,7 @@ const playSound = (sound) => {
   const playRequestId = (sound.playRequestId ?? 0) + 1;
   sound.playRequestId = playRequestId;
   sound.sourceEnded = false;
+  sound.playbackPending = true;
   debugAudio("play requested", {
     id: sound.id,
     src: sound.src,
@@ -522,6 +524,7 @@ const playSound = (sound) => {
     sound.pendingTimeoutId = null;
     const previousSource = sound.source;
     sound.source = createSourceForSound(sound);
+    sound.playbackPending = false;
     if (previousSource && previousSource !== sound.source) {
       disconnect(previousSource);
     }
@@ -551,6 +554,7 @@ const playSound = (sound) => {
 
 const stopSource = (sound, delayMs = 0) => {
   sound.playRequestId = (sound.playRequestId ?? 0) + 1;
+  sound.playbackPending = false;
 
   if (sound.pendingTimeoutId !== null) {
     clearTimeout(sound.pendingTimeoutId);
@@ -718,7 +722,9 @@ export const createAudioStage = () => {
       channelSounds.length === 0 ||
       channelSounds.some(
         (sound) =>
-          sound.pendingTimeoutId !== null || sound.sourceEnded !== true,
+          sound.playbackPending ||
+          sound.pendingTimeoutId !== null ||
+          sound.sourceEnded !== true,
       )
     ) {
       return;
@@ -733,6 +739,22 @@ export const createAudioStage = () => {
     sound.onSourceEnded = sound.channelId
       ? () => restartLoopingChannelIfComplete(sound.channelId)
       : null;
+  };
+
+  const finishChannelLoop = (channelId) => {
+    for (const sound of getCurrentChannelSounds(channelId)) {
+      if (!sound.playbackPending) {
+        continue;
+      }
+
+      sound.playRequestId = (sound.playRequestId ?? 0) + 1;
+      sound.playbackPending = false;
+      sound.sourceEnded = true;
+      if (sound.pendingTimeoutId !== null) {
+        clearTimeout(sound.pendingTimeoutId);
+        sound.pendingTimeoutId = null;
+      }
+    }
   };
 
   const ensureRootChannel = (id) => {
@@ -781,11 +803,16 @@ export const createAudioStage = () => {
       const nextVolumeValue = getVolumeValue(channel);
       const volumeChanged = currentVolumeValue !== nextVolumeValue;
       const panChanged = existing.pan !== (channel.pan ?? 0);
+      const loopInterrupted = existing.loop && !channel.loop;
 
       existing.volume = channel.volume;
       existing.muted = channel.muted;
       existing.pan = channel.pan;
       existing.loop = channel.loop;
+
+      if (loopInterrupted) {
+        finishChannelLoop(channel.id);
+      }
 
       if (volumeChanged && volumeTransition) {
         applyVolume({

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -383,6 +383,7 @@ const createChannelInstance = (channel, outputNode) => {
     volume: channel.volume ?? 100,
     muted: channel.muted ?? false,
     pan: channel.pan ?? 0,
+    loop: channel.loop ?? false,
     outputNode,
     cleanupTimeoutId: null,
   };
@@ -500,6 +501,7 @@ const playSound = (sound) => {
   const context = getAudioContext();
   const playRequestId = (sound.playRequestId ?? 0) + 1;
   sound.playRequestId = playRequestId;
+  sound.sourceEnded = false;
   debugAudio("play requested", {
     id: sound.id,
     src: sound.src,
@@ -518,7 +520,11 @@ const playSound = (sound) => {
     }
 
     sound.pendingTimeoutId = null;
+    const previousSource = sound.source;
     sound.source = createSourceForSound(sound);
+    if (previousSource && previousSource !== sound.source) {
+      disconnect(previousSource);
+    }
   };
 
   const scheduleStart = () => {
@@ -686,6 +692,49 @@ export const createAudioStage = () => {
   const directAudios = new Map();
   let soundGeneration = 0;
 
+  const getCurrentChannelSounds = (channelId) => {
+    const channelSounds = [];
+    for (const internalId of currentSoundKeyById.values()) {
+      const sound = sounds.get(internalId);
+      if (
+        sound?.channelId === channelId &&
+        !sound.finishing &&
+        !channelSounds.includes(sound)
+      ) {
+        channelSounds.push(sound);
+      }
+    }
+    return channelSounds;
+  };
+
+  const restartLoopingChannelIfComplete = (channelId) => {
+    const channel = channels.get(channelId);
+    if (!channel?.loop) {
+      return;
+    }
+
+    const channelSounds = getCurrentChannelSounds(channelId);
+    if (
+      channelSounds.length === 0 ||
+      channelSounds.some(
+        (sound) =>
+          sound.pendingTimeoutId !== null || sound.sourceEnded !== true,
+      )
+    ) {
+      return;
+    }
+
+    channelSounds.forEach((sound) => {
+      playSound(sound);
+    });
+  };
+
+  const bindChannelLoopCompletion = (sound) => {
+    sound.onSourceEnded = sound.channelId
+      ? () => restartLoopingChannelIfComplete(sound.channelId)
+      : null;
+  };
+
   const ensureRootChannel = (id) => {
     const existing = channels.get(id);
     if (existing) return existing;
@@ -736,6 +785,7 @@ export const createAudioStage = () => {
       existing.volume = channel.volume;
       existing.muted = channel.muted;
       existing.pan = channel.pan;
+      existing.loop = channel.loop;
 
       if (volumeChanged && volumeTransition) {
         applyVolume({
@@ -846,6 +896,7 @@ export const createAudioStage = () => {
     });
     sounds.set(internalId, instance);
     currentSoundKeyById.set(sound.id, internalId);
+    bindChannelLoopCompletion(instance);
 
     const volumeTransition = getTransitionPhase(
       effects,
@@ -985,6 +1036,7 @@ export const createAudioStage = () => {
     instance.startAt = sound.startAt;
     instance.endAt = sound.endAt;
     instance.channelId = sound.channelId;
+    bindChannelLoopCompletion(instance);
 
     if (instance.source) {
       instance.source.loop = sound.loop;
@@ -1192,6 +1244,10 @@ export const createAudioStage = () => {
           channels.delete(id);
         }
       }, duration);
+    }
+
+    for (const channel of next.channels) {
+      restartLoopingChannelIfComplete(channel.id);
     }
   };
 

--- a/src/schemas/audio/audio-channel.yaml
+++ b/src/schemas/audio/audio-channel.yaml
@@ -28,6 +28,10 @@ properties:
     default: 0
     minimum: -1
     maximum: 1
+  loop:
+    type: boolean
+    description: Whether to repeat the complete child sound schedule after every child finishes.
+    default: false
   children:
     type: array
     description: Sound nodes owned by this channel

--- a/src/types.js
+++ b/src/types.js
@@ -663,6 +663,7 @@
  * @property {number} [volume=100] - Volume (0-100, 100 default)
  * @property {boolean} [muted=false] - Whether the channel is muted
  * @property {number} [pan=0] - Stereo pan from -1 to 1
+ * @property {boolean} [loop=false] - Whether to repeat the complete child sound schedule
  * @property {SoundElement[]} [children=[]] - Sound nodes owned by the channel
  */
 

--- a/src/util/normalizeAudio.js
+++ b/src/util/normalizeAudio.js
@@ -153,6 +153,7 @@ const validateChannel = (
   const volume = normalizeVolumeValue(node.volume, `${path}.volume`);
   assertOptionalBoolean(node.muted, `${path}.muted`);
   assertOptionalNumber(node.pan, `${path}.pan`, { min: -1, max: 1 });
+  assertOptionalBoolean(node.loop, `${path}.loop`);
 
   if (node.children !== undefined && !Array.isArray(node.children)) {
     throw new Error(`Input error: ${path}.children must be an array.`);
@@ -164,6 +165,7 @@ const validateChannel = (
     volume,
     muted: node.muted ?? false,
     pan: node.pan ?? 0,
+    loop: node.loop ?? false,
   });
 
   for (const [index, child] of (node.children ?? []).entries()) {
@@ -178,6 +180,12 @@ const validateChannel = (
 
     if (child.type !== "sound") {
       throw new Error(`Input error: ${childPath}.type must be "sound".`);
+    }
+
+    if (node.loop === true && child.loop === true) {
+      throw new Error(
+        `Input error: ${childPath}.loop cannot be true when ${path}.loop is true.`,
+      );
     }
 
     validateSound(child, childPath, ids, flattenedSounds, node.id);


### PR DESCRIPTION
## Summary
- add channel-level looping for complete child sound schedules
- finish active child audio while cancelling not-yet-started children when channel looping is disabled
- validate and document channel loop behavior and reject nested sound loops
- bump the package patch version to 1.30.1

## Testing
- `bunx vitest run spec/audio/audioStage.spec.js spec/util/normalizeAudio.spec.js`
- pre-push hook: `bun run lint`
- pre-push hook: `bun run test` (88 files, 703 tests)