### PR TITLE
feat(audio): add command-controlled playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For complete usage details, go to:
 Design notes:
 
 - [Audio Effects](./docs/audio-effects.md)
-- [Command-Controlled Sound Playback Proposal](./docs/audio-playback-commands.md)
+- [Command-Controlled Sound Playback](./docs/audio-playback-commands.md)
 - [Shader Interface](./docs/shader-interface.md)
 
 ## Render CLI

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ For complete usage details, go to:
 Design notes:
 
 - [Audio Effects](./docs/audio-effects.md)
+- [Command-Controlled Sound Playback Proposal](./docs/audio-playback-commands.md)
 - [Shader Interface](./docs/shader-interface.md)
 
 ## Render CLI

--- a/docs/api-naming.md
+++ b/docs/api-naming.md
@@ -68,19 +68,18 @@ The public semantic event names are:
 
 These are the names Route Graphics consumers should listen for in `eventHandler`.
 
-### Proposed Event Names
+### Command-Controlled Sound Event Names
 
-The unimplemented command-controlled sound proposal reserves these candidate
-event names:
+Command-controlled sounds use these event names:
 
 - `soundReady`
 - `soundProgress`
 - `soundComplete`
 - `soundError`
 
-They are not part of the current stable public event set. Their proposed
-payloads and lifecycle rules are documented in
-[Command-Controlled Sound Playback Proposal](./audio-playback-commands.md).
+They join the public event set with the release that includes command-controlled
+playback. Their payloads and lifecycle rules are documented in
+[Command-Controlled Sound Playback](./audio-playback-commands.md).
 They follow the existing payload contract: sound runtime metadata is nested
 under `_event`, and `_event.id` identifies the sound.
 

--- a/docs/api-naming.md
+++ b/docs/api-naming.md
@@ -68,6 +68,20 @@ The public semantic event names are:
 
 These are the names Route Graphics consumers should listen for in `eventHandler`.
 
+### Proposed Event Names
+
+The unimplemented command-controlled sound proposal reserves these candidate
+event names:
+
+- `soundReady`
+- `soundProgress`
+- `soundComplete`
+- `soundError`
+
+They are not part of the current stable public event set. Their proposed
+payloads and lifecycle rules are documented in
+[Command-Controlled Sound Playback Proposal](./audio-playback-commands.md).
+
 ## Semantic Meaning
 
 Event names are semantic Route Graphics events, not native input events.

--- a/docs/api-naming.md
+++ b/docs/api-naming.md
@@ -81,6 +81,8 @@ event names:
 They are not part of the current stable public event set. Their proposed
 payloads and lifecycle rules are documented in
 [Command-Controlled Sound Playback Proposal](./audio-playback-commands.md).
+They follow the existing payload contract: sound runtime metadata is nested
+under `_event`, and `_event.id` identifies the sound.
 
 ## Semantic Meaning
 

--- a/docs/audio-effects.md
+++ b/docs/audio-effects.md
@@ -456,7 +456,8 @@ it carries a `playback` command. See
 [Command-Controlled Sound Playback Proposal](./audio-playback-commands.md).
 Under that proposal, a command-controlled sound cannot be a child of an
 `audio-channel` with `loop: true`, because channel-schedule replay would bypass
-command ordering.
+command ordering. A non-looping channel may retain either interruption mode;
+an outgoing `loopEnd` instance finishes as an event-detached tail.
 
 Cross-state identity rules:
 

--- a/docs/audio-effects.md
+++ b/docs/audio-effects.md
@@ -454,6 +454,9 @@ The proposed command-controlled playback extension does not change these rules
 for ordinary sounds. A sound opts into the proposed transport model only when
 it carries a `playback` command. See
 [Command-Controlled Sound Playback Proposal](./audio-playback-commands.md).
+Under that proposal, a command-controlled sound cannot be a child of an
+`audio-channel` with `loop: true`, because channel-schedule replay would bypass
+command ordering.
 
 Cross-state identity rules:
 

--- a/docs/audio-effects.md
+++ b/docs/audio-effects.md
@@ -23,14 +23,13 @@ also still accepts flat Route Graphics `sound` audio nodes for compatibility.
 ## Non-Goals
 
 - no nested audio channels in the first implementation
-- no command-style `play` / `stop` operation model in the currently implemented
-  channel graph
+- no requirement for ordinary declarative sounds to use command-style
+  operations
 - no required channel declarations in project resources
 - no audio filter or general-purpose DSP interface
 
-Command-controlled playback is now being designed as a separate opt-in
-extension for retained sounds. It is not implemented. See
-[Command-Controlled Sound Playback Proposal](./audio-playback-commands.md).
+Command-controlled playback is a separate opt-in extension for retained sounds.
+See [Command-Controlled Sound Playback](./audio-playback-commands.md).
 
 ## Render-State Shape
 
@@ -167,12 +166,18 @@ Fields:
 | `playbackRate` | number      | `1`      | Playback speed multiplier                    |
 | `startAt`      | number      | `0`      | Start offset in seconds                      |
 | `endAt`        | number/null | `null`   | Optional end time in seconds                 |
+| `playback`     | object      | omitted  | Optional command-controlled transport        |
 
 `startAt` and `endAt` are intended for partial playback. If `endAt` is present,
 duration is `endAt - startAt`.
 
 The channel audio graph uses `startDelayMs` only. `sound.delay` is not part of
 this interface.
+
+When `playback` is present, the sound uses ordered `play`, `pause`, `resume`,
+`stop`, and `seek` commands instead of automatic declarative startup. See
+[Command-Controlled Sound Playback](./audio-playback-commands.md) for the
+strict JSON shape, lifecycle events, and reconciliation rules.
 
 ### Sound Identity and Replay
 
@@ -450,11 +455,11 @@ The same `sound.id` and source identity fields mean continuation. It does not
 replay. Consumers must use a new playback-instance ID when replaying a one-shot
 sound.
 
-The proposed command-controlled playback extension does not change these rules
-for ordinary sounds. A sound opts into the proposed transport model only when
-it carries a `playback` command. See
-[Command-Controlled Sound Playback Proposal](./audio-playback-commands.md).
-Under that proposal, a command-controlled sound cannot be a child of an
+The command-controlled playback extension does not change these rules for
+ordinary sounds. A sound opts into the transport model only when it carries a
+`playback` command. See
+[Command-Controlled Sound Playback](./audio-playback-commands.md). A
+command-controlled sound cannot be a child of an
 `audio-channel` with `loop: true`, because channel-schedule replay would bypass
 command ordering. A non-looping channel may retain either interruption mode;
 an outgoing `loopEnd` instance finishes as an event-detached tail.

--- a/docs/audio-effects.md
+++ b/docs/audio-effects.md
@@ -23,9 +23,14 @@ also still accepts flat Route Graphics `sound` audio nodes for compatibility.
 ## Non-Goals
 
 - no nested audio channels in the first implementation
-- no command-style `play` / `stop` operation model in Route Graphics
+- no command-style `play` / `stop` operation model in the currently implemented
+  channel graph
 - no required channel declarations in project resources
 - no audio filter or general-purpose DSP interface
+
+Command-controlled playback is now being designed as a separate opt-in
+extension for retained sounds. It is not implemented. See
+[Command-Controlled Sound Playback Proposal](./audio-playback-commands.md).
 
 ## Render-State Shape
 
@@ -438,11 +443,17 @@ Route Graphics should keep audio declarative.
 - Removed audio node or effect: keep the internal node alive until `exit`
   transition from the previous `audioEffects` completes, then stop and clean up.
 
-No explicit `op: play` or `op: stop` is needed in Route Graphics render state.
+No explicit `op: play` or `op: stop` is needed for the currently implemented
+declarative sound lifecycle.
 
 The same `sound.id` and source identity fields mean continuation. It does not
 replay. Consumers must use a new playback-instance ID when replaying a one-shot
 sound.
+
+The proposed command-controlled playback extension does not change these rules
+for ordinary sounds. A sound opts into the proposed transport model only when
+it carries a `playback` command. See
+[Command-Controlled Sound Playback Proposal](./audio-playback-commands.md).
 
 Cross-state identity rules:
 

--- a/docs/audio-playback-commands.md
+++ b/docs/audio-playback-commands.md
@@ -1,0 +1,631 @@
+# Command-Controlled Sound Playback Proposal
+
+Status: proposed. This interface is not implemented.
+
+Last updated: 2026-07-25
+
+## Purpose
+
+Route Graphics currently treats audio as declarative graph state. Adding a
+sound starts it, removing it stops it, and changing its source identity replaces
+it. That model is still the default and remains appropriate for one-shot sound
+effects and ordinary background music.
+
+Some consumers need transport controls for a retained sound:
+
+- play or restart at a position
+- pause and preserve the exact renderer-owned cursor
+- resume from that cursor
+- stop and reset to zero
+- seek without changing whether the sound is playing or paused
+- receive decoded duration, progress, natural completion, and playback errors
+
+This proposal adds those capabilities without exposing Route Graphics' internal
+decode generation, source generation, cursor bookkeeping, or playback status.
+
+The public additions are limited to:
+
+1. one optional `playback` command object on a `sound`
+2. four sound lifecycle events
+
+Everything else in this document describes validation or internal runtime
+behavior required to make those two additions reliable.
+
+## Design Principles
+
+- Command-controlled playback is opt-in per sound.
+- Any number of sounds may be command controlled at the same time.
+- Existing sounds without `playback` keep their current declarative behavior.
+- Route Graphics owns the exact audio cursor and stale-callback suppression.
+- Consumers identify commands with one monotonically increasing `commandId`.
+- Mixer-only renders never execute a transport command.
+- Commands are transient runtime instructions, not save-state restoration data.
+- Playback output remains on the existing `eventHandler(eventName, payload)`
+  path.
+
+## Public Render-State Interface
+
+A command-controlled sound has the normal sound fields plus `playback`:
+
+```json
+{
+  "id": "music-room:player",
+  "type": "sound",
+  "src": "main-theme",
+  "volume": 100,
+  "muted": false,
+  "pan": 0,
+  "loop": false,
+  "startDelayMs": 0,
+  "playbackRate": 1,
+  "startAt": 10,
+  "endAt": 190,
+  "playback": {
+    "commandId": 42,
+    "operation": "play",
+    "positionMs": 0
+  }
+}
+```
+
+`playback` is optional. Its presence opts that sound into command-controlled
+transport and correlated sound events.
+
+### Playback Command Fields
+
+| Field        | Required                   | Description                                     |
+| ------------ | -------------------------- | ----------------------------------------------- |
+| `commandId`  | always                     | Ordered, exactly-once command identity          |
+| `operation`  | always                     | `play`, `pause`, `resume`, `stop`, or `seek`    |
+| `positionMs` | for `play` and `seek` only | Position relative to the playable sound segment |
+
+The command object is strict. Unknown properties are invalid.
+
+Validation rules:
+
+```json
+{
+  "commandId": "non-negative safe integer",
+  "operation": ["play", "pause", "resume", "stop", "seek"],
+  "positionMs": "finite non-negative number when required",
+  "unknownProperties": "rejected"
+}
+```
+
+`positionMs` is required for `play` and `seek`. It is invalid on `pause`,
+`resume`, and `stop`.
+
+### Time Units
+
+Existing sound segment fields remain seconds:
+
+```json
+{
+  "startAt": 10,
+  "endAt": 190
+}
+```
+
+Playback commands and events use milliseconds:
+
+```json
+{
+  "positionMs": 83000,
+  "durationMs": 180000
+}
+```
+
+`positionMs` is relative to the playable segment. Position zero means
+`startAt`, not necessarily the beginning of the decoded file.
+
+For a decoded source duration `decodedDuration`:
+
+```text
+segmentStart = startAt
+segmentEnd = endAt ?? decodedDuration
+durationMs = (segmentEnd - segmentStart) * 1000
+```
+
+The resolved segment must be finite and positive. `startAt` must be below the
+decoded source duration, and `endAt`, when present, must be greater than
+`startAt` and no greater than the decoded source duration.
+
+## Command Ordering
+
+`commandId` is the only public synchronization value.
+
+The consumer maintains one increasing audio-command counter. It advances only
+when issuing a transport command and is not reused during the consumer
+lifetime.
+
+Route Graphics compares command IDs for each sound:
+
+```json
+{
+  "sameCommandId": "acknowledgment; do not execute again",
+  "lowerCommandId": "stale command; ignore",
+  "higherCommandId": "execute exactly once"
+}
+```
+
+Gaps between command IDs are valid. Ordinary renders, progress updates, volume
+changes, and mute changes retain the current command ID.
+
+This rule is necessary because repeated render state is otherwise ambiguous.
+These two command objects have identical content:
+
+```json
+{
+  "commandId": 42,
+  "operation": "play",
+  "positionMs": 0
+}
+```
+
+Keeping command ID `42` means "this command was already issued." Sending the
+same operation with command ID `43` means "execute play again," which restarts
+the sound.
+
+## Operations
+
+### Play
+
+`play` starts or restarts a sound at `positionMs`.
+
+Initial play:
+
+```json
+{
+  "commandId": 42,
+  "operation": "play",
+  "positionMs": 0
+}
+```
+
+Restart:
+
+```json
+{
+  "commandId": 43,
+  "operation": "play",
+  "positionMs": 0
+}
+```
+
+There is no separate public `start` or `restart` operation. A new `play`
+command always creates a new active source at the requested segment-relative
+position.
+
+If a previous decode attempt failed, a new `play` command starts a fresh
+attempt rather than rebinding the previous error.
+
+### Pause
+
+```json
+{
+  "commandId": 44,
+  "operation": "pause"
+}
+```
+
+Pause captures Route Graphics' exact current cursor. The consumer does not send
+a position, so a delayed progress render cannot overwrite the captured cursor.
+
+Pausing while decode is pending records paused intent and retains that decode.
+Once ready, the sound remains paused instead of starting. If no source has
+started yet, the retained cursor is the sound's current stored position, or
+zero when no position has been established.
+
+Pausing an already-paused sound is a no-op after the command is accepted.
+
+### Resume
+
+```json
+{
+  "commandId": 45,
+  "operation": "resume"
+}
+```
+
+Resume continues from Route Graphics' captured cursor. The consumer does not
+send a position.
+
+Resuming while decode is pending records playing intent. Playback begins at the
+retained cursor after decode and browser audio-context requirements are
+satisfied.
+
+Resuming without a retained paused cursor is a no-op. The existing
+`resumeAudio()` method remains the separate browser autoplay-unlock hook; it is
+not a sound transport command.
+
+### Stop
+
+```json
+{
+  "commandId": 46,
+  "operation": "stop"
+}
+```
+
+Stop ends the active source and resets its cursor to zero. It retains the sound
+node, decoded buffer or pending decode, and known duration.
+
+Stopping while decode is pending prevents playback after decode but does not
+discard the decode.
+
+Use `pause` rather than `stop` when the cursor must be preserved.
+
+### Seek
+
+```json
+{
+  "commandId": 47,
+  "operation": "seek",
+  "positionMs": 83000
+}
+```
+
+Seek moves to `positionMs` and preserves the current playback state:
+
+- playing remains playing
+- paused remains paused
+- stopped remains stopped at the requested next-start position
+- ended becomes stopped when seeking earlier than duration
+
+Seeking while playing replaces the browser source internally without reporting
+natural completion. Seeking while paused updates the retained cursor without
+starting playback.
+
+Seeking before duration is known or beyond duration is a no-op. Seeking exactly
+to duration enters the internal ended state but does not emit
+`soundComplete`, because completion was caused by a command rather than natural
+playback.
+
+Repeating the same seek requires a higher command ID even when `positionMs` is
+unchanged.
+
+## Multiple Controlled Sounds
+
+The interface is not limited to one controlled sound:
+
+```json
+{
+  "audio": [
+    {
+      "id": "story:bgm",
+      "type": "sound",
+      "src": "story-theme",
+      "loop": true,
+      "playback": {
+        "commandId": 18,
+        "operation": "pause"
+      }
+    },
+    {
+      "id": "music-room:player",
+      "type": "sound",
+      "src": "main-theme",
+      "loop": false,
+      "playback": {
+        "commandId": 19,
+        "operation": "play",
+        "positionMs": 0
+      }
+    }
+  ]
+}
+```
+
+Each sound has one optional playback command object. Sound IDs remain globally
+unique within render state, and each sound is reconciled independently.
+
+This allows a consumer to pause retained story BGM while starting another
+controlled music sound. Voice and sound effects may remain ordinary sounds
+without `playback`.
+
+## Changes Outside the Playback Command
+
+Mixer properties do not require new commands:
+
+```json
+["volume", "muted", "pan", "channel volume", "channel muted"]
+```
+
+Updating only those properties must preserve the source, cursor, decode, and
+accepted command ID. Muting or setting volume to zero does not pause playback.
+
+`loop` may update the active source in place. `playbackRate` may also update in
+place, but Route Graphics must account for the rate when reporting position.
+
+These properties change source identity:
+
+```json
+["src", "startAt", "endAt", "startDelayMs"]
+```
+
+Changing a source-identity property on a command-controlled sound requires a
+higher command ID with operation `play`. Changing source identity while
+retaining the same command ID, or pairing the change with another operation, is
+an invalid cross-render transition.
+
+## Public Events
+
+Command-controlled sounds emit four semantic events through the existing Route
+Graphics event handler:
+
+```text
+eventHandler(eventName, payload)
+```
+
+Legacy sounds without `playback` do not emit these command-correlated events.
+These names are proposed and do not join the stable public event set until the
+interface is implemented and released.
+
+All sound events are dispatched outside the active `render()` call so cached
+decode results cannot cause reentrant rendering.
+
+### `soundReady`
+
+Emitted when decoding and playable-segment validation succeed:
+
+```json
+{
+  "soundId": "music-room:player",
+  "commandId": 42,
+  "positionMs": 0,
+  "durationMs": 180000
+}
+```
+
+### `soundProgress`
+
+Emitted at least every 250 milliseconds while playing and immediately after a
+successful pause, seek, or stop when duration is known:
+
+```json
+{
+  "soundId": "music-room:player",
+  "commandId": 44,
+  "positionMs": 83000,
+  "durationMs": 180000
+}
+```
+
+When pause, seek, or stop occurs before duration is known, the corresponding
+position event is deferred until `soundReady`.
+
+### `soundComplete`
+
+Emitted only when active non-looping playback reaches its natural end:
+
+```json
+{
+  "soundId": "music-room:player",
+  "commandId": 45,
+  "positionMs": 180000,
+  "durationMs": 180000
+}
+```
+
+Completion is not emitted for pause, seek, stop, replacement, removal, decode
+failure, audio-context suspension, or Route Graphics destruction.
+
+### `soundError`
+
+Emitted when a controlled sound cannot become ready or play:
+
+```json
+{
+  "soundId": "music-room:player",
+  "commandId": 42,
+  "errorCode": "decode-failed"
+}
+```
+
+Initial stable error codes:
+
+```json
+["asset-unavailable", "decode-failed", "invalid-segment", "playback-failed"]
+```
+
+The payload must not expose browser exception messages, asset URLs, file
+contents, stack traces, or other sensitive implementation details.
+
+## Event Correlation and Rebinding
+
+Consumers accept a sound event only when both of these values match current
+state:
+
+```json
+{
+  "soundId": "music-room:player",
+  "commandId": 42
+}
+```
+
+Route Graphics owns additional private instance and callback tokens. They are
+not part of render state or event payloads.
+
+Ready, error, and progress events bind to the latest accepted command. If a
+decode settles under an older command, Route Graphics suppresses that stale
+event and publishes the settled result under the latest applicable command.
+When a decode is already settled as ready, Route Graphics can re-emit
+`soundReady` for a newly accepted command before publishing progress for it.
+
+A new `play` following an error creates a fresh attempt. It must not re-emit the
+previous error as the result of the new command.
+
+Completion remains tied to the command that created the currently active
+playing source:
+
+- `play` creates a completion binding
+- `resume` creates a new active-source binding
+- `seek` while playing creates a new active-source binding
+- pause, stop, seek replacement, sound replacement, and removal invalidate the
+  previous binding
+
+The browser `AudioBufferSourceNode.onended` callback is not sufficient to
+identify natural completion because intentional `stop()` calls also trigger it.
+Route Graphics must distinguish natural completion from controlled teardown.
+
+## Decode Retention
+
+Decode lifetime belongs to the retained command-controlled sound, not to an
+individual browser source node.
+
+- pause retains an in-progress or completed decode
+- resume reuses the retained decode
+- stop retains an in-progress or completed decode
+- seek reuses the retained decode
+- changing source identity replaces the retained decode
+- removing the sound releases its binding and suppresses later callbacks
+- a new `play` after error creates a fresh attempt
+
+If a sound references an asset that is already decoded, it still emits
+`soundReady` with the current command correlation. If an asset is decoding,
+the sound subscribes to that in-flight result instead of warning once and
+remaining permanently unstarted.
+
+## Cursor Ownership
+
+Route Graphics calculates position from the decoded segment, current source
+offset, audio-context time, playback rate, and all pause/seek/source
+replacements.
+
+Consumers must not estimate current position from wall-clock time. They update
+their display state from `soundProgress`.
+
+Progress-derived position changes do not produce new playback commands. A
+consumer may render updated UI and mixer state while retaining the same
+playback command:
+
+```json
+{
+  "commandId": 42,
+  "operation": "play",
+  "positionMs": 0
+}
+```
+
+The original command position remains unchanged until the consumer issues
+another transport operation.
+
+## Runtime Lifecycle
+
+Playback commands are transient runtime instructions. They are intentionally
+not sufficient to restore an exact paused cursor after Route Graphics has been
+destroyed.
+
+Consumers must clear or deliberately restart command-controlled playback when:
+
+- creating a new Route Graphics instance
+- loading saved state
+- starting a new game or runtime session
+- replacing the project
+- otherwise invalidating renderer-owned audio state
+
+Re-rendering through the same Route Graphics instance preserves playback.
+Destroying and recreating the instance does not.
+
+This lifecycle keeps the public command small. Adding public decode generations
+and desired status would still not restore the renderer's exact cursor after
+destruction, so those fields do not belong in this interface.
+
+## Legacy Compatibility
+
+An ordinary sound remains valid:
+
+```json
+{
+  "id": "click",
+  "type": "sound",
+  "src": "click-sfx"
+}
+```
+
+Its behavior remains:
+
+- addition starts playback
+- removal stops playback
+- stable sound and source identity continues playback
+- source-identity changes replace playback
+- replaying a one-shot requires a new sound playback-instance ID
+
+No new command ID or events are required for legacy sounds.
+
+Audio channels require no interface changes. Existing channel and sound volume,
+mute, pan, loop, timing, and transition fields remain unchanged.
+
+## Internal Implementation Requirements
+
+This proposal does not prescribe public methods for transport. An eventual
+implementation will need internal support for:
+
+- a retained playback controller per command-controlled sound
+- private source/decode generations and callback tokens
+- exact cursor capture and source recreation for pause, resume, and seek
+- command ordering and exactly-once reconciliation
+- decoded segment validation and duration calculation
+- progress scheduling
+- event dispatch through the current Route Graphics event handler
+- settled-decode rebinding to the latest command
+- natural-completion detection
+- stale callback suppression after replacement, removal, and destruction
+
+The existing `resumeAudio()` public method remains unchanged.
+
+## Why the Interface Does Not Expose More State
+
+An earlier design considered this larger command:
+
+```json
+{
+  "trackId": "mainTheme",
+  "playbackGeneration": 12,
+  "commandRevision": 4,
+  "operation": "pause",
+  "status": "paused",
+  "positionMs": 83000
+}
+```
+
+That shape duplicates state already owned by the sound node, consumer, and
+renderer:
+
+- `sound.id` identifies the controlled renderer sound
+- the consumer already knows which logical track is selected
+- Route Graphics can own source and decode generations privately
+- one ordered command ID provides exactly-once reconciliation
+- the operation determines desired transport behavior
+- pause and resume must use the renderer's exact cursor rather than a supplied
+  projected position
+
+The smaller command preserves the required safety properties without making
+consumers coordinate multiple counters and duplicate playback status.
+
+## Required Test Coverage
+
+Implementation is not complete until tests cover:
+
+- strict command validation and operation-specific `positionMs`
+- multiple simultaneous command-controlled sounds
+- same, lower, and higher command IDs
+- repeated play and repeated seek
+- pause/resume cursor continuity
+- pause, resume, stop, and seek while decoding
+- source-identity change requirements
+- volume, mute, pan, and channel updates without restart
+- playback-rate-aware progress
+- segment-relative duration and position
+- ready, progress, complete, and error payloads
+- cached and in-flight decode rebinding
+- retry after decode error
+- intentional `onended` suppression
+- stale callbacks after command changes, replacement, removal, and destroy
+- story BGM pause/resume while another sound plays
+- lifecycle clearing when Route Graphics is recreated
+- backward compatibility for sounds without `playback`
+
+Unit tests should exercise the state machine with a mocked audio context.
+Browser audio tests should verify real cursor continuity, event timing, and
+autoplay-unlock behavior.

