### PR TITLE
feat(audio): support loop-end channel interruption

### DIFF
--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -322,6 +322,77 @@ describe("AudioStage graph rendering", () => {
     expect(context.sources).toHaveLength(1);
   });
 
+  it("finishes the active channel schedule when interruption uses loopEnd", async () => {
+    const { stage, context } = await setupAudioStage();
+    const audio = [
+      {
+        id: "music",
+        type: "audio-channel",
+        loop: true,
+        interruption: "loopEnd",
+        children: [
+          { id: "current", type: "sound", src: "current" },
+          {
+            id: "next",
+            type: "sound",
+            src: "next",
+            startDelayMs: 100,
+          },
+        ],
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: audio });
+    const activeSource = context.sources[0];
+
+    stage.renderGraph({ prevAudio: audio, nextAudio: [] });
+
+    expect(activeSource.stop).not.toHaveBeenCalled();
+    expect(findCurrentSound(stage, "next")).toBeUndefined();
+    expect(stage._inspect().channels.has("music")).toBe(true);
+
+    activeSource.onended();
+    vi.advanceTimersByTime(100);
+
+    expect(context.sources).toHaveLength(2);
+    expect(context.sources[1].stop).not.toHaveBeenCalled();
+
+    context.sources[1].onended();
+
+    expect(findSound(stage, "current")).toBeUndefined();
+    expect(findSound(stage, "next")).toBeUndefined();
+    expect(stage._inspect().channels.has("music")).toBe(false);
+  });
+
+  it("stops an interrupted channel schedule immediately by default", async () => {
+    const { stage, context } = await setupAudioStage();
+    const audio = [
+      {
+        id: "music",
+        type: "audio-channel",
+        children: [
+          { id: "current", type: "sound", src: "current" },
+          {
+            id: "next",
+            type: "sound",
+            src: "next",
+            startDelayMs: 100,
+          },
+        ],
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: audio });
+    const activeSource = context.sources[0];
+
+    stage.renderGraph({ prevAudio: audio, nextAudio: [] });
+    vi.advanceTimersByTime(100);
+
+    expect(activeSource.stop).toHaveBeenCalled();
+    expect(context.sources).toHaveLength(1);
+    expect(stage._inspect().channels.has("music")).toBe(false);
+  });
+
   it("sanitizes direct audio defaults across repeated ticks", async () => {
     const { stage } = await setupAudioStage();
 

--- a/spec/util/normalizeAudio.spec.js
+++ b/spec/util/normalizeAudio.spec.js
@@ -35,6 +35,7 @@ describe("normalizeAudioRenderState", () => {
         muted: false,
         pan: 0,
         loop: false,
+        interruption: "immediate",
       },
     ]);
     expect(result.sounds).toEqual([
@@ -137,6 +138,27 @@ describe("normalizeAudioRenderState", () => {
     expect(() =>
       flattenAudioNodes([{ id: "music", type: "audio-channel", loop: "yes" }]),
     ).toThrow("audio[0].loop must be a boolean");
+  });
+
+  it("normalizes channel interruption behavior", () => {
+    const result = flattenAudioNodes([
+      {
+        id: "music",
+        type: "audio-channel",
+        interruption: "loopEnd",
+      },
+    ]);
+
+    expect(result.channels[0].interruption).toBe("loopEnd");
+    expect(() =>
+      flattenAudioNodes([
+        {
+          id: "music",
+          type: "audio-channel",
+          interruption: "later",
+        },
+      ]),
+    ).toThrow("audio[0].interruption must be one of immediate, loopEnd");
   });
 
   it("rejects duplicate IDs across nodes and effects", () => {

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -384,8 +384,10 @@ const createChannelInstance = (channel, outputNode) => {
     muted: channel.muted ?? false,
     pan: channel.pan ?? 0,
     loop: channel.loop ?? false,
+    interruption: channel.interruption ?? "immediate",
     outputNode,
     cleanupTimeoutId: null,
+    deferredRemovalToken: null,
   };
 };
 
@@ -799,6 +801,7 @@ export const createAudioStage = () => {
     }
 
     if (existing) {
+      existing.deferredRemovalToken = null;
       const currentVolumeValue = getVolumeValue(existing);
       const nextVolumeValue = getVolumeValue(channel);
       const volumeChanged = currentVolumeValue !== nextVolumeValue;
@@ -809,6 +812,7 @@ export const createAudioStage = () => {
       existing.muted = channel.muted;
       existing.pan = channel.pan;
       existing.loop = channel.loop;
+      existing.interruption = channel.interruption;
 
       if (loopInterrupted) {
         finishChannelLoop(channel.id);
@@ -1007,7 +1011,7 @@ export const createAudioStage = () => {
     return duration;
   };
 
-  const finishSoundInstance = (instance) => {
+  const finishSoundInstance = (instance, onFinished) => {
     if (!instance || instance.finishing) {
       return;
     }
@@ -1026,19 +1030,24 @@ export const createAudioStage = () => {
       if (sounds.get(instance.internalId) === instance) {
         sounds.delete(instance.internalId);
       }
+      onFinished?.();
     };
 
-    if (
-      !instance.source ||
-      instance.sourceEnded ||
-      getAudioContext().state !== "running"
-    ) {
+    if (getAudioContext().state !== "running") {
+      cleanupFinishedSound();
+      return;
+    }
+
+    instance.onSourceEnded = cleanupFinishedSound;
+    if (instance.playbackPending || instance.pendingTimeoutId !== null) {
+      return;
+    }
+    if (!instance.source || instance.sourceEnded) {
       cleanupFinishedSound();
       return;
     }
 
     instance.source.loop = false;
-    instance.onSourceEnded = cleanupFinishedSound;
   };
 
   const updateSoundInstance = ({ instance, sound, effects }) => {
@@ -1167,12 +1176,50 @@ export const createAudioStage = () => {
 
     const removedChannels = new Map();
     const channelCleanupDurations = new Map();
+    const deferredChannelCleanup = new Map();
+    const tryCleanupDeferredChannel = (entry) => {
+      if (
+        entry.registeringSounds ||
+        !entry.transitionComplete ||
+        entry.soundIds.size > 0 ||
+        entry.channel.deferredRemovalToken !== entry.token
+      ) {
+        return;
+      }
 
-    for (const [id] of prevChannelById) {
+      cleanupChannel(entry.channel);
+      if (channels.get(entry.channel.id) === entry.channel) {
+        channels.delete(entry.channel.id);
+      }
+      entry.channel.deferredRemovalToken = null;
+    };
+
+    for (const [id, prevChannel] of prevChannelById) {
       if (!nextChannelById.has(id)) {
-        const duration = removeChannel(channels.get(id), prevAudioEffects);
-        removedChannels.set(id, channels.get(id));
+        const channel = channels.get(id);
+        const duration = removeChannel(channel, prevAudioEffects);
         channelCleanupDurations.set(id, duration);
+        if (prevChannel.interruption === "loopEnd" && channel) {
+          channel.loop = false;
+          const token = {};
+          channel.deferredRemovalToken = token;
+          const entry = {
+            channel,
+            token,
+            registeringSounds: true,
+            transitionComplete: duration <= 0,
+            soundIds: new Set(),
+          };
+          deferredChannelCleanup.set(id, entry);
+          if (duration > 0) {
+            schedule(() => {
+              entry.transitionComplete = true;
+              tryCleanupDeferredChannel(entry);
+            }, duration);
+          }
+        } else {
+          removedChannels.set(id, channel);
+        }
       }
     }
 
@@ -1191,13 +1238,34 @@ export const createAudioStage = () => {
       const inheritedDuration = prevSound.channelId
         ? (channelCleanupDurations.get(prevSound.channelId) ?? 0)
         : 0;
+      const finishAtLoopEnd =
+        prevSound.channelId !== null &&
+        prevChannelById.get(prevSound.channelId)?.interruption === "loopEnd";
+      const finishPreviousSound = () => {
+        if (!finishAtLoopEnd) {
+          return removeSoundInstance(
+            instance,
+            prevAudioEffects,
+            inheritedDuration,
+          );
+        }
+
+        const deferredCleanup = deferredChannelCleanup.get(prevSound.channelId);
+        if (instance && deferredCleanup) {
+          deferredCleanup.soundIds.add(instance.internalId);
+        }
+        finishSoundInstance(instance, () => {
+          if (!deferredCleanup) {
+            return;
+          }
+          deferredCleanup.soundIds.delete(instance.internalId);
+          tryCleanupDeferredChannel(deferredCleanup);
+        });
+        return 0;
+      };
 
       if (!nextSound) {
-        const duration = removeSoundInstance(
-          instance,
-          prevAudioEffects,
-          inheritedDuration,
-        );
+        const duration = finishPreviousSound();
         if (prevSound.channelId) {
           channelCleanupDurations.set(
             prevSound.channelId,
@@ -1212,11 +1280,7 @@ export const createAudioStage = () => {
       }
 
       if (!hasSameSoundSourceIdentity(prevSound, nextSound)) {
-        const duration = removeSoundInstance(
-          instance,
-          prevAudioEffects,
-          inheritedDuration,
-        );
+        const duration = finishPreviousSound();
         if (prevSound.channelId) {
           channelCleanupDurations.set(
             prevSound.channelId,
@@ -1260,6 +1324,11 @@ export const createAudioStage = () => {
           effects: nextAudioEffects,
         });
       }
+    }
+
+    for (const entry of deferredChannelCleanup.values()) {
+      entry.registeringSounds = false;
+      tryCleanupDeferredChannel(entry);
     }
 
     for (const [id, channel] of removedChannels) {

--- a/src/schemas/audio/audio-channel.yaml
+++ b/src/schemas/audio/audio-channel.yaml
@@ -32,6 +32,11 @@ properties:
     type: boolean
     description: Whether to repeat the complete child sound schedule after every child finishes.
     default: false
+  interruption:
+    type: string
+    enum: [immediate, loopEnd]
+    description: How active channel playback stops when the channel is interrupted.
+    default: immediate
   children:
     type: array
     description: Sound nodes owned by this channel

--- a/src/types.js
+++ b/src/types.js
@@ -664,6 +664,7 @@
  * @property {boolean} [muted=false] - Whether the channel is muted
  * @property {number} [pan=0] - Stereo pan from -1 to 1
  * @property {boolean} [loop=false] - Whether to repeat the complete child sound schedule
+ * @property {'immediate' | 'loopEnd'} [interruption='immediate'] - Whether interruption stops immediately or finishes the active schedule iteration
  * @property {SoundElement[]} [children=[]] - Sound nodes owned by the channel
  */
 

--- a/src/util/normalizeAudio.js
+++ b/src/util/normalizeAudio.js
@@ -1,6 +1,7 @@
 import { SUPPORTED_EASING_NAMES } from "./animationTimeline.js";
 
 const AUDIO_NODE_TYPES = new Set(["audio-channel", "sound"]);
+const AUDIO_CHANNEL_INTERRUPTION_VALUES = new Set(["immediate", "loopEnd"]);
 const AUDIO_TRANSITION_TYPE = "audio-transition";
 const AUDIO_EFFECT_TYPES = new Set([AUDIO_TRANSITION_TYPE]);
 const AUDIO_TRANSITION_PHASES = new Set(["enter", "exit", "update"]);
@@ -154,6 +155,12 @@ const validateChannel = (
   assertOptionalBoolean(node.muted, `${path}.muted`);
   assertOptionalNumber(node.pan, `${path}.pan`, { min: -1, max: 1 });
   assertOptionalBoolean(node.loop, `${path}.loop`);
+  const interruption = node.interruption ?? "immediate";
+  if (!AUDIO_CHANNEL_INTERRUPTION_VALUES.has(interruption)) {
+    throw new Error(
+      `Input error: ${path}.interruption must be one of immediate, loopEnd.`,
+    );
+  }
 
   if (node.children !== undefined && !Array.isArray(node.children)) {
     throw new Error(`Input error: ${path}.children must be an array.`);
@@ -166,6 +173,7 @@ const validateChannel = (
     muted: node.muted ?? false,
     pan: node.pan ?? 0,
     loop: node.loop ?? false,
+    interruption,
   });
 
   for (const [index, child] of (node.children ?? []).entries()) {


### PR DESCRIPTION
## Summary
- add immediate and loopEnd interruption modes to audio channels, defaulting to immediate
- let loopEnd channels finish the active child schedule, including delayed sounds, before cleanup
- cancel deferred cleanup if the channel is reused and retain immediate interruption behavior by default

## Testing
- bun run lint
- bunx vitest run --maxWorkers=2 (88 files, 706 tests)
- pre-push full suite (88 files, 706 tests)