--- a/docs/audio-playback-commands.md
+++ b/docs/audio-playback-commands.md
@@ -1,6 +1,6 @@
-# Command-Controlled Sound Playback Proposal
+# Command-Controlled Sound Playback
 
-Status: proposed. This interface is not implemented.
+Status: implemented for the Route Graphics 1.31.0 release.
 
 Last updated: 2026-07-25
 
@@ -20,7 +20,7 @@ Some consumers need transport controls for a retained sound:
 - seek without changing whether the sound is playing or paused
 - receive decoded duration, progress, natural completion, and playback errors
 
-This proposal adds those capabilities without exposing Route Graphics' internal
+This interface adds those capabilities without exposing Route Graphics' internal
 decode generation, source generation, cursor bookkeeping, or playback status.
 
 The public additions are limited to:
@@ -87,8 +87,8 @@ mode, and accepted command ID unchanged.
 To change modes, the consumer must first complete a render in which the sound
 ID is absent, then add the sound in a later render. Re-adding it starts a new
 runtime lifetime that may independently choose legacy or command-controlled
-mode. Removing and replacing a sound with the same ID in one render is not a
-mode transition because there is no observable absent lifetime.
+mode. Replacing a sound with the same ID in one render does not create an
+observable absent lifetime and therefore cannot change modes.
 
 ### Playback Command Fields
 
@@ -277,7 +277,9 @@ Once ready, the sound remains paused instead of starting. If no source has
 started yet, the retained cursor is the sound's current stored position, or
 zero when no position has been established.
 
-Pausing an already-paused sound is a no-op after the command is accepted.
+Pausing an already-paused, stopped, ended, or never-started sound is a no-op
+after the command is accepted. In particular, pausing a stopped sound does not
+arm a later `resume`; a new `play` command is required.
 
 ### Resume
 
@@ -507,8 +509,10 @@ Mixer properties do not require new commands:
 Updating only those properties must preserve the source, cursor, decode, and
 accepted command ID. Muting or setting volume to zero does not pause playback.
 
-`loop` may update the active source in place. `playbackRate` may also update in
-place, but Route Graphics must account for the rate when reporting position.
+`loop` may update without a transport command. Route Graphics may recreate the
+browser source at its captured cursor when needed to preserve segment
+boundaries. `playbackRate` may update in place, but Route Graphics must account
+for the rate when reporting position.
 
 These properties change source identity:
 
@@ -554,8 +558,8 @@ eventHandler(eventName, payload)
 ```
 
 Legacy sounds without `playback` do not emit these command-correlated events.
-These names are proposed and do not join the stable public event set until the
-interface is implemented and released.
+These names join the public event set with the release that includes this
+interface.
 
 All sound events are dispatched outside the active `render()` call so cached
 decode results cannot cause reentrant rendering.
@@ -676,8 +680,10 @@ not part of render state or event payloads.
 Ready, error, and progress events bind to the latest accepted command. If a
 decode settles under an older command, Route Graphics suppresses that stale
 event and publishes the settled result under the latest applicable command.
-When a decode is already settled as ready, Route Graphics can re-emit
-`soundReady` for a newly accepted command before publishing progress for it.
+An already-cached decode still emits `soundReady` when it is first bound to a
+new controlled sound lifetime or source identity. Once readiness has been
+announced for that lifetime, later commands reuse it without re-emitting
+`soundReady`.
 Deferred progress that still describes the current retained state is likewise
 rebound. For example, `play`, `stop`, then no-op `resume` during decode emits
 readiness and the deferred stopped-at-zero progress under the accepted
@@ -803,8 +809,8 @@ restriction that a looping channel cannot contain a command-controlled sound.
 
 ## Internal Implementation Requirements
 
-This proposal does not prescribe public methods for transport. An eventual
-implementation will need internal support for:
+This interface does not add public methods for transport. Its implementation
+includes:
 
 - a retained playback controller per command-controlled sound
 - private source/decode generations and callback tokens
@@ -850,7 +856,7 @@ consumers coordinate multiple counters and duplicate playback status.
 
 ## Required Test Coverage
 
-Implementation is not complete until tests cover:
+Test coverage includes:
 
 - strict command validation and operation-specific `positionMs`
 - multiple simultaneous command-controlled sounds

--- a/docs/audio-playback-commands.md
+++ b/docs/audio-playback-commands.md
@@ -166,8 +166,10 @@ correlation.
 A `play` command that also changes source identity is different: accepting the
 replacement first detaches the old source. If the position is invalid for the
 new source, Route Graphics does not roll back to the old identity or playback.
-The new sound remains stopped at position zero. The source replacement rules
-below define teardown and event ownership in detail.
+The new sound remains stopped at position zero. Any exit-transition or
+`loopEnd` tail remains detached and event-suppressed; it is never restored as
+the controlled source. The source replacement rules below define teardown and
+event ownership in detail.
 
 ## Command Ordering
 
@@ -329,12 +331,14 @@ Use `pause` rather than `stop` when the cursor must be preserved.
 }
 ```
 
-Seek moves to `positionMs` and preserves the current playback state:
+Seek changes the cursor only when the sound is playing, delay-pending, or
+paused:
 
 - playing remains playing
+- delay-pending remains delay-pending
 - paused remains paused
-- stopped remains stopped at the requested next-start position
-- ended becomes stopped when seeking earlier than duration
+- stopped remains stopped at its existing cursor; the seek is an accepted no-op
+- ended remains ended at the terminal cursor; the seek is an accepted no-op
 
 Seeking while playing replaces the browser source internally without reporting
 natural completion. Seeking while paused updates the retained cursor without
@@ -343,14 +347,21 @@ starting playback.
 Seeking before duration is known is queued, not discarded. After decoding and
 segment validation, Route Graphics resolves the requested position before
 dispatching events. It emits `soundReady` first, followed by `soundProgress`
-for a successful seek or `soundError` with `invalid-position` for a position
-beyond duration.
+when the current transport state permits the seek or `soundError` with
+`invalid-position` for a position beyond duration. An in-range seek that
+resolves while stopped or ended remains a no-op and emits no progress.
 
-Seeking exactly to duration tears down any active source and enters the ended
-state. It emits `soundProgress` but not `soundComplete`, because completion was
-caused by a command rather than natural playback. Seeking beyond duration
-follows the `invalid-position` rule and preserves the existing cursor,
-transport state, and active source.
+Seeking exactly to duration from playing, delay-pending, or paused state tears
+down any active or delayed source and enters the ended state. It emits
+`soundProgress` but not `soundComplete`, because completion was caused by a
+command rather than natural playback. From stopped or ended state, the same
+in-range command is the no-op defined above. Seeking beyond duration follows
+the `invalid-position` rule and preserves the existing cursor, transport state,
+and active source.
+
+To start a stopped or ended sound at a selected position, issue `play` with
+that `positionMs`. A stopped seek does not arm a later `resume` or override the
+position carried by a later `play`.
 
 Repeating the same seek requires a higher command ID even when `positionMs` is
 unchanged.
@@ -375,16 +386,18 @@ owns its countdown:
   the remaining delay and playing intent
 - `seek` while paused updates the cursor and preserves any retained remaining
   delay
-- `stop`, removal, source replacement, and destruction cancel and clear the
-  delayed start
+- `stop`, destruction, and removal or source replacement of a top-level sound
+  or a sound under immediate channel interruption cancel and clear the delayed
+  start
 
-A `play` or `seek` to the terminal cursor cancels the delayed start and enters
-ended state. An out-of-range `play` or `seek` with unchanged source identity
-is an execution error and leaves the existing delayed start, remaining delay,
-and cursor unchanged while rebinding correlation to the accepted command. An
-out-of-range `play` during source replacement follows the replacement rule:
-the old delayed start is cancelled and the new identity remains stopped at
-zero.
+While a delayed start exists, a `play` or `seek` to the terminal cursor cancels
+it and enters ended state. An out-of-range `play` or `seek` with unchanged
+source identity is an execution error and leaves the existing delayed start,
+remaining delay, and cursor unchanged while rebinding correlation to the
+accepted command. An out-of-range `play` during source replacement follows the
+replacement rule: an old delayed start is cancelled for immediate interruption
+or transferred to an event-detached `loopEnd` tail, and the new identity
+remains stopped at zero.
 
 If `play` is issued while decode is pending, the full delay is retained but
 does not count down yet. A pause before decode completes retains that full
@@ -456,6 +469,33 @@ channel and sound runtime unchanged. Use `loop: true` on the controlled sound
 itself when one command should authorize continuous looping, or keep the
 channel non-looping and issue higher playback commands explicitly.
 
+### Audio-Channel Interruption
+
+A command-controlled sound in an allowed non-looping channel preserves the
+channel's existing `interruption` behavior:
+
+- `interruption: "immediate"` detaches and tears down an outgoing sound,
+  subject to any configured exit transition
+- `interruption: "loopEnd"` immediately detaches the outgoing sound from its
+  playback controller, then allows its already-authorized schedule iteration
+  to finish
+
+For `loopEnd`, an active source finishes its current iteration. A pending decode
+or delayed start that was already authorized is allowed to become ready, finish
+its retained delay, and play once. A looping sound is switched to non-looping
+for that final iteration. No new channel schedule or sound loop begins.
+
+The detached outgoing instance cannot receive later playback commands and
+cannot emit `soundReady`, `soundProgress`, `soundComplete`, or `soundError`.
+Those events belong only to the retained or replacement controller. Configured
+exit transitions run concurrently with the loop-end tail, and cleanup waits
+until both the transition and final iteration have finished.
+
+An explicit `stop` command always takes precedence over channel interruption
+and stops the current controlled sound immediately. Once removal or replacement
+has detached a loop-end tail, later commands address only the retained or
+replacement sound and do not affect that outgoing tail.
+
 ## Changes Outside the Playback Command
 
 Mixer properties do not require new commands:
@@ -485,11 +525,16 @@ An accepted source replacement is committed before decode or resolved-position
 validation for the new identity:
 
 1. Route Graphics makes the new source identity current.
-2. It cancels the old delayed start, detaches the old active source from the
-   playback controller, and invalidates its decode and event bindings.
+2. It detaches the old instance from the playback controller and invalidates
+   its public event bindings. A top-level sound or immediate channel
+   interruption cancels its delayed start and begins active-source teardown,
+   allowing only a configured exit-transition tail. `loopEnd` interruption
+   transfers any already-authorized pending or active iteration to the detached
+   outgoing tail defined above.
 3. An outgoing instance may remain audible only for a configured exit
-   transition. It cannot receive later transport commands or emit
-   `soundReady`, `soundProgress`, `soundComplete`, or `soundError`.
+   transition, a `loopEnd` tail, or both. It cannot receive later transport
+   commands or emit `soundReady`, `soundProgress`, `soundComplete`, or
+   `soundError`.
 4. Route Graphics decodes and validates the new identity under the new command.
 5. If decoding, segment validation, position validation, or playback fails, the
    new identity remains current and stopped at position zero.
@@ -815,12 +860,14 @@ Implementation is not complete until tests cover:
 - pause/resume cursor continuity
 - pause, resume, stop, play, and queued seek while decoding
 - play, stop, then resume while decoding
+- stopped and ended seeks as accepted no-ops that do not arm resume
 - play and seek positions below, equal to, and greater than duration
 - retained-sound transitions into and out of command-controlled mode
 - source-identity change requirements
 - source replacement followed by decode, segment, position, or playback failure
 - full and remaining `startDelayMs` behavior for every transport operation
 - rejection of command-controlled children in looping channels
+- immediate and loop-end interruption of active, decoding, and delayed sounds
 - volume, mute, pan, and channel updates without restart
 - playback-rate-aware progress
 - segment-relative duration and position

--- a/docs/audio-playback-commands.md
+++ b/docs/audio-playback-commands.md
@@ -257,6 +257,12 @@ position and resolves these same boundary rules after decoding and segment
 validation. Route Graphics emits `soundReady` before starting valid playback,
 reporting terminal progress, or emitting `invalid-position`.
 
+If multiple `play` commands arrive while the same source is decoding and the
+latest position is out of range, Route Graphics falls back through the earlier
+pending commands and preserves the most recent executable cursor and transport
+state. The `invalid-position` error still carries the latest accepted command
+ID. A source-identity replacement has no earlier same-source fallback.
+
 If a previous decode attempt failed, a new `play` command starts a fresh
 attempt rather than rebinding the previous error.
 
@@ -563,6 +569,12 @@ interface.
 
 All sound events are dispatched outside the active `render()` call so cached
 decode results cannot cause reentrant rendering.
+
+An event handler may synchronously render another state. In particular, a
+higher command issued from `soundReady` is applied before startup completes. If
+that command preserves playing intent, Route Graphics starts at the resulting
+latest cursor; pause, stop, terminal seek, removal, or destruction still prevent
+startup.
 
 Sound lifecycle metadata follows the existing event payload contract in
 `api-naming.md`: renderer-provided fields live under the reserved `_event`

--- a/docs/audio-playback-commands.md
+++ b/docs/audio-playback-commands.md
@@ -68,8 +68,27 @@ A command-controlled sound has the normal sound fields plus `playback`:
 }
 ```
 
-`playback` is optional. Its presence opts that sound into command-controlled
-transport and correlated sound events.
+`playback` is optional when a sound ID first appears. Its presence opts that
+sound into command-controlled transport and correlated sound events for that
+sound's retained lifetime.
+
+### Playback Mode Lifetime
+
+Playback mode cannot change while a sound with the same ID is retained across
+renders:
+
+- a legacy sound cannot gain `playback`
+- a command-controlled sound cannot lose `playback`
+
+Either transition is a validation error. Route Graphics rejects that render
+before audio reconciliation and leaves the existing source, cursor, decode,
+mode, and accepted command ID unchanged.
+
+To change modes, the consumer must first complete a render in which the sound
+ID is absent, then add the sound in a later render. Re-adding it starts a new
+runtime lifetime that may independently choose legacy or command-controlled
+mode. Removing and replacing a sound with the same ID in one render is not a
+mode transition because there is no observable absent lifetime.
 
 ### Playback Command Fields
 
@@ -130,6 +149,19 @@ The resolved segment must be finite and positive. `startAt` must be below the
 decoded source duration, and `endAt`, when present, must be greater than
 `startAt` and no greater than the decoded source duration.
 
+Command schema validation accepts any finite, non-negative `positionMs`.
+Resolved position validation occurs once `durationMs` is known:
+
+- a position below `durationMs` is playable
+- a position equal to `durationMs` is the valid terminal cursor
+- a position greater than `durationMs` cannot be executed
+
+A position beyond duration does not change the existing cursor, transport
+state, or active source. Route Graphics emits `soundError` with error code
+`invalid-position`. This is a command execution error, not a render-schema
+error: the higher command ID remains accepted, and any unchanged active source
+is rebound to that command for future event correlation.
+
 ## Command Ordering
 
 `commandId` is the only public synchronization value.
@@ -150,6 +182,13 @@ Route Graphics compares command IDs for each sound:
 
 Gaps between command IDs are valid. Ordinary renders, progress updates, volume
 changes, and mute changes retain the current command ID.
+
+A schema-invalid command is not accepted and does not advance correlation. A
+schema-valid command with a higher ID is accepted before its transport effect
+is evaluated. It therefore advances correlation even when the operation is a
+state-dependent no-op or later produces an execution error such as
+`invalid-position`. Any active source that survives the command is rebound to
+the newly accepted command without restarting.
 
 This rule is necessary because repeated render state is otherwise ambiguous.
 These two command objects have identical content:
@@ -194,7 +233,18 @@ Restart:
 
 There is no separate public `start` or `restart` operation. A new `play`
 command always creates a new active source at the requested segment-relative
-position.
+position when that position is below `durationMs`.
+
+A `play` position equal to `durationMs` tears down any previous active source,
+sets the cursor and transport state to ended, and emits `soundProgress`. It
+does not create a source or emit `soundComplete`, because no natural playback
+occurred. A position greater than `durationMs` follows the
+`invalid-position` rule above and leaves any existing playback unchanged.
+
+When duration is not known yet, Route Graphics retains the requested play
+position and resolves these same boundary rules after decoding and segment
+validation. Route Graphics emits `soundReady` before starting valid playback,
+reporting terminal progress, or emitting `invalid-position`.
 
 If a previous decode attempt failed, a new `play` command starts a fresh
 attempt rather than rebinding the previous error.
@@ -276,10 +326,17 @@ Seeking while playing replaces the browser source internally without reporting
 natural completion. Seeking while paused updates the retained cursor without
 starting playback.
 
-Seeking before duration is known or beyond duration is a no-op. Seeking exactly
-to duration enters the internal ended state but does not emit
-`soundComplete`, because completion was caused by a command rather than natural
-playback.
+Seeking before duration is known is queued, not discarded. After decoding and
+segment validation, Route Graphics resolves the requested position before
+dispatching events. It emits `soundReady` first, followed by `soundProgress`
+for a successful seek or `soundError` with `invalid-position` for a position
+beyond duration.
+
+Seeking exactly to duration tears down any active source and enters the ended
+state. It emits `soundProgress` but not `soundComplete`, because completion was
+caused by a command rather than natural playback. Seeking beyond duration
+follows the `invalid-position` rule and preserves the existing cursor,
+transport state, and active source.
 
 Repeating the same seek requires a higher command ID even when `positionMs` is
 unchanged.
@@ -364,35 +421,47 @@ interface is implemented and released.
 All sound events are dispatched outside the active `render()` call so cached
 decode results cannot cause reentrant rendering.
 
+Sound lifecycle metadata follows the existing event payload contract in
+`api-naming.md`: renderer-provided fields live under the reserved `_event`
+object, and `_event.id` identifies the sound. These events do not place runtime
+metadata at the payload's top level.
+
 ### `soundReady`
 
 Emitted when decoding and playable-segment validation succeed:
 
 ```json
 {
-  "soundId": "music-room:player",
-  "commandId": 42,
-  "positionMs": 0,
-  "durationMs": 180000
+  "_event": {
+    "id": "music-room:player",
+    "commandId": 42,
+    "positionMs": 0,
+    "durationMs": 180000
+  }
 }
 ```
 
 ### `soundProgress`
 
 Emitted at least every 250 milliseconds while playing and immediately after a
-successful pause, seek, or stop when duration is known:
+successful pause, seek, or stop when duration is known. A `play` or `seek`
+command that moves to the terminal cursor also emits it:
 
 ```json
 {
-  "soundId": "music-room:player",
-  "commandId": 44,
-  "positionMs": 83000,
-  "durationMs": 180000
+  "_event": {
+    "id": "music-room:player",
+    "commandId": 44,
+    "positionMs": 83000,
+    "durationMs": 180000
+  }
 }
 ```
 
-When pause, seek, or stop occurs before duration is known, the corresponding
-position event is deferred until `soundReady`.
+When a cursor-changing operation is resolved during pending decode,
+`soundReady` is emitted first. A successful pause, seek, stop, or terminal
+`play` then emits one immediate `soundProgress`. A queued `play` or `seek`
+beyond duration emits `soundError` instead of progress.
 
 ### `soundComplete`
 
@@ -400,10 +469,12 @@ Emitted only when active non-looping playback reaches its natural end:
 
 ```json
 {
-  "soundId": "music-room:player",
-  "commandId": 45,
-  "positionMs": 180000,
-  "durationMs": 180000
+  "_event": {
+    "id": "music-room:player",
+    "commandId": 45,
+    "positionMs": 180000,
+    "durationMs": 180000
+  }
 }
 ```
 
@@ -412,24 +483,36 @@ failure, audio-context suspension, or Route Graphics destruction.
 
 ### `soundError`
 
-Emitted when a controlled sound cannot become ready or play:
+Emitted when a controlled sound cannot become ready or execute a command:
 
 ```json
 {
-  "soundId": "music-room:player",
-  "commandId": 42,
-  "errorCode": "decode-failed"
+  "_event": {
+    "id": "music-room:player",
+    "commandId": 42,
+    "errorCode": "decode-failed"
+  }
 }
 ```
 
 Initial stable error codes:
 
 ```json
-["asset-unavailable", "decode-failed", "invalid-segment", "playback-failed"]
+[
+  "asset-unavailable",
+  "decode-failed",
+  "invalid-segment",
+  "invalid-position",
+  "playback-failed"
+]
 ```
 
 The payload must not expose browser exception messages, asset URLs, file
 contents, stack traces, or other sensitive implementation details.
+
+`invalid-position` means a `play` or `seek` position is greater than the
+decoded playable segment's `durationMs`. It leaves existing transport state
+unchanged.
 
 ## Event Correlation and Rebinding
 
@@ -438,11 +521,14 @@ state:
 
 ```json
 {
-  "soundId": "music-room:player",
-  "commandId": 42
+  "_event": {
+    "id": "music-room:player",
+    "commandId": 42
+  }
 }
 ```
 
+Consumers compare `payload._event.id` and `payload._event.commandId`.
 Route Graphics owns additional private instance and callback tokens. They are
 not part of render state or event payloads.
 
@@ -455,14 +541,23 @@ When a decode is already settled as ready, Route Graphics can re-emit
 A new `play` following an error creates a fresh attempt. It must not re-emit the
 previous error as the result of the new command.
 
-Completion remains tied to the command that created the currently active
-playing source:
+Completion is tied to the latest accepted command under which the current
+active source remains valid:
 
-- `play` creates a completion binding
-- `resume` creates a new active-source binding
-- `seek` while playing creates a new active-source binding
-- pause, stop, seek replacement, sound replacement, and removal invalidate the
-  previous binding
+- `play`, `resume`, and `seek` while playing bind their new active source
+- any accepted higher command that leaves an active source unchanged rebinds
+  that source to the new command without restarting it
+- source replacement invalidates the previous private binding before binding
+  the replacement
+- pause, stop, transition to ended, sound removal, and sound replacement
+  invalidate the binding without reporting completion
+
+The rebinding rule includes accepted no-ops such as `resume` while already
+playing and execution errors such as an out-of-range position. If that
+unchanged source later reaches its natural end, `soundComplete` carries the
+latest accepted command ID rather than the ID that originally created the
+browser source. Schema-invalid, repeated, lower, and otherwise stale commands
+do not advance or rebind correlation.
 
 The browser `AudioBufferSourceNode.onended` callback is not sufficient to
 identify natural completion because intentional `stop()` calls also trigger it.
@@ -610,14 +705,17 @@ Implementation is not complete until tests cover:
 - strict command validation and operation-specific `positionMs`
 - multiple simultaneous command-controlled sounds
 - same, lower, and higher command IDs
+- accepted no-op and execution-error completion rebinding
 - repeated play and repeated seek
 - pause/resume cursor continuity
-- pause, resume, stop, and seek while decoding
+- pause, resume, stop, play, and queued seek while decoding
+- play and seek positions below, equal to, and greater than duration
+- retained-sound transitions into and out of command-controlled mode
 - source-identity change requirements
 - volume, mute, pan, and channel updates without restart
 - playback-rate-aware progress
 - segment-relative duration and position
-- ready, progress, complete, and error payloads
+- ready, progress, complete, and error payloads under `_event`
 - cached and in-flight decode rebinding
 - retry after decode error
 - intentional `onended` suppression

--- a/docs/audio-playback-commands.md
+++ b/docs/audio-playback-commands.md
@@ -156,11 +156,18 @@ Resolved position validation occurs once `durationMs` is known:
 - a position equal to `durationMs` is the valid terminal cursor
 - a position greater than `durationMs` cannot be executed
 
-A position beyond duration does not change the existing cursor, transport
-state, or active source. Route Graphics emits `soundError` with error code
-`invalid-position`. This is a command execution error, not a render-schema
-error: the higher command ID remains accepted, and any unchanged active source
-is rebound to that command for future event correlation.
+When source identity is unchanged, a position beyond duration does not change
+the existing cursor, transport state, or active source. Route Graphics emits
+`soundError` with error code `invalid-position`. This is a command execution
+error, not a render-schema error: the higher command ID remains accepted, and
+any unchanged active source is rebound to that command for future event
+correlation.
+
+A `play` command that also changes source identity is different: accepting the
+replacement first detaches the old source. If the position is invalid for the
+new source, Route Graphics does not roll back to the old identity or playback.
+The new sound remains stopped at position zero. The source replacement rules
+below define teardown and event ownership in detail.
 
 ## Command Ordering
 
@@ -239,7 +246,9 @@ A `play` position equal to `durationMs` tears down any previous active source,
 sets the cursor and transport state to ended, and emits `soundProgress`. It
 does not create a source or emit `soundComplete`, because no natural playback
 occurred. A position greater than `durationMs` follows the
-`invalid-position` rule above and leaves any existing playback unchanged.
+`invalid-position` rule above. It leaves playback unchanged when source
+identity is retained; during source replacement, it leaves the new sound
+stopped at zero and never restores the old source.
 
 When duration is not known yet, Route Graphics retains the requested play
 position and resolves these same boundary rules after decoding and segment
@@ -280,13 +289,18 @@ Pausing an already-paused sound is a no-op after the command is accepted.
 Resume continues from Route Graphics' captured cursor. The consumer does not
 send a position.
 
-Resuming while decode is pending records playing intent. Playback begins at the
-retained cursor after decode and browser audio-context requirements are
-satisfied.
+Pending decode does not make `resume` valid by itself. Resume records playing
+intent only when the controller is paused and has a retained paused cursor.
+Playback begins at that cursor after decode and browser audio-context
+requirements are satisfied.
 
-Resuming without a retained paused cursor is a no-op. The existing
-`resumeAudio()` method remains the separate browser autoplay-unlock hook; it is
-not a sound transport command.
+Resuming from stopped, ended, or never-started state is a no-op, including
+while decode is pending. Therefore `play`, then `stop`, then `resume` before
+decode settles remains stopped when decoding completes. A new `play` command
+is required to start it.
+
+The existing `resumeAudio()` method remains the separate browser
+autoplay-unlock hook; it is not a sound transport command.
 
 ### Stop
 
@@ -341,6 +355,49 @@ transport state, and active source.
 Repeating the same seek requires a higher command ID even when `positionMs` is
 unchanged.
 
+### Delayed Start
+
+`startDelayMs` belongs to source identity, but command-controlled transport
+owns its countdown:
+
+- every successful `play` below duration cancels any previous delayed start and
+  applies the full current `startDelayMs`
+- the countdown begins after decode and segment validation succeed
+- a pending countdown is an internal playing-intent substate, so `resume` while
+  it is already counting down is an accepted no-op
+- position remains at the requested play cursor and periodic progress does not
+  begin until the browser source starts
+- `pause` during the countdown cancels the timer, preserves the remaining delay
+  and cursor, and enters paused state
+- `resume` from that paused state continues the remaining delay; it does not
+  reapply the full delay
+- `seek` during the countdown updates the pending start cursor and preserves
+  the remaining delay and playing intent
+- `seek` while paused updates the cursor and preserves any retained remaining
+  delay
+- `stop`, removal, source replacement, and destruction cancel and clear the
+  delayed start
+
+A `play` or `seek` to the terminal cursor cancels the delayed start and enters
+ended state. An out-of-range `play` or `seek` with unchanged source identity
+is an execution error and leaves the existing delayed start, remaining delay,
+and cursor unchanged while rebinding correlation to the accepted command. An
+out-of-range `play` during source replacement follows the replacement rule:
+the old delayed start is cancelled and the new identity remains stopped at
+zero.
+
+If `play` is issued while decode is pending, the full delay is retained but
+does not count down yet. A pause before decode completes retains that full
+delay; a later valid resume starts the countdown after readiness. A stop before
+decode completes clears it, and a later resume is the stopped-state no-op
+defined above.
+
+`soundReady` is emitted before the delay countdown begins. Pausing, seeking, or
+stopping during a known-duration delayed start emits the same immediate
+`soundProgress` as performing that operation on an active source. No
+`soundComplete` is emitted unless actual non-looping playback later reaches its
+natural end.
+
 ## Multiple Controlled Sounds
 
 The interface is not limited to one controlled sound:
@@ -380,6 +437,25 @@ This allows a consumer to pause retained story BGM while starting another
 controlled music sound. Voice and sound effects may remain ordinary sounds
 without `playback`.
 
+### Audio-Channel Loop Restriction
+
+A command-controlled sound may be a child of an `audio-channel` only when that
+channel has `loop: false`. A looping channel automatically restarts its complete
+child schedule without a new command ID, so combining the two ownership models
+is invalid.
+
+Route Graphics rejects any render that:
+
+- adds a command-controlled sound to a channel with `loop: true`
+- moves a command-controlled sound into a channel with `loop: true`
+- changes a containing channel to `loop: true` while it has a
+  command-controlled child
+
+The render is rejected before audio reconciliation, leaving the previous
+channel and sound runtime unchanged. Use `loop: true` on the controlled sound
+itself when one command should authorize continuous looping, or keep the
+channel non-looping and issue higher playback commands explicitly.
+
 ## Changes Outside the Playback Command
 
 Mixer properties do not require new commands:
@@ -404,6 +480,24 @@ Changing a source-identity property on a command-controlled sound requires a
 higher command ID with operation `play`. Changing source identity while
 retaining the same command ID, or pairing the change with another operation, is
 an invalid cross-render transition.
+
+An accepted source replacement is committed before decode or resolved-position
+validation for the new identity:
+
+1. Route Graphics makes the new source identity current.
+2. It cancels the old delayed start, detaches the old active source from the
+   playback controller, and invalidates its decode and event bindings.
+3. An outgoing instance may remain audible only for a configured exit
+   transition. It cannot receive later transport commands or emit
+   `soundReady`, `soundProgress`, `soundComplete`, or `soundError`.
+4. Route Graphics decodes and validates the new identity under the new command.
+5. If decoding, segment validation, position validation, or playback fails, the
+   new identity remains current and stopped at position zero.
+
+Replacement is never rolled back to the old source. A later command operates
+only on the new identity. A later `play` may reuse a successfully decoded new
+buffer after `invalid-position`; decode and asset failures follow the fresh
+attempt rule defined for `play`.
 
 ## Public Events
 
@@ -512,7 +606,9 @@ contents, stack traces, or other sensitive implementation details.
 
 `invalid-position` means a `play` or `seek` position is greater than the
 decoded playable segment's `durationMs`. It leaves existing transport state
-unchanged.
+unchanged when source identity is retained. During source replacement, the old
+identity has already been detached and the new identity remains stopped at
+zero.
 
 ## Event Correlation and Rebinding
 
@@ -537,9 +633,15 @@ decode settles under an older command, Route Graphics suppresses that stale
 event and publishes the settled result under the latest applicable command.
 When a decode is already settled as ready, Route Graphics can re-emit
 `soundReady` for a newly accepted command before publishing progress for it.
+Deferred progress that still describes the current retained state is likewise
+rebound. For example, `play`, `stop`, then no-op `resume` during decode emits
+readiness and the deferred stopped-at-zero progress under the accepted
+`resume` command ID.
 
-A new `play` following an error creates a fresh attempt. It must not re-emit the
-previous error as the result of the new command.
+A new `play` following an asset, decode, or playback failure creates a fresh
+attempt. It must not re-emit the previous error as the result of the new
+command. `invalid-position` does not invalidate an otherwise usable decoded
+buffer, so a later valid `play` may reuse that buffer.
 
 Completion is tied to the latest accepted command under which the current
 active source remains valid:
@@ -574,7 +676,9 @@ individual browser source node.
 - seek reuses the retained decode
 - changing source identity replaces the retained decode
 - removing the sound releases its binding and suppresses later callbacks
-- a new `play` after error creates a fresh attempt
+- an invalid position retains a successfully decoded buffer
+- a new `play` after an asset, decode, or playback failure creates a fresh
+  attempt
 
 If a sound references an asset that is already decoded, it still emits
 `soundReady` with the current command correlation. If an asset is decoding,
@@ -648,8 +752,9 @@ Its behavior remains:
 
 No new command ID or events are required for legacy sounds.
 
-Audio channels require no interface changes. Existing channel and sound volume,
-mute, pan, loop, timing, and transition fields remain unchanged.
+Audio channels require no new fields. Existing channel and sound volume, mute,
+pan, sound-loop, timing, and transition fields remain unchanged, subject to the
+restriction that a looping channel cannot contain a command-controlled sound.
 
 ## Internal Implementation Requirements
 
@@ -709,9 +814,13 @@ Implementation is not complete until tests cover:
 - repeated play and repeated seek
 - pause/resume cursor continuity
 - pause, resume, stop, play, and queued seek while decoding
+- play, stop, then resume while decoding
 - play and seek positions below, equal to, and greater than duration
 - retained-sound transitions into and out of command-controlled mode
 - source-identity change requirements
+- source replacement followed by decode, segment, position, or playback failure
+- full and remaining `startDelayMs` behavior for every transport operation
+- rejection of command-controlled children in looping channels
 - volume, mute, pan, and channel updates without restart
 - playback-rate-aware progress
 - segment-relative duration and position

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.30.2",
+  "version": "1.31.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/pages/docs/nodes/sound.md
+++ b/playground/pages/docs/nodes/sound.md
@@ -5,7 +5,8 @@ tags: documentation
 sidebarId: node-sound
 ---
 
-`sound` is the built-in audio node for one-shot SFX and looping BGM.
+`sound` is the built-in audio node for one-shot SFX, looping BGM, and optional
+command-controlled playback.
 
 Try it in the [Playground](/playground/?template=sound-demo).
 
@@ -15,20 +16,32 @@ Try it in the [Playground](/playground/?template=sound-demo).
 
 ## Field Reference
 
-| Field          | Type    | Required | Default | Notes                               |
-| -------------- | ------- | -------- | ------- | ----------------------------------- |
-| `id`           | string  | Yes      | -       | Audio id.                           |
-| `type`         | string  | Yes      | -       | Must be `sound`.                    |
-| `src`          | string  | Yes      | -       | Audio source alias/URL.             |
-| `volume`       | number  | No       | `100`   | Runtime maps to `volume / 100`.     |
-| `loop`         | boolean | No       | `false` | Loop playback.                      |
-| `startDelayMs` | number  | No       | `0`     | Delay in ms before playback starts. |
+| Field          | Type        | Required | Default | Notes                                      |
+| -------------- | ----------- | -------- | ------- | ------------------------------------------ |
+| `id`           | string      | Yes      | -       | Globally unique sound id.                  |
+| `type`         | string      | Yes      | -       | Must be `sound`.                           |
+| `src`          | string      | Yes      | -       | Audio source alias/URL.                    |
+| `volume`       | number      | No       | `100`   | Local volume from `0` to `100`.            |
+| `muted`        | boolean     | No       | `false` | Mutes this sound without pausing it.       |
+| `pan`          | number      | No       | `0`     | Stereo pan from `-1` to `1`.               |
+| `loop`         | boolean     | No       | `false` | Loop playback.                             |
+| `startDelayMs` | number      | No       | `0`     | Delay in ms before playback starts.        |
+| `playbackRate` | number      | No       | `1`     | Playback speed multiplier.                 |
+| `startAt`      | number      | No       | `0`     | Playable segment start in seconds.         |
+| `endAt`        | number/null | No       | `null`  | Optional playable segment end in seconds.  |
+| `playback`     | object      | No       | omitted | Strict command-controlled playback object. |
 
 ## Behavior Notes
 
 - Delayed sounds are scheduled and can be canceled by updates/deletes with the same `id`.
 - Updating a pending delayed sound with `startDelayMs` reschedules from scratch.
 - If a pending delayed sound is updated to immediate playback, the pending timer is canceled and sound is added immediately.
+- A sound without `playback` keeps the ordinary declarative behavior shown
+  below.
+- A sound with `playback` accepts ordered transport commands and emits
+  `soundReady`, `soundProgress`, `soundComplete`, and `soundError`.
+- A command-controlled sound cannot be retained across a render that removes
+  `playback`, and it cannot be a child of a looping audio channel.
 
 ## Example: Minimal SFX
 
@@ -60,3 +73,37 @@ audio:
     startDelayMs: 1200
     volume: 90
 ```
+
+## Example: Command-Controlled Playback
+
+```json
+{
+  "audio": [
+    {
+      "id": "music-room:player",
+      "type": "sound",
+      "src": "main-theme",
+      "playback": {
+        "commandId": 42,
+        "operation": "play",
+        "positionMs": 0
+      }
+    }
+  ]
+}
+```
+
+The `playback` object has exactly these fields:
+
+```json
+{
+  "commandId": "non-negative safe integer",
+  "operation": ["play", "pause", "resume", "stop", "seek"],
+  "positionMs": "required for play and seek; forbidden otherwise"
+}
+```
+
+Keep `commandId` unchanged for ordinary UI, volume, mute, and progress renders.
+Increment it only when issuing another transport command. See
+[`docs/audio-playback-commands.md`](https://github.com/RouteVN/route-graphics/blob/main/docs/audio-playback-commands.md)
+for the complete operation, event, cursor, and error rules.

--- a/spec/audio/audioAsset.spec.js
+++ b/spec/audio/audioAsset.spec.js
@@ -134,11 +134,13 @@ describe("AudioAsset", () => {
     const secondLoad = AudioAsset.load("click", arrayBuffer);
 
     expect(firstLoad).toBe(secondLoad);
+    expect(AudioAsset.getAssetPromise("click")).toBe(firstLoad);
     expect(context.decodeAudioData).toHaveBeenCalledTimes(1);
 
     resolveDecode();
     await expect(firstLoad).resolves.toBe(decodedBuffer);
     expect(AudioAsset.getAsset("click")).toBe(decodedBuffer);
+    expect(AudioAsset.getAssetPromise("click")).toBeUndefined();
   });
 
   it("prepares the Vorbis fallback once and stores decoded PCM as an AudioBuffer", async () => {

--- a/spec/audio/controlledPlayback.spec.js
+++ b/spec/audio/controlledPlayback.spec.js
@@ -438,6 +438,62 @@ describe("command-controlled sound playback", () => {
     ).toBe(2);
   });
 
+  it("starts a seek issued reentrantly from soundReady", async () => {
+    const { context, eventHandler, render } = await setupControlledStage();
+    eventHandler.mockImplementation((eventName) => {
+      if (eventName === "soundReady") {
+        render([
+          playbackSound({
+            commandId: 2,
+            operation: "seek",
+            positionMs: 4000,
+          }),
+        ]);
+      }
+    });
+
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 1000,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(1);
+    expect(context.sources[0].start).toHaveBeenCalledWith(10, 4, 6);
+    expect(eventsByName(eventHandler, "soundProgress").at(-1)).toEqual({
+      _event: {
+        id: "player",
+        commandId: 2,
+        positionMs: 4000,
+        durationMs: 10000,
+      },
+    });
+  });
+
+  it("starts pending play after a reentrant no-op resume from soundReady", async () => {
+    const { context, eventHandler, render } = await setupControlledStage();
+    eventHandler.mockImplementation((eventName) => {
+      if (eventName === "soundReady") {
+        render([playbackSound({ commandId: 2, operation: "resume" })]);
+      }
+    });
+
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 2000,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(1);
+    expect(context.sources[0].start).toHaveBeenCalledWith(10, 2, 8);
+  });
+
   it("reports only an error for an out-of-range seek queued during decode", async () => {
     let resolveDecode;
     const decodePromise = new Promise((resolve) => {
@@ -471,6 +527,52 @@ describe("command-controlled sound playback", () => {
       "soundReady",
       "soundError",
     ]);
+    expect(eventsByName(eventHandler, "soundError").at(-1)).toEqual({
+      _event: {
+        id: "player",
+        commandId: 2,
+        errorCode: "invalid-position",
+      },
+    });
+  });
+
+  it("preserves a valid pending play when a later play is out of range", async () => {
+    let resolveDecode;
+    const decodePromise = new Promise((resolve) => {
+      resolveDecode = resolve;
+    });
+    const { context, eventHandler, render } = await setupControlledStage({
+      assets: new Map(),
+      pendingAssets: new Map([["track", decodePromise]]),
+    });
+
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 1000,
+      }),
+    ]);
+    render([
+      playbackSound({
+        commandId: 2,
+        operation: "play",
+        positionMs: 11000,
+      }),
+    ]);
+    resolveDecode({ duration: 10 });
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(1);
+    expect(context.sources[0].start).toHaveBeenCalledWith(10, 1, 9);
+    expect(eventsByName(eventHandler, "soundReady").at(-1)).toEqual({
+      _event: {
+        id: "player",
+        commandId: 2,
+        positionMs: 1000,
+        durationMs: 10000,
+      },
+    });
     expect(eventsByName(eventHandler, "soundError").at(-1)).toEqual({
       _event: {
         id: "player",

--- a/spec/audio/controlledPlayback.spec.js
+++ b/spec/audio/controlledPlayback.spec.js
@@ -1,0 +1,985 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const createAudioParam = (initialValue = 0) => {
+  const param = {
+    value: initialValue,
+    cancelScheduledValues: vi.fn(),
+    cancelAndHoldAtTime: vi.fn(),
+    setValueAtTime: vi.fn((value) => {
+      param.value = value;
+    }),
+    linearRampToValueAtTime: vi.fn((value) => {
+      param.value = value;
+    }),
+  };
+  return param;
+};
+
+const createAudioContextMock = ({ startImpl } = {}) => {
+  const context = {
+    currentTime: 10,
+    state: "running",
+    destination: { label: "destination" },
+    sources: [],
+    resume: vi.fn(() => Promise.resolve()),
+    createGain: vi.fn(() => ({
+      gain: createAudioParam(1),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    })),
+    createStereoPanner: vi.fn(() => ({
+      pan: createAudioParam(0),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    })),
+    createBufferSource: vi.fn(() => {
+      const source = {
+        buffer: null,
+        loop: false,
+        loopStart: 0,
+        loopEnd: 0,
+        playbackRate: createAudioParam(1),
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        start: vi.fn(startImpl),
+        stop: vi.fn(),
+        onended: null,
+      };
+      context.sources.push(source);
+      return source;
+    }),
+  };
+  return context;
+};
+
+const flushMicrotasks = async () => {
+  for (let index = 0; index < 6; index++) {
+    await Promise.resolve();
+  }
+};
+
+const playbackSound = ({ commandId, operation, positionMs, ...overrides }) => ({
+  id: "player",
+  type: "sound",
+  src: "track",
+  ...overrides,
+  playback: {
+    commandId,
+    operation,
+    ...(positionMs !== undefined ? { positionMs } : {}),
+  },
+});
+
+const setupControlledStage = async ({
+  assets = new Map([["track", { duration: 10 }]]),
+  pendingAssets = new Map(),
+  contextOptions,
+} = {}) => {
+  vi.resetModules();
+  const context = createAudioContextMock(contextOptions);
+  window.AudioContext = vi.fn(function AudioContextMock() {
+    return context;
+  });
+  window.webkitAudioContext = undefined;
+
+  vi.doMock("../../src/AudioAsset.js", () => ({
+    AudioAsset: {
+      getAsset: vi.fn((src) => assets.get(src)),
+      getAssetPromise: vi.fn((src) => pendingAssets.get(src)),
+    },
+  }));
+
+  const { createAudioStage } = await import("../../src/AudioStage.js");
+  const stage = createAudioStage();
+  const eventHandler = vi.fn();
+  let currentAudio = [];
+  const render = (nextAudio) => {
+    stage.renderGraph({
+      prevAudio: currentAudio,
+      nextAudio,
+      eventHandler,
+    });
+    currentAudio = nextAudio;
+  };
+
+  return { context, eventHandler, render, stage };
+};
+
+const eventsByName = (eventHandler, eventName) =>
+  eventHandler.mock.calls
+    .filter(([name]) => name === eventName)
+    .map(([, payload]) => payload);
+
+describe("command-controlled sound playback", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.doUnmock("../../src/AudioAsset.js");
+    vi.resetModules();
+  });
+
+  it("plays a decoded segment and emits soundReady under _event", async () => {
+    const { context, eventHandler, render } = await setupControlledStage({
+      assets: new Map([["track", { duration: 200 }]]),
+    });
+
+    render([
+      playbackSound({
+        commandId: 42,
+        operation: "play",
+        positionMs: 83000,
+        startAt: 10,
+        endAt: 190,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    expect(eventsByName(eventHandler, "soundReady")).toEqual([
+      {
+        _event: {
+          id: "player",
+          commandId: 42,
+          positionMs: 83000,
+          durationMs: 180000,
+        },
+      },
+    ]);
+    expect(context.sources).toHaveLength(1);
+    expect(context.sources[0].start).toHaveBeenCalledWith(10, 93, 97);
+  });
+
+  it("does not restart for mixer-only renders or repeated commands", async () => {
+    const { context, render } = await setupControlledStage();
+    const initial = playbackSound({
+      commandId: 1,
+      operation: "play",
+      positionMs: 0,
+    });
+
+    render([initial]);
+    await flushMicrotasks();
+    render([{ ...initial, volume: 40, muted: true }]);
+    render([
+      playbackSound({
+        commandId: 0,
+        operation: "play",
+        positionMs: 0,
+        volume: 60,
+      }),
+    ]);
+
+    expect(context.sources).toHaveLength(1);
+  });
+
+  it("pauses at the renderer cursor and resumes without a supplied position", async () => {
+    const { context, eventHandler, render } = await setupControlledStage();
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    context.currentTime = 12;
+    render([playbackSound({ commandId: 2, operation: "pause" })]);
+    await flushMicrotasks();
+
+    expect(context.sources[0].stop).toHaveBeenCalledWith(12);
+    expect(eventsByName(eventHandler, "soundProgress").at(-1)).toEqual({
+      _event: {
+        id: "player",
+        commandId: 2,
+        positionMs: 2000,
+        durationMs: 10000,
+      },
+    });
+
+    render([playbackSound({ commandId: 3, operation: "resume" })]);
+    expect(context.sources).toHaveLength(2);
+    const [startTime, offset, duration] =
+      context.sources[1].start.mock.calls[0];
+    expect(startTime).toBe(12);
+    expect(offset).toBeCloseTo(2);
+    expect(duration).toBeCloseTo(8);
+  });
+
+  it("rebinds natural completion after an accepted no-op", async () => {
+    const { context, eventHandler, render } = await setupControlledStage();
+    render([
+      playbackSound({
+        commandId: 10,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    await flushMicrotasks();
+    const source = context.sources[0];
+
+    render([playbackSound({ commandId: 11, operation: "resume" })]);
+    expect(context.sources).toHaveLength(1);
+    source.onended();
+    await flushMicrotasks();
+
+    expect(eventsByName(eventHandler, "soundComplete")).toEqual([
+      {
+        _event: {
+          id: "player",
+          commandId: 11,
+          positionMs: 10000,
+          durationMs: 10000,
+        },
+      },
+    ]);
+  });
+
+  it("seeks active playback and suppresses the replaced source callback", async () => {
+    const { context, eventHandler, render } = await setupControlledStage();
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    await flushMicrotasks();
+    const replacedSource = context.sources[0];
+
+    render([
+      playbackSound({
+        commandId: 2,
+        operation: "seek",
+        positionMs: 4000,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(2);
+    expect(context.sources[1].start).toHaveBeenCalledWith(10, 4, 6);
+    expect(replacedSource.onended).toBeNull();
+    expect(eventsByName(eventHandler, "soundProgress").at(-1)).toEqual({
+      _event: {
+        id: "player",
+        commandId: 2,
+        positionMs: 4000,
+        durationMs: 10000,
+      },
+    });
+  });
+
+  it("keeps resume and seek as no-ops after stop", async () => {
+    const { context, render } = await setupControlledStage();
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    render([playbackSound({ commandId: 2, operation: "stop" })]);
+    render([playbackSound({ commandId: 3, operation: "resume" })]);
+    render([
+      playbackSound({
+        commandId: 4,
+        operation: "seek",
+        positionMs: 5000,
+      }),
+    ]);
+    expect(context.sources).toHaveLength(1);
+
+    render([
+      playbackSound({
+        commandId: 5,
+        operation: "play",
+        positionMs: 3000,
+      }),
+    ]);
+    expect(context.sources).toHaveLength(2);
+    expect(context.sources[1].start).toHaveBeenCalledWith(10, 3, 7);
+  });
+
+  it("does not let pause arm resume after stop", async () => {
+    const { context, render } = await setupControlledStage();
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    render([playbackSound({ commandId: 2, operation: "stop" })]);
+    render([playbackSound({ commandId: 3, operation: "pause" })]);
+    render([playbackSound({ commandId: 4, operation: "resume" })]);
+
+    expect(context.sources).toHaveLength(1);
+  });
+
+  it("reports invalid positions without replacing retained playback", async () => {
+    const { context, eventHandler, render } = await setupControlledStage();
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    await flushMicrotasks();
+    const source = context.sources[0];
+
+    render([
+      playbackSound({
+        commandId: 2,
+        operation: "play",
+        positionMs: 10001,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(1);
+    expect(source.stop).not.toHaveBeenCalled();
+    expect(eventsByName(eventHandler, "soundError").at(-1)).toEqual({
+      _event: {
+        id: "player",
+        commandId: 2,
+        errorCode: "invalid-position",
+      },
+    });
+
+    source.onended();
+    await flushMicrotasks();
+    expect(
+      eventsByName(eventHandler, "soundComplete").at(-1)._event.commandId,
+    ).toBe(2);
+  });
+
+  it("rebinds a pending decode to the latest pause and resumes it", async () => {
+    let resolveDecode;
+    const decodePromise = new Promise((resolve) => {
+      resolveDecode = resolve;
+    });
+    const { context, eventHandler, render } = await setupControlledStage({
+      assets: new Map(),
+      pendingAssets: new Map([["track", decodePromise]]),
+    });
+
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 2000,
+      }),
+    ]);
+    render([playbackSound({ commandId: 2, operation: "pause" })]);
+    resolveDecode({ duration: 10 });
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(0);
+    expect(
+      eventsByName(eventHandler, "soundReady").at(-1)._event.commandId,
+    ).toBe(2);
+    expect(eventsByName(eventHandler, "soundProgress").at(-1)).toEqual({
+      _event: {
+        id: "player",
+        commandId: 2,
+        positionMs: 2000,
+        durationMs: 10000,
+      },
+    });
+
+    render([playbackSound({ commandId: 3, operation: "resume" })]);
+    expect(context.sources).toHaveLength(1);
+    expect(context.sources[0].start).toHaveBeenCalledWith(10, 2, 8);
+  });
+
+  it("queues a seek during decode and applies it after soundReady", async () => {
+    let resolveDecode;
+    const decodePromise = new Promise((resolve) => {
+      resolveDecode = resolve;
+    });
+    const { context, eventHandler, render } = await setupControlledStage({
+      assets: new Map(),
+      pendingAssets: new Map([["track", decodePromise]]),
+    });
+
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 1000,
+      }),
+    ]);
+    render([
+      playbackSound({
+        commandId: 2,
+        operation: "seek",
+        positionMs: 4000,
+      }),
+    ]);
+    resolveDecode({ duration: 10 });
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(1);
+    expect(context.sources[0].start).toHaveBeenCalledWith(10, 4, 6);
+    expect(eventHandler.mock.calls.map(([name]) => name).slice(-2)).toEqual([
+      "soundReady",
+      "soundProgress",
+    ]);
+    expect(
+      eventsByName(eventHandler, "soundProgress").at(-1)._event.commandId,
+    ).toBe(2);
+  });
+
+  it("reports only an error for an out-of-range seek queued during decode", async () => {
+    let resolveDecode;
+    const decodePromise = new Promise((resolve) => {
+      resolveDecode = resolve;
+    });
+    const { context, eventHandler, render } = await setupControlledStage({
+      assets: new Map(),
+      pendingAssets: new Map([["track", decodePromise]]),
+    });
+
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 1000,
+      }),
+    ]);
+    render([
+      playbackSound({
+        commandId: 2,
+        operation: "seek",
+        positionMs: 11000,
+      }),
+    ]);
+    resolveDecode({ duration: 10 });
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(1);
+    expect(context.sources[0].start).toHaveBeenCalledWith(10, 1, 9);
+    expect(eventHandler.mock.calls.map(([name]) => name)).toEqual([
+      "soundReady",
+      "soundError",
+    ]);
+    expect(eventsByName(eventHandler, "soundError").at(-1)).toEqual({
+      _event: {
+        id: "player",
+        commandId: 2,
+        errorCode: "invalid-position",
+      },
+    });
+  });
+
+  it("keeps resume stopped after stop supersedes pending decode", async () => {
+    let resolveDecode;
+    const decodePromise = new Promise((resolve) => {
+      resolveDecode = resolve;
+    });
+    const { context, eventHandler, render } = await setupControlledStage({
+      assets: new Map(),
+      pendingAssets: new Map([["track", decodePromise]]),
+    });
+
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 1000,
+      }),
+    ]);
+    render([playbackSound({ commandId: 2, operation: "stop" })]);
+    render([playbackSound({ commandId: 3, operation: "resume" })]);
+    resolveDecode({ duration: 10 });
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(0);
+    expect(eventsByName(eventHandler, "soundProgress").at(-1)).toEqual({
+      _event: {
+        id: "player",
+        commandId: 3,
+        positionMs: 0,
+        durationMs: 10000,
+      },
+    });
+  });
+
+  it("preserves remaining start delay across pause and resume", async () => {
+    const { context, render } = await setupControlledStage();
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+        startDelayMs: 100,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    vi.advanceTimersByTime(40);
+    render([
+      playbackSound({
+        commandId: 2,
+        operation: "pause",
+        startDelayMs: 100,
+      }),
+    ]);
+    vi.advanceTimersByTime(100);
+    expect(context.sources).toHaveLength(0);
+
+    render([
+      playbackSound({
+        commandId: 3,
+        operation: "resume",
+        startDelayMs: 100,
+      }),
+    ]);
+    vi.advanceTimersByTime(59);
+    expect(context.sources).toHaveLength(0);
+    vi.advanceTimersByTime(1);
+    expect(context.sources).toHaveLength(1);
+  });
+
+  it("commits source replacement and leaves an invalid new source stopped", async () => {
+    const { context, eventHandler, render, stage } = await setupControlledStage(
+      {
+        assets: new Map([
+          ["track", { duration: 10 }],
+          ["next", { duration: 5 }],
+        ]),
+      },
+    );
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    render([
+      playbackSound({
+        commandId: 2,
+        operation: "play",
+        positionMs: 6000,
+        src: "next",
+      }),
+    ]);
+    await flushMicrotasks();
+
+    const currentKey = stage._inspect().currentSoundKeyById.get("player");
+    const current = stage._inspect().sounds.get(currentKey);
+    expect(current.src).toBe("next");
+    expect(current.control.status).toBe("stopped");
+    expect(context.sources).toHaveLength(1);
+    expect(eventsByName(eventHandler, "soundError").at(-1)).toEqual({
+      _event: {
+        id: "player",
+        commandId: 2,
+        errorCode: "invalid-position",
+      },
+    });
+  });
+
+  it("rejects retained playback-mode and invalid source transitions", async () => {
+    const { render } = await setupControlledStage();
+    const controlled = playbackSound({
+      commandId: 4,
+      operation: "play",
+      positionMs: 0,
+    });
+    render([controlled]);
+    await flushMicrotasks();
+
+    expect(() =>
+      render([{ id: "player", type: "sound", src: "track" }]),
+    ).toThrow("cannot change command-controlled playback mode");
+    expect(() =>
+      render([
+        playbackSound({
+          commandId: 4,
+          operation: "play",
+          positionMs: 0,
+          src: "next",
+        }),
+      ]),
+    ).toThrow("must change source identity with a higher play command");
+  });
+
+  it("emits progress on the 250ms cadence with playback rate applied", async () => {
+    const { context, eventHandler, render } = await setupControlledStage();
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+        playbackRate: 2,
+      }),
+    ]);
+    await flushMicrotasks();
+    eventHandler.mockClear();
+
+    context.currentTime = 10.25;
+    vi.advanceTimersByTime(250);
+    await flushMicrotasks();
+
+    expect(eventsByName(eventHandler, "soundProgress")).toEqual([
+      {
+        _event: {
+          id: "player",
+          commandId: 1,
+          positionMs: 500,
+          durationMs: 10000,
+        },
+      },
+    ]);
+  });
+
+  it("rebinds deferred progress to the latest accepted command", async () => {
+    const { eventHandler, render } = await setupControlledStage();
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    await flushMicrotasks();
+    eventHandler.mockClear();
+
+    render([playbackSound({ commandId: 2, operation: "pause" })]);
+    render([playbackSound({ commandId: 3, operation: "resume" })]);
+    await flushMicrotasks();
+
+    expect(eventsByName(eventHandler, "soundProgress")).toEqual([
+      {
+        _event: {
+          id: "player",
+          commandId: 3,
+          positionMs: 0,
+          durationMs: 10000,
+        },
+      },
+    ]);
+  });
+
+  it("uses the decoded segment as the loop and preserves cursor on loop changes", async () => {
+    const { context, render } = await setupControlledStage({
+      assets: new Map([["track", { duration: 20 }]]),
+    });
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 2000,
+        startAt: 5,
+        endAt: 15,
+        loop: true,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    expect(context.sources[0].loopStart).toBe(5);
+    expect(context.sources[0].loopEnd).toBe(15);
+    expect(context.sources[0].start).toHaveBeenCalledWith(10, 7);
+
+    context.currentTime = 12;
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 2000,
+        startAt: 5,
+        endAt: 15,
+        loop: false,
+      }),
+    ]);
+
+    expect(context.sources).toHaveLength(2);
+    expect(context.sources[0].stop).toHaveBeenCalledWith(12);
+    expect(context.sources[1].loop).toBe(false);
+    const [startTime, offset, duration] =
+      context.sources[1].start.mock.calls[0];
+    expect(startTime).toBe(12);
+    expect(offset).toBeCloseTo(9);
+    expect(duration).toBeCloseTo(6);
+  });
+
+  it("reports asset, segment, and playback failures with stable codes", async () => {
+    const unavailable = await setupControlledStage({
+      assets: new Map(),
+    });
+    unavailable.render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    await flushMicrotasks();
+    expect(eventsByName(unavailable.eventHandler, "soundError").at(-1)).toEqual(
+      {
+        _event: {
+          id: "player",
+          commandId: 1,
+          errorCode: "asset-unavailable",
+        },
+      },
+    );
+    unavailable.stage.destroy();
+
+    const invalidSegment = await setupControlledStage({
+      assets: new Map([["track", { duration: 10 }]]),
+    });
+    invalidSegment.render([
+      playbackSound({
+        commandId: 2,
+        operation: "play",
+        positionMs: 0,
+        startAt: 10,
+      }),
+    ]);
+    await flushMicrotasks();
+    expect(
+      eventsByName(invalidSegment.eventHandler, "soundError").at(-1),
+    ).toEqual({
+      _event: {
+        id: "player",
+        commandId: 2,
+        errorCode: "invalid-segment",
+      },
+    });
+    invalidSegment.stage.destroy();
+
+    const playbackFailure = await setupControlledStage({
+      contextOptions: {
+        startImpl: () => {
+          throw new Error("browser start failure");
+        },
+      },
+    });
+    playbackFailure.render([
+      playbackSound({
+        commandId: 3,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    await flushMicrotasks();
+    expect(
+      eventsByName(playbackFailure.eventHandler, "soundError").at(-1),
+    ).toEqual({
+      _event: {
+        id: "player",
+        commandId: 3,
+        errorCode: "playback-failed",
+      },
+    });
+    expect(playbackFailure.context.sources[0].disconnect).toHaveBeenCalled();
+  });
+
+  it("retries an unavailable asset on a later play command", async () => {
+    const assets = new Map();
+    const { context, eventHandler, render } = await setupControlledStage({
+      assets,
+    });
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    await flushMicrotasks();
+    expect(eventsByName(eventHandler, "soundError")).toHaveLength(1);
+
+    assets.set("track", { duration: 10 });
+    render([
+      playbackSound({
+        commandId: 2,
+        operation: "play",
+        positionMs: 1000,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(1);
+    expect(context.sources[0].start).toHaveBeenCalledWith(10, 1, 9);
+    expect(
+      eventsByName(eventHandler, "soundReady").at(-1)._event.commandId,
+    ).toBe(2);
+  });
+
+  it("enters ended at the terminal cursor without natural completion", async () => {
+    const { context, eventHandler, render } = await setupControlledStage();
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 10000,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(0);
+    expect(eventsByName(eventHandler, "soundProgress").at(-1)).toEqual({
+      _event: {
+        id: "player",
+        commandId: 1,
+        positionMs: 10000,
+        durationMs: 10000,
+      },
+    });
+    expect(eventsByName(eventHandler, "soundComplete")).toEqual([]);
+  });
+
+  it("controls multiple sounds independently", async () => {
+    const { context, eventHandler, render } = await setupControlledStage({
+      assets: new Map([
+        ["story", { duration: 30 }],
+        ["music", { duration: 20 }],
+      ]),
+    });
+    render([
+      playbackSound({
+        id: "story:bgm",
+        src: "story",
+        commandId: 1,
+        operation: "pause",
+      }),
+      playbackSound({
+        id: "music-room:player",
+        src: "music",
+        commandId: 2,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(1);
+    expect(eventsByName(eventHandler, "soundReady")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          _event: expect.objectContaining({
+            id: "story:bgm",
+            commandId: 1,
+          }),
+        }),
+        expect.objectContaining({
+          _event: expect.objectContaining({
+            id: "music-room:player",
+            commandId: 2,
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("suppresses decode callbacks after immediate removal", async () => {
+    let resolveDecode;
+    const decodePromise = new Promise((resolve) => {
+      resolveDecode = resolve;
+    });
+    const { context, eventHandler, render } = await setupControlledStage({
+      assets: new Map(),
+      pendingAssets: new Map([["track", decodePromise]]),
+    });
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    render([]);
+    resolveDecode({ duration: 10 });
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(0);
+    expect(eventHandler).not.toHaveBeenCalled();
+  });
+
+  it("does not start when a soundReady handler removes the sound", async () => {
+    const { context, eventHandler, render } = await setupControlledStage();
+    eventHandler.mockImplementation((eventName) => {
+      if (eventName === "soundReady") {
+        render([]);
+      }
+    });
+
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(0);
+  });
+
+  it("suppresses progress and completion after destruction", async () => {
+    const { context, eventHandler, render, stage } =
+      await setupControlledStage();
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+      }),
+    ]);
+    await flushMicrotasks();
+    const source = context.sources[0];
+    eventHandler.mockClear();
+
+    stage.destroy();
+    context.currentTime = 11;
+    vi.advanceTimersByTime(500);
+    source.onended?.();
+    await flushMicrotasks();
+
+    expect(eventHandler).not.toHaveBeenCalled();
+  });
+
+  it("finishes loopEnd playback as an event-suppressed outgoing tail", async () => {
+    const { context, eventHandler, render } = await setupControlledStage();
+    const channel = {
+      id: "music",
+      type: "audio-channel",
+      loop: false,
+      interruption: "loopEnd",
+      children: [
+        playbackSound({
+          commandId: 1,
+          operation: "play",
+          positionMs: 0,
+          loop: true,
+        }),
+      ],
+    };
+    render([channel]);
+    await flushMicrotasks();
+    eventHandler.mockClear();
+    const source = context.sources[0];
+
+    render([{ ...channel, children: [] }]);
+    expect(source.loop).toBe(false);
+    expect(source.stop).toHaveBeenCalledWith(20);
+    source.onended();
+    await flushMicrotasks();
+
+    expect(eventsByName(eventHandler, "soundComplete")).toEqual([]);
+  });
+});

--- a/spec/audio/renderAudio.spec.js
+++ b/spec/audio/renderAudio.spec.js
@@ -8,6 +8,7 @@ describe("renderAudio", () => {
         renderGraph: vi.fn(),
       },
     };
+    const eventHandler = vi.fn();
     const nextAudioTree = [
       {
         id: "music",
@@ -38,6 +39,7 @@ describe("renderAudio", () => {
       prevAudioEffects: [],
       nextAudioEffects,
       audioPlugins: [],
+      eventHandler,
     });
 
     expect(app.audioStage.renderGraph).toHaveBeenCalledWith({
@@ -45,6 +47,7 @@ describe("renderAudio", () => {
       nextAudio: nextAudioTree,
       prevAudioEffects: [],
       nextAudioEffects,
+      eventHandler,
     });
   });
 

--- a/spec/util/normalizeAudio.spec.js
+++ b/spec/util/normalizeAudio.spec.js
@@ -161,6 +161,108 @@ describe("normalizeAudioRenderState", () => {
     ).toThrow("audio[0].interruption must be one of immediate, loopEnd");
   });
 
+  it("normalizes strict playback commands", () => {
+    const result = flattenAudioNodes([
+      {
+        id: "music",
+        type: "sound",
+        src: "theme",
+        playback: {
+          commandId: 42,
+          operation: "play",
+          positionMs: 1200,
+        },
+      },
+      {
+        id: "ambience",
+        type: "sound",
+        src: "rain",
+        playback: {
+          commandId: 43,
+          operation: "pause",
+        },
+      },
+    ]);
+
+    expect(result.sounds[0].playback).toEqual({
+      commandId: 42,
+      operation: "play",
+      positionMs: 1200,
+    });
+    expect(result.sounds[1].playback).toEqual({
+      commandId: 43,
+      operation: "pause",
+    });
+  });
+
+  it.each([
+    [
+      { commandId: -1, operation: "play", positionMs: 0 },
+      "commandId must be a non-negative safe integer",
+    ],
+    [
+      { commandId: Number.MAX_SAFE_INTEGER + 1, operation: "pause" },
+      "commandId must be a non-negative safe integer",
+    ],
+    [
+      { commandId: 1, operation: "rewind" },
+      "operation must be one of play, pause, resume, stop, seek",
+    ],
+    [
+      { commandId: 1, operation: "play" },
+      "positionMs must be a finite non-negative number for play",
+    ],
+    [
+      { commandId: 1, operation: "seek", positionMs: Number.POSITIVE_INFINITY },
+      "positionMs must be a finite non-negative number for seek",
+    ],
+    [
+      { commandId: 1, operation: "pause", positionMs: 0 },
+      "positionMs is not allowed for pause",
+    ],
+    [
+      { commandId: 1, operation: "stop", status: "stopped" },
+      'unsupported playback field "status"',
+    ],
+  ])("rejects invalid playback command %#", (playback, message) => {
+    expect(() =>
+      flattenAudioNodes([
+        {
+          id: "music",
+          type: "sound",
+          src: "theme",
+          playback,
+        },
+      ]),
+    ).toThrow(message);
+  });
+
+  it("rejects command-controlled children in looping channels", () => {
+    expect(() =>
+      flattenAudioNodes([
+        {
+          id: "music",
+          type: "audio-channel",
+          loop: true,
+          children: [
+            {
+              id: "track",
+              type: "sound",
+              src: "theme",
+              playback: {
+                commandId: 1,
+                operation: "play",
+                positionMs: 0,
+              },
+            },
+          ],
+        },
+      ]),
+    ).toThrow(
+      "audio[0].children[0].playback is not allowed when audio[0].loop is true",
+    );
+  });
+
   it("rejects duplicate IDs across nodes and effects", () => {
     expect(() =>
       normalizeAudioRenderState({

--- a/src/AudioAsset.js
+++ b/src/AudioAsset.js
@@ -94,6 +94,8 @@ const getAsset = (url) => {
   return arrayBuffer;
 };
 
+const getAssetPromise = (url) => loadingAssets[url];
+
 const unload = (key) => {
   const hadAsset = !!loadedAssets[key] || !!loadingAssets[key];
   delete loadedAssets[key];
@@ -105,5 +107,6 @@ export const AudioAsset = {
   prepareDecoders,
   load,
   getAsset,
+  getAssetPromise,
   unload,
 };

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -1091,7 +1091,16 @@ export const createAudioStage = () => {
       }
 
       if (candidate.positionMs > control.durationMs) {
-        if (candidate.operation === "seek" && candidate.fallback) {
+        if (candidate.fallback) {
+          if (candidate.fallbackState) {
+            control.status = candidate.fallbackState.status;
+            control.cursorMs = candidate.fallbackState.cursorMs;
+            control.pausedCursorRetained =
+              candidate.fallbackState.pausedCursorRetained;
+            control.remainingDelayMs = candidate.fallbackState.remainingDelayMs;
+            control.deferredProgress = candidate.fallbackState.deferredProgress;
+            instance.playbackPending = candidate.fallbackState.playbackPending;
+          }
           const fallbackResult = resolve(candidate.fallback, false);
           return {
             ...fallbackResult,
@@ -1226,6 +1235,7 @@ export const createAudioStage = () => {
     stopControlledSource(instance);
     control.status = "stopped";
     control.cursorMs = 0;
+    control.pendingPosition = null;
     control.pausedCursorRetained = false;
     control.remainingDelayMs = 0;
     queueControlledError(instance, errorCode);
@@ -1353,6 +1363,7 @@ export const createAudioStage = () => {
 
       const commandId = control.commandId;
       const resolution = resolvePendingControlledPosition(instance);
+      const playRequestId = instance.playRequestId;
       control.readyAnnounced = true;
       try {
         emitControlledEventNow(
@@ -1365,11 +1376,17 @@ export const createAudioStage = () => {
           commandId,
         );
       } finally {
-        if (
-          control.commandId === commandId &&
-          isCurrentControlledInstance(instance)
-        ) {
-          applyResolvedControlledState(instance, resolution);
+        if (isCurrentControlledInstance(instance)) {
+          if (control.commandId === commandId) {
+            applyResolvedControlledState(instance, resolution);
+          } else if (
+            control.status === "playing" &&
+            !instance.source &&
+            instance.pendingTimeoutId === null &&
+            instance.playRequestId === playRequestId
+          ) {
+            startControlledPlayback(instance, control.remainingDelayMs);
+          }
         }
       }
     });
@@ -1453,6 +1470,17 @@ export const createAudioStage = () => {
     const control = instance.control;
     switch (command.operation) {
       case "play": {
+        const fallback = control.pendingPosition;
+        const fallbackState = fallback
+          ? {
+              status: control.status,
+              cursorMs: control.cursorMs,
+              pausedCursorRetained: control.pausedCursorRetained,
+              remainingDelayMs: control.remainingDelayMs,
+              deferredProgress: control.deferredProgress,
+              playbackPending: instance.playbackPending,
+            }
+          : null;
         cancelControlledPendingStart(instance);
         stopControlledSource(instance);
         control.status = "playing";
@@ -1462,7 +1490,8 @@ export const createAudioStage = () => {
         control.pendingPosition = {
           operation: "play",
           positionMs: command.positionMs,
-          fallback: null,
+          fallback,
+          fallbackState,
         };
         control.deferredProgress = false;
         instance.playbackPending = true;

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -8,6 +8,7 @@ const ROOT_CHANNEL_ID = "__route_graphics_audio_root__";
 const DIRECT_CHANNEL_ID = "__route_graphics_audio_direct__";
 const AUDIO_AUTOMATION_SAMPLE_INTERVAL_MS = 16;
 const AUDIO_AUTOMATION_MAX_SAMPLES = 1024;
+const CONTROLLED_PROGRESS_INTERVAL_MS = 250;
 const audioParamAutomation = new WeakMap();
 
 const isAudioDebugEnabled = () =>
@@ -79,6 +80,37 @@ const getCurrentParamValue = (param, context = getAudioContext()) => {
   return automation.normalizeValue(
     getTimelineValueAtTime(automation.timeline, elapsedMs),
   );
+};
+
+const integrateAudioParamValue = (param, startTime, endTime) => {
+  const durationSeconds = Math.max(0, endTime - startTime);
+  if (durationSeconds === 0) {
+    return 0;
+  }
+
+  const automation = audioParamAutomation.get(param);
+  if (!automation) {
+    return durationSeconds * Math.max(0, getParamValue(param, 1));
+  }
+
+  const durationMs = durationSeconds * 1000;
+  const sampleCount = Math.min(
+    AUDIO_AUTOMATION_MAX_SAMPLES,
+    Math.max(1, Math.ceil(durationMs / AUDIO_AUTOMATION_SAMPLE_INTERVAL_MS)),
+  );
+  const sampleDurationSeconds = durationSeconds / sampleCount;
+  let integratedSeconds = 0;
+
+  for (let sample = 0; sample < sampleCount; sample++) {
+    const sampleTime = startTime + (sample + 0.5) * sampleDurationSeconds;
+    const elapsedMs = Math.max(0, (sampleTime - automation.startTime) * 1000);
+    const value = automation.normalizeValue(
+      getTimelineValueAtTime(automation.timeline, elapsedMs),
+    );
+    integratedSeconds += Math.max(0, value) * sampleDurationSeconds;
+  }
+
+  return integratedSeconds;
 };
 
 const setParamAtTime = (param, value, time) => {
@@ -487,6 +519,33 @@ const createSoundInstance = ({ sound, channelNode, internalId }) => {
     pendingTimeoutId: null,
     cleanupTimeoutId: null,
     playRequestId: 0,
+    playback: sound.playback ?? null,
+    control: sound.playback
+      ? {
+          commandId: -1,
+          status: "stopped",
+          cursorMs: 0,
+          durationMs: null,
+          decodedBuffer: null,
+          ready: false,
+          readyAnnounced: false,
+          readyTaskQueued: false,
+          decodeRequestId: 0,
+          decodePending: false,
+          pendingPosition: null,
+          deferredProgress: false,
+          pausedCursorRetained: false,
+          remainingDelayMs: 0,
+          delayDeadlineMs: null,
+          progressIntervalId: null,
+          sourceToken: 0,
+          sourceCursorMs: 0,
+          sourceStartedAt: null,
+          eventsSuppressed: false,
+          detached: false,
+          lastErrorCode: null,
+        }
+      : null,
   };
 };
 
@@ -648,6 +707,17 @@ const stopSource = (sound, delayMs = 0) => {
 const cleanupSound = (sound) => {
   sound.onSourceEnded = null;
 
+  if (sound.control) {
+    sound.control.decodeRequestId += 1;
+    sound.control.sourceToken += 1;
+    sound.control.eventsSuppressed = true;
+    sound.control.detached = true;
+    if (sound.control.progressIntervalId !== null) {
+      clearInterval(sound.control.progressIntervalId);
+      sound.control.progressIntervalId = null;
+    }
+  }
+
   if (sound.pendingTimeoutId !== null) {
     clearTimeout(sound.pendingTimeoutId);
     sound.pendingTimeoutId = null;
@@ -769,6 +839,839 @@ export const createAudioStage = () => {
   const currentSoundKeyById = new Map();
   const directAudios = new Map();
   let soundGeneration = 0;
+  let soundEventHandler;
+  let destroyed = false;
+
+  const isCurrentControlledInstance = (instance) =>
+    !destroyed &&
+    instance?.control &&
+    !instance.control.eventsSuppressed &&
+    !instance.control.detached &&
+    sounds.get(instance.internalId) === instance &&
+    currentSoundKeyById.get(instance.id) === instance.internalId;
+
+  const getControlledPositionMs = (instance) => {
+    const control = instance.control;
+    if (
+      !control ||
+      control.status !== "playing" ||
+      !instance.source ||
+      control.sourceStartedAt === null ||
+      control.durationMs === null
+    ) {
+      return Math.max(0, control?.cursorMs ?? 0);
+    }
+
+    const context = getAudioContext();
+    const playedSeconds = integrateAudioParamValue(
+      instance.source.playbackRate,
+      control.sourceStartedAt,
+      context.currentTime,
+    );
+    let positionMs = control.sourceCursorMs + playedSeconds * 1000;
+    if (instance.loop && control.durationMs > 0) {
+      positionMs %= control.durationMs;
+    } else {
+      positionMs = Math.min(positionMs, control.durationMs);
+    }
+
+    return Math.max(0, positionMs);
+  };
+
+  const captureControlledPosition = (instance) => {
+    const control = instance.control;
+    if (!control) return 0;
+
+    control.cursorMs = getControlledPositionMs(instance);
+    control.sourceCursorMs = control.cursorMs;
+    control.sourceStartedAt = getAudioContext().currentTime;
+    return control.cursorMs;
+  };
+
+  const normalizeEventPosition = (value) =>
+    Math.max(0, Math.round(toFiniteParamValue(value, 0)));
+
+  const emitControlledEventNow = (
+    instance,
+    eventName,
+    fields,
+    commandId = instance.control?.commandId,
+  ) => {
+    if (
+      !isCurrentControlledInstance(instance) ||
+      instance.control.commandId !== commandId
+    ) {
+      return false;
+    }
+
+    soundEventHandler?.(eventName, {
+      _event: {
+        id: instance.id,
+        commandId,
+        ...fields,
+      },
+    });
+    return true;
+  };
+
+  const queueControlledEvent = (
+    instance,
+    eventName,
+    fields,
+    commandId = instance.control?.commandId,
+  ) => {
+    queueMicrotask(() => {
+      emitControlledEventNow(instance, eventName, fields, commandId);
+    });
+  };
+
+  const getControlledEventPosition = (instance) =>
+    normalizeEventPosition(getControlledPositionMs(instance));
+
+  const queueControlledProgress = (instance) => {
+    const control = instance.control;
+    if (!control?.ready || control.durationMs === null) return;
+
+    queueMicrotask(() => {
+      if (!isCurrentControlledInstance(instance)) {
+        return;
+      }
+
+      emitControlledEventNow(
+        instance,
+        "soundProgress",
+        {
+          positionMs: getControlledEventPosition(instance),
+          durationMs: normalizeEventPosition(control.durationMs),
+        },
+        control.commandId,
+      );
+    });
+  };
+
+  const queueControlledError = (instance, errorCode) => {
+    const control = instance.control;
+    if (!control) return;
+
+    control.lastErrorCode = errorCode;
+    queueControlledEvent(
+      instance,
+      "soundError",
+      { errorCode },
+      control.commandId,
+    );
+  };
+
+  const stopControlledProgress = (instance) => {
+    const control = instance.control;
+    if (!control || control.progressIntervalId === null) return;
+
+    clearInterval(control.progressIntervalId);
+    control.progressIntervalId = null;
+  };
+
+  const startControlledProgress = (instance) => {
+    const control = instance.control;
+    stopControlledProgress(instance);
+    if (!control || !instance.source || control.status !== "playing") {
+      return;
+    }
+
+    control.progressIntervalId = setInterval(() => {
+      if (
+        !isCurrentControlledInstance(instance) ||
+        control.status !== "playing" ||
+        !instance.source
+      ) {
+        stopControlledProgress(instance);
+        return;
+      }
+      queueControlledProgress(instance);
+    }, CONTROLLED_PROGRESS_INTERVAL_MS);
+  };
+
+  const getRemainingControlledDelayMs = (instance) => {
+    const control = instance.control;
+    if (!control) return 0;
+    if (control.delayDeadlineMs === null) {
+      return Math.max(0, control.remainingDelayMs);
+    }
+
+    return Math.max(0, control.delayDeadlineMs - Date.now());
+  };
+
+  const cancelControlledPendingStart = (
+    instance,
+    { preserveRemainingDelay = false } = {},
+  ) => {
+    const control = instance.control;
+    if (!control) return;
+
+    const remainingDelayMs = preserveRemainingDelay
+      ? getRemainingControlledDelayMs(instance)
+      : 0;
+    instance.playRequestId = (instance.playRequestId ?? 0) + 1;
+    instance.playbackPending = false;
+    if (instance.pendingTimeoutId !== null) {
+      clearTimeout(instance.pendingTimeoutId);
+      instance.pendingTimeoutId = null;
+    }
+    control.delayDeadlineMs = null;
+    control.remainingDelayMs = remainingDelayMs;
+  };
+
+  const stopControlledSource = (instance) => {
+    const control = instance.control;
+    if (!control) return;
+
+    stopControlledProgress(instance);
+    control.sourceToken += 1;
+    control.sourceStartedAt = null;
+    const source = instance.source;
+    instance.source = null;
+    instance.sourceEnded = true;
+    if (!source) return;
+
+    source.onended = null;
+    try {
+      source.stop(getAudioContext().currentTime);
+    } catch {
+      // Stopping an already-stopped source is harmless.
+    }
+    disconnect(source);
+  };
+
+  const validateControlledSegment = (instance, audioBuffer) => {
+    const decodedDuration = toFiniteParamValue(
+      audioBuffer?.duration,
+      Number.NaN,
+    );
+    const segmentStart = toFiniteParamValue(instance.startAt, Number.NaN);
+    const segmentEnd =
+      instance.endAt === null || instance.endAt === undefined
+        ? decodedDuration
+        : toFiniteParamValue(instance.endAt, Number.NaN);
+
+    if (
+      !Number.isFinite(decodedDuration) ||
+      !Number.isFinite(segmentStart) ||
+      !Number.isFinite(segmentEnd) ||
+      segmentStart < 0 ||
+      segmentStart >= decodedDuration ||
+      segmentEnd <= segmentStart ||
+      segmentEnd > decodedDuration
+    ) {
+      return null;
+    }
+
+    return (segmentEnd - segmentStart) * 1000;
+  };
+
+  const configureControlledLoop = (instance, source) => {
+    const control = instance.control;
+    source.loop = instance.loop ?? false;
+    if (!source.loop || control.durationMs === null) {
+      return;
+    }
+
+    source.loopStart = instance.startAt;
+    source.loopEnd = instance.startAt + control.durationMs / 1000;
+  };
+
+  const resolvePendingControlledPosition = (instance) => {
+    const control = instance.control;
+    const pending = control?.pendingPosition;
+    if (!control || !pending || control.durationMs === null) {
+      return { invalidPosition: false, terminal: false };
+    }
+
+    const resolve = (candidate, reportInvalid) => {
+      if (!candidate) {
+        return { invalidPosition: false, terminal: false };
+      }
+
+      if (candidate.positionMs > control.durationMs) {
+        if (candidate.operation === "seek" && candidate.fallback) {
+          const fallbackResult = resolve(candidate.fallback, false);
+          return {
+            ...fallbackResult,
+            invalidPosition: reportInvalid,
+          };
+        }
+        if (candidate.operation === "play") {
+          control.status = "stopped";
+          control.cursorMs = 0;
+          control.remainingDelayMs = 0;
+          control.pausedCursorRetained = false;
+          instance.playbackPending = false;
+        }
+        return {
+          invalidPosition: reportInvalid,
+          terminal: false,
+        };
+      }
+
+      if (candidate.operation === "seekNoop") {
+        return { invalidPosition: false, terminal: false };
+      }
+
+      control.cursorMs = candidate.positionMs;
+      if (candidate.positionMs === control.durationMs) {
+        control.status = "ended";
+        control.remainingDelayMs = 0;
+        control.pausedCursorRetained = false;
+        instance.playbackPending = false;
+        return { invalidPosition: false, terminal: true };
+      }
+
+      return { invalidPosition: false, terminal: false };
+    };
+
+    const result = resolve(pending, true);
+    control.pendingPosition = null;
+    return result;
+  };
+
+  const createControlledSource = (instance) => {
+    const control = instance.control;
+    const context = getAudioContext();
+    const source = context.createBufferSource();
+    source.buffer = control.decodedBuffer;
+    configureControlledLoop(instance, source);
+
+    applyPlaybackRate({
+      source,
+      targetValue: instance.playbackRate ?? 1,
+      transition: instance.playbackRateTransition,
+    });
+    instance.playbackRateTransition = null;
+    connect(source, instance.gainNode);
+
+    const sourceToken = control.sourceToken + 1;
+    control.sourceToken = sourceToken;
+    instance.sourceEnded = false;
+    source.onended = () => {
+      if (instance.source !== source || control.sourceToken !== sourceToken) {
+        return;
+      }
+
+      instance.sourceEnded = true;
+      if (instance.finishing) {
+        instance.onSourceEnded?.();
+        return;
+      }
+      if (
+        control.eventsSuppressed ||
+        control.detached ||
+        control.status !== "playing" ||
+        instance.loop
+      ) {
+        return;
+      }
+
+      stopControlledProgress(instance);
+      instance.source = null;
+      disconnect(source);
+      control.status = "ended";
+      control.cursorMs = control.durationMs;
+      control.sourceStartedAt = null;
+      queueControlledEvent(
+        instance,
+        "soundComplete",
+        {
+          positionMs: normalizeEventPosition(control.durationMs),
+          durationMs: normalizeEventPosition(control.durationMs),
+        },
+        control.commandId,
+      );
+    };
+
+    const offsetSeconds = instance.startAt + control.cursorMs / 1000;
+    const remainingSeconds = Math.max(
+      0,
+      (control.durationMs - control.cursorMs) / 1000,
+    );
+    const startTime = Math.max(0, toFiniteParamValue(context.currentTime, 0));
+    instance.sourceStartedAt = startTime;
+    instance.sourceStartOffset = offsetSeconds;
+    control.sourceStartedAt = startTime;
+    control.sourceCursorMs = control.cursorMs;
+
+    try {
+      if (
+        source.loop &&
+        instance.endAt !== null &&
+        instance.endAt !== undefined
+      ) {
+        source.loopStart = instance.startAt;
+        source.loopEnd = instance.endAt;
+        source.start(startTime, offsetSeconds);
+      } else if (!source.loop) {
+        source.start(startTime, offsetSeconds, remainingSeconds);
+      } else {
+        source.start(startTime, offsetSeconds);
+      }
+    } catch (error) {
+      source.onended = null;
+      disconnect(source);
+      throw error;
+    }
+
+    return source;
+  };
+
+  const failControlledPlayback = (instance, errorCode) => {
+    const control = instance.control;
+    cancelControlledPendingStart(instance);
+    stopControlledSource(instance);
+    control.status = "stopped";
+    control.cursorMs = 0;
+    control.pausedCursorRetained = false;
+    control.remainingDelayMs = 0;
+    queueControlledError(instance, errorCode);
+    if (instance.finishing) {
+      instance.sourceEnded = true;
+      instance.onSourceEnded?.();
+    }
+  };
+
+  const startControlledPlayback = (instance, delayMs = 0) => {
+    const control = instance.control;
+    if (
+      !control?.ready ||
+      control.durationMs === null ||
+      control.cursorMs >= control.durationMs
+    ) {
+      return;
+    }
+
+    cancelControlledPendingStart(instance);
+    stopControlledSource(instance);
+    control.status = "playing";
+    control.remainingDelayMs = Math.max(0, delayMs);
+    instance.sourceEnded = false;
+    instance.playbackPending = true;
+    const playRequestId = (instance.playRequestId ?? 0) + 1;
+    instance.playRequestId = playRequestId;
+    const context = getAudioContext();
+    const needsResume =
+      context.state === "suspended" && typeof context.resume === "function";
+
+    const start = () => {
+      if (
+        instance.playRequestId !== playRequestId ||
+        control.status !== "playing"
+      ) {
+        return;
+      }
+
+      instance.pendingTimeoutId = null;
+      control.delayDeadlineMs = null;
+      control.remainingDelayMs = 0;
+      try {
+        instance.source = createControlledSource(instance);
+      } catch {
+        failControlledPlayback(instance, "playback-failed");
+        return;
+      }
+      instance.playbackPending = false;
+      startControlledProgress(instance);
+      if (instance.finishing) {
+        instance.onFinishingSourceStarted?.();
+      }
+    };
+
+    const scheduleStart = () => {
+      if (
+        instance.playRequestId !== playRequestId ||
+        control.status !== "playing"
+      ) {
+        return;
+      }
+
+      if (control.remainingDelayMs > 0) {
+        control.delayDeadlineMs = Date.now() + control.remainingDelayMs;
+        instance.pendingTimeoutId = setTimeout(start, control.remainingDelayMs);
+        return;
+      }
+      start();
+    };
+
+    const resumePromise = resumeAudioContext(context);
+    if (needsResume) {
+      void resumePromise.then(scheduleStart);
+    } else {
+      scheduleStart();
+    }
+  };
+
+  const applyResolvedControlledState = (
+    instance,
+    { invalidPosition, terminal },
+  ) => {
+    const control = instance.control;
+    if (invalidPosition) {
+      queueControlledError(instance, "invalid-position");
+      control.deferredProgress = false;
+      if (control.status === "playing") {
+        startControlledPlayback(instance, control.remainingDelayMs);
+      }
+      return;
+    }
+    if (terminal) {
+      cancelControlledPendingStart(instance);
+      stopControlledSource(instance);
+      queueControlledProgress(instance);
+      return;
+    }
+
+    if (control.status === "playing") {
+      startControlledPlayback(instance, control.remainingDelayMs);
+    }
+    if (control.deferredProgress) {
+      control.deferredProgress = false;
+      queueControlledProgress(instance);
+    }
+  };
+
+  const scheduleControlledReady = (instance) => {
+    const control = instance.control;
+    if (!control || control.readyTaskQueued || control.readyAnnounced) {
+      return;
+    }
+
+    control.readyTaskQueued = true;
+    queueMicrotask(() => {
+      control.readyTaskQueued = false;
+      if (
+        !isCurrentControlledInstance(instance) ||
+        !control.ready ||
+        control.readyAnnounced
+      ) {
+        return;
+      }
+
+      const commandId = control.commandId;
+      const resolution = resolvePendingControlledPosition(instance);
+      control.readyAnnounced = true;
+      try {
+        emitControlledEventNow(
+          instance,
+          "soundReady",
+          {
+            positionMs: getControlledEventPosition(instance),
+            durationMs: normalizeEventPosition(control.durationMs),
+          },
+          commandId,
+        );
+      } finally {
+        if (
+          control.commandId === commandId &&
+          isCurrentControlledInstance(instance)
+        ) {
+          applyResolvedControlledState(instance, resolution);
+        }
+      }
+    });
+  };
+
+  const settleControlledDecode = (instance, decodeRequestId, audioBuffer) => {
+    const control = instance.control;
+    if (
+      !control ||
+      control.decodeRequestId !== decodeRequestId ||
+      control.detached
+    ) {
+      return;
+    }
+
+    control.decodePending = false;
+    const durationMs = validateControlledSegment(instance, audioBuffer);
+    if (durationMs === null) {
+      failControlledPlayback(instance, "invalid-segment");
+      return;
+    }
+
+    control.decodedBuffer = audioBuffer;
+    control.durationMs = durationMs;
+    control.ready = true;
+    control.lastErrorCode = null;
+
+    if (control.eventsSuppressed && instance.finishing) {
+      const resolution = resolvePendingControlledPosition(instance);
+      if (resolution.invalidPosition || control.status !== "playing") {
+        instance.sourceEnded = true;
+        instance.onSourceEnded?.();
+        return;
+      }
+      startControlledPlayback(instance, control.remainingDelayMs);
+      return;
+    }
+
+    scheduleControlledReady(instance);
+  };
+
+  const beginControlledDecode = (instance) => {
+    const control = instance.control;
+    if (!control || control.decodePending || control.ready) return;
+
+    const decodeRequestId = control.decodeRequestId + 1;
+    control.decodeRequestId = decodeRequestId;
+    control.decodePending = true;
+    instance.playbackPending = control.status === "playing";
+    const cachedBuffer = AudioAsset.getAsset(instance.src);
+    if (cachedBuffer) {
+      queueMicrotask(() => {
+        settleControlledDecode(instance, decodeRequestId, cachedBuffer);
+      });
+      return;
+    }
+
+    const assetPromise = AudioAsset.getAssetPromise?.(instance.src);
+    if (!assetPromise) {
+      queueMicrotask(() => {
+        if (control.decodeRequestId !== decodeRequestId) return;
+        control.decodePending = false;
+        failControlledPlayback(instance, "asset-unavailable");
+      });
+      return;
+    }
+
+    Promise.resolve(assetPromise).then(
+      (audioBuffer) => {
+        settleControlledDecode(instance, decodeRequestId, audioBuffer);
+      },
+      () => {
+        if (control.decodeRequestId !== decodeRequestId) return;
+        control.decodePending = false;
+        failControlledPlayback(instance, "decode-failed");
+      },
+    );
+  };
+
+  const applyPendingControlledCommand = (instance, command) => {
+    const control = instance.control;
+    switch (command.operation) {
+      case "play": {
+        cancelControlledPendingStart(instance);
+        stopControlledSource(instance);
+        control.status = "playing";
+        control.cursorMs = command.positionMs;
+        control.pausedCursorRetained = false;
+        control.remainingDelayMs = instance.startDelayMs;
+        control.pendingPosition = {
+          operation: "play",
+          positionMs: command.positionMs,
+          fallback: null,
+        };
+        control.deferredProgress = false;
+        instance.playbackPending = true;
+        break;
+      }
+      case "pause": {
+        if (control.status !== "playing") {
+          break;
+        }
+        cancelControlledPendingStart(instance, {
+          preserveRemainingDelay: true,
+        });
+        control.status = "paused";
+        control.pausedCursorRetained = true;
+        control.deferredProgress = true;
+        instance.playbackPending = false;
+        break;
+      }
+      case "resume": {
+        if (control.status !== "paused" || !control.pausedCursorRetained) {
+          break;
+        }
+        control.status = "playing";
+        control.pausedCursorRetained = false;
+        instance.playbackPending = true;
+        break;
+      }
+      case "stop": {
+        const changed =
+          control.status !== "stopped" ||
+          control.cursorMs !== 0 ||
+          instance.playbackPending;
+        cancelControlledPendingStart(instance);
+        stopControlledSource(instance);
+        control.status = "stopped";
+        control.cursorMs = 0;
+        control.pausedCursorRetained = false;
+        control.remainingDelayMs = 0;
+        control.pendingPosition = null;
+        control.deferredProgress ||= changed;
+        instance.playbackPending = false;
+        break;
+      }
+      case "seek": {
+        const canSeek =
+          control.status === "playing" || control.status === "paused";
+        control.pendingPosition = {
+          operation: canSeek ? "seek" : "seekNoop",
+          positionMs: command.positionMs,
+          fallback: canSeek ? control.pendingPosition : null,
+        };
+        control.deferredProgress = canSeek;
+        break;
+      }
+    }
+  };
+
+  const applyReadyControlledCommand = (instance, command) => {
+    const control = instance.control;
+    const durationMs = control.durationMs;
+
+    switch (command.operation) {
+      case "play": {
+        if (command.positionMs > durationMs) {
+          queueControlledError(instance, "invalid-position");
+          return;
+        }
+
+        cancelControlledPendingStart(instance);
+        stopControlledSource(instance);
+        control.pausedCursorRetained = false;
+        control.cursorMs = command.positionMs;
+        if (command.positionMs === durationMs) {
+          control.status = "ended";
+          control.remainingDelayMs = 0;
+          queueControlledProgress(instance);
+          return;
+        }
+
+        control.status = "playing";
+        control.remainingDelayMs = instance.startDelayMs;
+        startControlledPlayback(instance, instance.startDelayMs);
+        return;
+      }
+      case "pause": {
+        if (control.status !== "playing") {
+          return;
+        }
+
+        if (instance.source) {
+          captureControlledPosition(instance);
+        }
+        const remainingDelayMs = getRemainingControlledDelayMs(instance);
+        cancelControlledPendingStart(instance, {
+          preserveRemainingDelay: true,
+        });
+        stopControlledSource(instance);
+        control.status = "paused";
+        control.pausedCursorRetained = true;
+        control.remainingDelayMs = remainingDelayMs;
+        queueControlledProgress(instance);
+        return;
+      }
+      case "resume": {
+        if (
+          control.status !== "paused" ||
+          !control.pausedCursorRetained ||
+          control.cursorMs >= durationMs
+        ) {
+          return;
+        }
+
+        control.status = "playing";
+        control.pausedCursorRetained = false;
+        startControlledPlayback(instance, control.remainingDelayMs);
+        return;
+      }
+      case "stop": {
+        const changed =
+          control.status !== "stopped" ||
+          control.cursorMs !== 0 ||
+          instance.source !== null ||
+          instance.playbackPending;
+        if (!changed) return;
+
+        cancelControlledPendingStart(instance);
+        stopControlledSource(instance);
+        control.status = "stopped";
+        control.cursorMs = 0;
+        control.pausedCursorRetained = false;
+        control.remainingDelayMs = 0;
+        queueControlledProgress(instance);
+        return;
+      }
+      case "seek": {
+        if (command.positionMs > durationMs) {
+          queueControlledError(instance, "invalid-position");
+          return;
+        }
+        if (control.status === "stopped" || control.status === "ended") {
+          return;
+        }
+        if (command.positionMs === durationMs) {
+          cancelControlledPendingStart(instance);
+          stopControlledSource(instance);
+          control.status = "ended";
+          control.cursorMs = durationMs;
+          control.pausedCursorRetained = false;
+          control.remainingDelayMs = 0;
+          queueControlledProgress(instance);
+          return;
+        }
+
+        if (control.status === "paused") {
+          control.cursorMs = command.positionMs;
+          queueControlledProgress(instance);
+          return;
+        }
+
+        if (!instance.source) {
+          control.cursorMs = command.positionMs;
+          queueControlledProgress(instance);
+          return;
+        }
+
+        stopControlledSource(instance);
+        control.cursorMs = command.positionMs;
+        control.status = "playing";
+        startControlledPlayback(instance, 0);
+        queueControlledProgress(instance);
+      }
+    }
+  };
+
+  const acceptControlledCommand = (instance, command) => {
+    const control = instance.control;
+    if (!control || command.commandId <= control.commandId) {
+      return false;
+    }
+
+    const isInitialCommand = control.commandId < 0;
+    control.commandId = command.commandId;
+    control.lastErrorCode = null;
+    instance.playback = command;
+
+    if (control.ready && control.readyAnnounced) {
+      applyReadyControlledCommand(instance, command);
+      return true;
+    }
+
+    applyPendingControlledCommand(instance, command);
+    if (!control.ready && !control.decodePending) {
+      if (isInitialCommand || command.operation === "play") {
+        control.readyAnnounced = false;
+        beginControlledDecode(instance);
+      }
+    } else if (control.ready) {
+      scheduleControlledReady(instance);
+    }
+    return true;
+  };
+
+  const suppressControlledEvents = (instance) => {
+    const control = instance?.control;
+    if (!control) return;
+
+    control.eventsSuppressed = true;
+    stopControlledProgress(instance);
+  };
 
   const getCurrentChannelSounds = (channelId) => {
     const channelSounds = [];
@@ -1029,7 +1932,11 @@ export const createAudioStage = () => {
       "playbackRate",
       phase,
     );
-    playSound(instance);
+    if (instance.control) {
+      acceptControlledCommand(instance, sound.playback);
+    } else {
+      playSound(instance);
+    }
     return instance;
   };
 
@@ -1237,8 +2144,18 @@ export const createAudioStage = () => {
     const nextVolumeValue = getVolumeValue(sound);
     const volumeChanged = currentVolumeValue !== nextVolumeValue;
     const panChanged = instance.pan !== sound.pan;
+    const loopChanged = instance.loop !== sound.loop;
     const playbackRateChanged = instance.playbackRate !== sound.playbackRate;
     const startDelayChanged = instance.startDelayMs !== sound.startDelayMs;
+    const sourceBeforeUpdate = instance.source;
+
+    if (
+      instance.control &&
+      instance.source &&
+      (loopChanged || playbackRateChanged)
+    ) {
+      captureControlledPosition(instance);
+    }
 
     if (instance.channelId !== sound.channelId) {
       const parentChannel = getParentChannelForSound(sound);
@@ -1256,7 +2173,7 @@ export const createAudioStage = () => {
     instance.channelId = sound.channelId;
     bindChannelLoopCompletion(instance);
 
-    if (instance.source) {
+    if (instance.source && !instance.control) {
       instance.source.loop = sound.loop;
     }
 
@@ -1295,7 +2212,9 @@ export const createAudioStage = () => {
         "playbackRate",
         "update",
       );
-      if (instance.source) {
+      if (instance.control && loopChanged && instance.source) {
+        instance.playbackRateTransition = playbackRateTransition;
+      } else if (instance.source) {
         applyPlaybackRate({
           source: instance.source,
           targetValue: sound.playbackRate,
@@ -1306,12 +2225,28 @@ export const createAudioStage = () => {
       }
     }
 
-    if (startDelayChanged && instance.pendingTimeoutId !== null) {
+    if (
+      !instance.control &&
+      startDelayChanged &&
+      instance.pendingTimeoutId !== null
+    ) {
       playSound(instance);
+    }
+
+    if (instance.control) {
+      acceptControlledCommand(instance, sound.playback);
+      if (
+        loopChanged &&
+        instance.source === sourceBeforeUpdate &&
+        instance.control.status === "playing"
+      ) {
+        stopControlledSource(instance);
+        startControlledPlayback(instance, 0);
+      }
     }
   };
 
-  const renderGraph = ({
+  const validateGraphTransition = ({
     prevAudio = [],
     nextAudio = [],
     prevAudioEffects = [],
@@ -1353,6 +2288,65 @@ export const createAudioStage = () => {
         );
       }
     }
+
+    for (const [id, prevSound] of prevSoundById) {
+      const nextSound = nextSoundById.get(id);
+      if (!nextSound) continue;
+
+      const wasControlled = prevSound.playback !== undefined;
+      const isControlled = nextSound.playback !== undefined;
+      if (wasControlled !== isControlled) {
+        throw new Error(
+          `Input error: sound "${id}" cannot change command-controlled playback mode while retained.`,
+        );
+      }
+
+      if (isControlled && !hasSameSoundSourceIdentity(prevSound, nextSound)) {
+        const currentKey = currentSoundKeyById.get(id);
+        const currentInstance = currentKey ? sounds.get(currentKey) : null;
+        const acceptedCommandId =
+          currentInstance?.control?.commandId ?? prevSound.playback.commandId;
+        if (
+          nextSound.playback.operation !== "play" ||
+          nextSound.playback.commandId <= acceptedCommandId
+        ) {
+          throw new Error(
+            `Input error: command-controlled sound "${id}" must change source identity with a higher play command.`,
+          );
+        }
+      }
+    }
+
+    return {
+      prev,
+      next,
+      prevChannelById,
+      nextChannelById,
+      prevSoundById,
+      nextSoundById,
+    };
+  };
+
+  const renderGraph = ({
+    prevAudio = [],
+    nextAudio = [],
+    prevAudioEffects = [],
+    nextAudioEffects = [],
+    eventHandler = soundEventHandler,
+  } = {}) => {
+    const {
+      next,
+      prevChannelById,
+      nextChannelById,
+      prevSoundById,
+      nextSoundById,
+    } = validateGraphTransition({
+      prevAudio,
+      nextAudio,
+      prevAudioEffects,
+      nextAudioEffects,
+    });
+    soundEventHandler = eventHandler;
 
     ensureRootChannel(ROOT_CHANNEL_ID);
 
@@ -1447,6 +2441,7 @@ export const createAudioStage = () => {
         prevSound.channelId !== null &&
         prevChannelById.get(prevSound.channelId)?.interruption === "loopEnd";
       const finishPreviousSound = () => {
+        suppressControlledEvents(instance);
         if (!finishAtLoopEnd) {
           return removeSoundInstance(
             instance,
@@ -1670,6 +2665,8 @@ export const createAudioStage = () => {
   };
 
   const destroy = () => {
+    destroyed = true;
+    soundEventHandler = undefined;
     for (const sound of sounds.values()) {
       cleanupSound(sound);
     }
@@ -1690,6 +2687,7 @@ export const createAudioStage = () => {
     getById,
     resume,
     tick,
+    validateGraphTransition,
     renderGraph,
     destroy,
     _inspect: () => ({

--- a/src/RouteGraphics.js
+++ b/src/RouteGraphics.js
@@ -1191,6 +1191,13 @@ const createRouteGraphics = () => {
       return;
     }
 
+    appInstance.audioStage?.validateGraphTransition?.({
+      prevAudio: state.audio,
+      nextAudio: nextState.audio,
+      prevAudioEffects: state.audioEffects,
+      nextAudioEffects: nextState.audioEffects,
+    });
+
     const continuityPlan = buildAnimationContinuityPlan({
       prevState: state,
       nextState,
@@ -1243,6 +1250,7 @@ const createRouteGraphics = () => {
       prevAudioEffects: state.audioEffects,
       nextAudioEffects: nextState.audioEffects,
       audioPlugins: plugins.audio,
+      eventHandler: handler,
     });
 
     state = nextState;

--- a/src/plugins/audio/renderAudio.js
+++ b/src/plugins/audio/renderAudio.js
@@ -66,6 +66,7 @@ const renderPluginDiff = ({
  * @param {Object[]} [params.prevAudioEffects] - Previous audio effects
  * @param {Object[]} [params.nextAudioEffects] - Next audio effects
  * @param {import("./audio/audioPlugin.js").AudioPlugin[]} params.audioPlugins - Array of audio plugins
+ * @param {Function} [params.eventHandler] - Route Graphics event handler
  */
 export const renderAudio = ({
   app,
@@ -74,6 +75,7 @@ export const renderAudio = ({
   prevAudioEffects = [],
   nextAudioEffects = [],
   audioPlugins,
+  eventHandler,
 }) => {
   normalizeAudioRenderState({
     audio: prevAudioTree,
@@ -90,6 +92,7 @@ export const renderAudio = ({
       nextAudio: filterGraphAudio(nextAudioTree),
       prevAudioEffects,
       nextAudioEffects,
+      eventHandler,
     });
     renderPluginDiff({
       app,

--- a/src/schemas/audio/sound.yaml
+++ b/src/schemas/audio/sound.yaml
@@ -58,3 +58,44 @@ properties:
     description: Optional end time in seconds
     default: null
     minimum: 0
+  playback:
+    type: object
+    description: Optional command-controlled playback instruction
+    additionalProperties: false
+    required:
+      - commandId
+      - operation
+    properties:
+      commandId:
+        type: integer
+        minimum: 0
+        maximum: 9007199254740991
+        description: Monotonically increasing command identity
+      operation:
+        type: string
+        enum: [play, pause, resume, stop, seek]
+        description: Transport operation
+      positionMs:
+        type: number
+        minimum: 0
+        description: Segment-relative position required by play and seek
+    allOf:
+      - if:
+          properties:
+            operation:
+              enum: [play, seek]
+          required:
+            - operation
+        then:
+          required:
+            - positionMs
+      - if:
+          properties:
+            operation:
+              enum: [pause, resume, stop]
+          required:
+            - operation
+        then:
+          not:
+            required:
+              - positionMs

--- a/src/types.js
+++ b/src/types.js
@@ -642,6 +642,13 @@
  */
 
 /**
+ * @typedef {Object} SoundPlaybackCommand
+ * @property {number} commandId - Monotonically increasing command identity
+ * @property {'play' | 'pause' | 'resume' | 'stop' | 'seek'} operation - Transport operation
+ * @property {number} [positionMs] - Segment-relative position for play and seek
+ */
+
+/**
  * @typedef {Object} SoundElement
  * @property {string} id - Unique identifier
  * @property {string} type - Should be "sound"
@@ -654,6 +661,7 @@
  * @property {number} [playbackRate=1] - Playback speed multiplier
  * @property {number} [startAt=0] - Start offset in seconds
  * @property {number|null} [endAt=null] - Optional end time in seconds
+ * @property {SoundPlaybackCommand} [playback] - Optional command-controlled playback instruction
  */
 
 /**

--- a/src/util/normalizeAudio.js
+++ b/src/util/normalizeAudio.js
@@ -2,6 +2,15 @@ import { SUPPORTED_EASING_NAMES } from "./animationTimeline.js";
 
 const AUDIO_NODE_TYPES = new Set(["audio-channel", "sound"]);
 const AUDIO_CHANNEL_INTERRUPTION_VALUES = new Set(["immediate", "loopEnd"]);
+const AUDIO_PLAYBACK_OPERATIONS = new Set([
+  "play",
+  "pause",
+  "resume",
+  "stop",
+  "seek",
+]);
+const AUDIO_PLAYBACK_POSITION_OPERATIONS = new Set(["play", "seek"]);
+const AUDIO_PLAYBACK_KEYS = new Set(["commandId", "operation", "positionMs"]);
 const AUDIO_TRANSITION_TYPE = "audio-transition";
 const AUDIO_EFFECT_TYPES = new Set([AUDIO_TRANSITION_TYPE]);
 const AUDIO_TRANSITION_PHASES = new Set(["enter", "exit", "update"]);
@@ -94,6 +103,55 @@ const assertUniqueId = (ids, id, path) => {
   ids.add(id);
 };
 
+const normalizePlaybackCommand = (playback, path) => {
+  assertRecord(playback, path);
+
+  for (const key of Object.keys(playback)) {
+    if (!AUDIO_PLAYBACK_KEYS.has(key)) {
+      throw new Error(
+        `Input error: unsupported playback field "${key}" at ${path}.`,
+      );
+    }
+  }
+
+  if (!Number.isSafeInteger(playback.commandId) || playback.commandId < 0) {
+    throw new Error(
+      `Input error: ${path}.commandId must be a non-negative safe integer.`,
+    );
+  }
+
+  if (!AUDIO_PLAYBACK_OPERATIONS.has(playback.operation)) {
+    throw new Error(
+      `Input error: ${path}.operation must be one of play, pause, resume, stop, seek.`,
+    );
+  }
+
+  const requiresPosition = AUDIO_PLAYBACK_POSITION_OPERATIONS.has(
+    playback.operation,
+  );
+  if (requiresPosition) {
+    if (
+      typeof playback.positionMs !== "number" ||
+      !Number.isFinite(playback.positionMs) ||
+      playback.positionMs < 0
+    ) {
+      throw new Error(
+        `Input error: ${path}.positionMs must be a finite non-negative number for ${playback.operation}.`,
+      );
+    }
+  } else if (playback.positionMs !== undefined) {
+    throw new Error(
+      `Input error: ${path}.positionMs is not allowed for ${playback.operation}.`,
+    );
+  }
+
+  return {
+    commandId: playback.commandId,
+    operation: playback.operation,
+    ...(requiresPosition ? { positionMs: playback.positionMs } : {}),
+  };
+};
+
 const validateSound = (node, path, ids, flattenedSounds, channelId = null) => {
   assertNonEmptyString(node.id, `${path}.id`);
   assertUniqueId(ids, node.id, `${path}.id`);
@@ -125,6 +183,11 @@ const validateSound = (node, path, ids, flattenedSounds, channelId = null) => {
     );
   }
 
+  const playback =
+    node.playback === undefined
+      ? undefined
+      : normalizePlaybackCommand(node.playback, `${path}.playback`);
+
   flattenedSounds.push({
     id: node.id,
     type: "sound",
@@ -138,6 +201,7 @@ const validateSound = (node, path, ids, flattenedSounds, channelId = null) => {
     startAt: node.startAt ?? 0,
     endAt: node.endAt ?? null,
     channelId,
+    ...(playback ? { playback } : {}),
   });
 };
 
@@ -193,6 +257,12 @@ const validateChannel = (
     if (node.loop === true && child.loop === true) {
       throw new Error(
         `Input error: ${childPath}.loop cannot be true when ${path}.loop is true.`,
+      );
+    }
+
+    if (node.loop === true && child.playback !== undefined) {
+      throw new Error(
+        `Input error: ${childPath}.playback is not allowed when ${path}.loop is true.`,
       );
     }
 


### PR DESCRIPTION
## Summary

- add the strict opt-in `sound.playback` JSON command interface using `commandId`, `operation`, and operation-specific `positionMs`
- implement play/restart, pause, resume, stop, and seek with renderer-owned cursor preservation, decoded duration, retained decode reuse, delayed-start handling, and segment-relative loop boundaries
- reconcile higher commands exactly once while preserving playback for repeated/stale commands and volume, mute, pan, or channel-only renders
- preserve valid pending playback when later deferred position validation fails, including higher commands issued reentrantly from `soundReady`
- emit `soundReady`, `soundProgress`, `soundComplete`, and `soundError` through the existing event handler with runtime metadata under `_event`
- suppress stale decode/source callbacks after command changes, source replacement, removal, loop-end detachment, and destruction
- reject retained playback-mode changes, invalid source transitions, and controlled children in looping audio channels before reconciliation
- preserve legacy declarative sound behavior and bump the package to Route Graphics 1.31.0
- document the released interface in the audio design, event API, README, and sound-node guide

## Validation

- `bun run lint`
- `bun run build`
- `bun run test -- --exclude spec/cli/renderPngCli.spec.js`: 88 files passed, 746 tests passed
- focused audio/schema suite: 5 files passed, 114 tests passed
- all 26 changed JSON examples parse successfully
- `git diff --check`

The environment-sensitive `spec/cli/renderPngCli.spec.js` is not green in this workspace: its isolated outside-sandbox run passed 2 tests and failed 3 due a render timeout, an inaccessible image fixture, and the existing renderer destroy-path resize hook. The audio and non-CLI suites are green.
