### PR TITLE
fix(audio): preserve looping channel playback on pause

### DIFF
--- a/docs/audio-effects.md
+++ b/docs/audio-effects.md
@@ -107,20 +107,24 @@ volume: 80
 muted: false
 pan: 0
 loop: false
+playback:
+  commandId: 1
+  operation: resume
 children: []
 ```
 
 Fields:
 
-| Field      | Type            | Default  | Description                                    |
-| ---------- | --------------- | -------- | ---------------------------------------------- |
-| `id`       | string          | required | Stable globally unique channel ID              |
-| `type`     | `audio-channel` | required | Node type                                      |
-| `volume`   | number          | `100`    | Local channel volume, `0` to `100`             |
-| `muted`    | boolean         | `false`  | Forces this channel's effective output to zero |
-| `pan`      | number          | `0`      | Stereo pan, `-1` left to `1` right             |
-| `loop`     | boolean         | `false`  | Repeats the complete child schedule            |
-| `children` | sound[]         | `[]`     | Sound nodes owned by this channel              |
+| Field      | Type            | Default  | Description                                     |
+| ---------- | --------------- | -------- | ----------------------------------------------- |
+| `id`       | string          | required | Stable globally unique channel ID               |
+| `type`     | `audio-channel` | required | Node type                                       |
+| `volume`   | number          | `100`    | Local channel volume, `0` to `100`              |
+| `muted`    | boolean         | `false`  | Forces this channel's effective output to zero  |
+| `pan`      | number          | `0`      | Stereo pan, `-1` left to `1` right              |
+| `loop`     | boolean         | `false`  | Repeats the complete child schedule             |
+| `playback` | object          | omitted  | Optional channel-level `pause`/`resume` command |
+| `children` | sound[]         | `[]`     | Sound nodes owned by this channel               |
 
 First implementation rule:
 
@@ -132,6 +136,9 @@ First implementation rule:
   finished. Looping channels cannot contain child sounds with `loop: true`.
 - Changing a channel from `loop: true` to `loop: false` cancels child sounds
   that have not started yet and lets already-playing child sounds finish.
+- Optional channel `playback` preserves active child cursors and remaining
+  delays across monotonic `pause`/`resume` commands. See
+  [Command-Controlled Sound Playback](./audio-playback-commands.md#audio-channel-pause-and-resume).
 
 ### Sounds
 
@@ -459,17 +466,18 @@ The command-controlled playback extension does not change these rules for
 ordinary sounds. A sound opts into the transport model only when it carries a
 `playback` command. See
 [Command-Controlled Sound Playback](./audio-playback-commands.md). A
-command-controlled sound cannot be a child of an
-`audio-channel` with `loop: true`, because channel-schedule replay would bypass
-command ordering. A non-looping channel may retain either interruption mode;
-an outgoing `loopEnd` instance finishes as an event-detached tail.
+command-controlled sound cannot be a child of an `audio-channel` with
+`loop: true` or a channel that has its own `playback` command, because two
+transport owners would conflict. A non-looping uncontrolled channel may retain
+either interruption mode; an outgoing `loopEnd` instance finishes as an
+event-detached tail.
 
 Cross-state identity rules:
 
-| Object          | Continues when                                       | Replaced when                                        |
-| --------------- | ---------------------------------------------------- | ---------------------------------------------------- |
-| `audio-channel` | Its `id` exists as an `audio-channel` in both states | It is removed and later added                        |
-| `sound`         | Its `id` and all source identity fields match        | `src`, `startAt`, `endAt`, or `startDelayMs` changes |
+| Object          | Continues when                                | Replaced when                                        |
+| --------------- | --------------------------------------------- | ---------------------------------------------------- |
+| `audio-channel` | Its `id` and playback-control mode match      | It is removed and later added                        |
+| `sound`         | Its `id` and all source identity fields match | `src`, `startAt`, `endAt`, or `startDelayMs` changes |
 
 Changing an ID between `sound` and `audio-channel` is invalid rather than a
 replacement. Moving a continuing sound between channels reroutes it without

--- a/docs/audio-playback-commands.md
+++ b/docs/audio-playback-commands.md
@@ -1,8 +1,9 @@
 # Command-Controlled Sound Playback
 
-Status: implemented for the Route Graphics 1.31.0 release.
+Status: sound commands implemented in Route Graphics 1.31.0; channel
+pause/resume implemented in 1.31.1.
 
-Last updated: 2026-07-25
+Last updated: 2026-07-28
 
 ## Purpose
 
@@ -458,7 +459,48 @@ This allows a consumer to pause retained story BGM while starting another
 controlled music sound. Voice and sound effects may remain ordinary sounds
 without `playback`.
 
-### Audio-Channel Loop Restriction
+### Audio-Channel Pause and Resume
+
+An `audio-channel` may opt into cursor-preserving transport with a strict
+channel command:
+
+```yaml
+id: story-bgm
+type: audio-channel
+loop: true
+playback:
+  commandId: 42
+  operation: pause
+children:
+  - id: intro
+    type: sound
+    src: intro
+  - id: theme
+    type: sound
+    src: theme
+    startDelayMs: 500
+```
+
+Channel playback supports only `pause` and `resume`. `positionMs` and unknown
+fields are invalid. Higher `commandId` values execute once; repeated and lower
+IDs do nothing.
+
+`pause` captures each active child cursor and each pending child's remaining
+`startDelayMs`. A paused looping channel does not begin another schedule
+iteration. `resume` continues those exact cursors and delays; children that
+already ended remain ended. If the complete iteration had ended, resuming a
+looping channel begins its next iteration.
+
+Children added to a paused channel remain paused from their initial cursor.
+Continuing sounds moved into or out of a paused channel pause or resume without
+restarting. Mixer updates do not affect playback state.
+
+Channel playback is opt-in for the complete retained channel lifetime. Adding
+or removing `playback` while retaining the same channel ID is invalid. Channel
+commands emit no sound transport events because a channel has no single
+position or duration.
+
+### Audio-Channel Command Ownership
 
 A command-controlled sound may be a child of an `audio-channel` only when that
 channel has `loop: false`. A looping channel automatically restarts its complete
@@ -476,6 +518,10 @@ The render is rejected before audio reconciliation, leaving the previous
 channel and sound runtime unchanged. Use `loop: true` on the controlled sound
 itself when one command should authorize continuous looping, or keep the
 channel non-looping and issue higher playback commands explicitly.
+
+A channel with its own `playback` command cannot contain command-controlled
+sounds. Use channel commands to pause or resume the complete ordinary child
+schedule, or sound commands for independent child transport, but not both.
 
 ### Audio-Channel Interruption
 
@@ -815,9 +861,9 @@ Its behavior remains:
 
 No new command ID or events are required for legacy sounds.
 
-Audio channels require no new fields. Existing channel and sound volume, mute,
-pan, sound-loop, timing, and transition fields remain unchanged, subject to the
-restriction that a looping channel cannot contain a command-controlled sound.
+Audio channels remain ordinary declarative buses unless they opt into the
+`playback` field. Existing channel and sound volume, mute, pan, sound-loop,
+timing, and transition fields remain unchanged.
 
 ## Internal Implementation Requirements
 
@@ -885,6 +931,11 @@ Test coverage includes:
 - source replacement followed by decode, segment, position, or playback failure
 - full and remaining `startDelayMs` behavior for every transport operation
 - rejection of command-controlled children in looping channels
+- strict channel pause/resume validation and command ordering
+- active-cursor and remaining-delay continuity for multi-sound channels
+- paused looping-channel scheduling and child add/remove/reroute behavior
+- rejection of retained channel transitions into or out of controlled mode
+- rejection of independent sound commands inside a controlled channel
 - immediate and loop-end interruption of active, decoding, and delayed sounds
 - volume, mute, pan, and channel updates without restart
 - playback-rate-aware progress

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -1891,6 +1891,283 @@ describe("AudioStage graph rendering", () => {
     expect(source.start.mock.calls[0]).toHaveLength(2);
   });
 
+  it("pauses and resumes a looping channel at each child cursor and remaining delay", async () => {
+    const { stage, context } = await setupAudioStage({
+      assetMap: new Map([
+        ["intro", { duration: 10 }],
+        ["outro", { duration: 10 }],
+      ]),
+    });
+    const channel = (commandId, operation) => [
+      {
+        id: "music",
+        type: "audio-channel",
+        loop: true,
+        playback: { commandId, operation },
+        children: [
+          { id: "intro", type: "sound", src: "intro" },
+          {
+            id: "outro",
+            type: "sound",
+            src: "outro",
+            startDelayMs: 100,
+          },
+        ],
+      },
+    ];
+    const playing = channel(1, "resume");
+    const paused = channel(2, "pause");
+    const resumed = channel(3, "resume");
+
+    stage.renderGraph({ nextAudio: playing });
+    context.currentTime = 10.04;
+    vi.advanceTimersByTime(40);
+    const firstSource = context.sources[0];
+
+    stage.renderGraph({ prevAudio: playing, nextAudio: paused });
+
+    expect(firstSource.stop).toHaveBeenCalledWith(10.04);
+    expect(findCurrentSound(stage, "intro").channelPauseState).toMatchObject({
+      kind: "active",
+      remainingDelayMs: 0,
+    });
+    expect(
+      findCurrentSound(stage, "intro").channelPauseState.offset,
+    ).toBeCloseTo(0.04);
+    expect(findCurrentSound(stage, "outro").channelPauseState).toEqual({
+      kind: "pending",
+      offset: 0,
+      remainingDelayMs: 60,
+    });
+
+    vi.advanceTimersByTime(1000);
+    expect(context.sources).toHaveLength(1);
+
+    context.currentTime = 20;
+    stage.renderGraph({ prevAudio: paused, nextAudio: resumed });
+
+    expect(context.sources).toHaveLength(2);
+    expect(context.sources[1].start).toHaveBeenCalledTimes(1);
+    expect(context.sources[1].start.mock.calls[0][0]).toBe(20);
+    expect(context.sources[1].start.mock.calls[0][1]).toBeCloseTo(0.04);
+    vi.advanceTimersByTime(59);
+    expect(context.sources).toHaveLength(2);
+    vi.advanceTimersByTime(1);
+    expect(context.sources).toHaveLength(3);
+    expect(context.sources[2].start).toHaveBeenCalledWith(20, 0);
+
+    context.sources[1].onended();
+    expect(context.sources).toHaveLength(3);
+    context.sources[2].onended();
+    expect(context.sources).toHaveLength(4);
+    expect(findCurrentSound(stage, "outro").pendingTimeoutId).not.toBeNull();
+  });
+
+  it("starts children only after an initially paused channel resumes", async () => {
+    const { stage, context, getAsset } = await setupAudioStage();
+    const paused = [
+      {
+        id: "music",
+        type: "audio-channel",
+        playback: { commandId: 1, operation: "pause" },
+        children: [
+          { id: "theme", type: "sound", src: "theme", startDelayMs: 100 },
+        ],
+      },
+    ];
+    const resumed = [
+      {
+        ...paused[0],
+        playback: { commandId: 2, operation: "resume" },
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: paused });
+    vi.advanceTimersByTime(500);
+    expect(getAsset).not.toHaveBeenCalled();
+    expect(context.sources).toHaveLength(0);
+
+    stage.renderGraph({ prevAudio: paused, nextAudio: resumed });
+    vi.advanceTimersByTime(99);
+    expect(context.sources).toHaveLength(0);
+    vi.advanceTimersByTime(1);
+    expect(context.sources).toHaveLength(1);
+  });
+
+  it("reconciles child additions and removals without starting a paused channel", async () => {
+    const { stage, context, getAsset } = await setupAudioStage();
+    const first = [
+      {
+        id: "music",
+        type: "audio-channel",
+        playback: { commandId: 1, operation: "pause" },
+        children: [{ id: "first", type: "sound", src: "first" }],
+      },
+    ];
+    const replaced = [
+      {
+        ...first[0],
+        children: [{ id: "second", type: "sound", src: "second" }],
+      },
+    ];
+    const resumed = [
+      {
+        ...replaced[0],
+        playback: { commandId: 2, operation: "resume" },
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: first });
+    stage.renderGraph({ prevAudio: first, nextAudio: replaced });
+    expect(getAsset).not.toHaveBeenCalled();
+    expect(context.sources).toHaveLength(0);
+    expect(findCurrentSound(stage, "first")).toBeUndefined();
+
+    stage.renderGraph({ prevAudio: replaced, nextAudio: resumed });
+    expect(context.sources).toHaveLength(1);
+    expect(getAsset).toHaveBeenCalledWith("second");
+  });
+
+  it("ignores repeated and stale channel playback commands", async () => {
+    const { stage, context } = await setupAudioStage();
+    const channel = (commandId, operation) => [
+      {
+        id: "music",
+        type: "audio-channel",
+        playback: { commandId, operation },
+        children: [{ id: "theme", type: "sound", src: "theme" }],
+      },
+    ];
+    const paused = channel(5, "pause");
+
+    stage.renderGraph({ nextAudio: paused });
+    stage.renderGraph({
+      prevAudio: paused,
+      nextAudio: channel(4, "resume"),
+    });
+    expect(context.sources).toHaveLength(0);
+
+    stage.renderGraph({
+      prevAudio: channel(4, "resume"),
+      nextAudio: channel(6, "resume"),
+    });
+    expect(context.sources).toHaveLength(1);
+
+    stage.renderGraph({
+      prevAudio: channel(6, "resume"),
+      nextAudio: channel(6, "pause"),
+    });
+    expect(context.sources[0].stop).not.toHaveBeenCalled();
+    expect(stage._inspect().channels.get("music").playback).toEqual({
+      commandId: 6,
+      operation: "resume",
+    });
+
+    stage.renderGraph({
+      prevAudio: channel(6, "pause"),
+      nextAudio: channel(7, "pause"),
+    });
+    expect(context.sources[0].stop).toHaveBeenCalledTimes(1);
+    expect(stage._inspect().channels.get("music").playback).toEqual({
+      commandId: 7,
+      operation: "pause",
+    });
+  });
+
+  it("accounts for playback rate and segment bounds when resuming a channel", async () => {
+    const { stage, context } = await setupAudioStage({
+      assetMap: new Map([["theme", { duration: 10 }]]),
+    });
+    const channel = (commandId, operation) => [
+      {
+        id: "music",
+        type: "audio-channel",
+        playback: { commandId, operation },
+        children: [
+          {
+            id: "theme",
+            type: "sound",
+            src: "theme",
+            playbackRate: 2,
+            startAt: 2,
+            endAt: 8,
+          },
+        ],
+      },
+    ];
+    const playing = channel(1, "resume");
+    const paused = channel(2, "pause");
+    const resumed = channel(3, "resume");
+
+    stage.renderGraph({ nextAudio: playing });
+    context.currentTime = 11.25;
+    stage.renderGraph({ prevAudio: playing, nextAudio: paused });
+    context.currentTime = 20;
+    stage.renderGraph({ prevAudio: paused, nextAudio: resumed });
+
+    expect(context.sources[1].start).toHaveBeenCalledWith(20, 4.5, 3.5);
+  });
+
+  it("keeps continuing sounds synchronized when they move across a paused channel", async () => {
+    const { stage, context } = await setupAudioStage();
+    const outside = [
+      {
+        id: "theme",
+        type: "sound",
+        src: "theme",
+      },
+      {
+        id: "music",
+        type: "audio-channel",
+        playback: { commandId: 1, operation: "pause" },
+        children: [],
+      },
+    ];
+    const inside = [
+      {
+        ...outside[1],
+        children: [{ ...outside[0] }],
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: outside });
+    const originalSource = context.sources[0];
+    context.currentTime = 10.5;
+    stage.renderGraph({ prevAudio: outside, nextAudio: inside });
+    expect(originalSource.stop).toHaveBeenCalledWith(10.5);
+
+    context.currentTime = 20;
+    stage.renderGraph({ prevAudio: inside, nextAudio: outside });
+    expect(context.sources).toHaveLength(2);
+    expect(context.sources[1].start).toHaveBeenCalledWith(20, 0.5);
+  });
+
+  it("rejects changing channel playback mode before mutating audio", async () => {
+    const { stage, context } = await setupAudioStage();
+    const ordinary = [
+      {
+        id: "music",
+        type: "audio-channel",
+        children: [{ id: "theme", type: "sound", src: "theme" }],
+      },
+    ];
+    const controlled = [
+      {
+        ...ordinary[0],
+        playback: { commandId: 1, operation: "pause" },
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: ordinary });
+    const source = context.sources[0];
+
+    expect(() =>
+      stage.renderGraph({ prevAudio: ordinary, nextAudio: controlled }),
+    ).toThrow("cannot change command-controlled playback mode");
+    expect(source.stop).not.toHaveBeenCalled();
+    expect(stage._inspect().channels.get("music").control).toBeNull();
+  });
+
   it("validates effects when renderGraph is called directly", async () => {
     const { stage } = await setupAudioStage();
 

--- a/spec/util/normalizeAudio.spec.js
+++ b/spec/util/normalizeAudio.spec.js
@@ -161,6 +161,55 @@ describe("normalizeAudioRenderState", () => {
     ).toThrow("audio[0].interruption must be one of immediate, loopEnd");
   });
 
+  it("normalizes strict channel playback commands", () => {
+    const result = flattenAudioNodes([
+      {
+        id: "music",
+        type: "audio-channel",
+        loop: true,
+        playback: {
+          commandId: 42,
+          operation: "pause",
+        },
+        children: [{ id: "theme", type: "sound", src: "theme" }],
+      },
+    ]);
+
+    expect(result.channels[0].playback).toEqual({
+      commandId: 42,
+      operation: "pause",
+    });
+  });
+
+  it.each([
+    [
+      { commandId: -1, operation: "pause" },
+      "commandId must be a non-negative safe integer",
+    ],
+    [
+      { commandId: 1, operation: "play" },
+      "operation must be one of pause, resume",
+    ],
+    [
+      { commandId: 1, operation: "pause", positionMs: 0 },
+      "positionMs is not allowed for pause",
+    ],
+    [
+      { commandId: 1, operation: "pause", status: "paused" },
+      'unsupported playback field "status"',
+    ],
+  ])("rejects invalid channel playback command %#", (playback, message) => {
+    expect(() =>
+      flattenAudioNodes([
+        {
+          id: "music",
+          type: "audio-channel",
+          playback,
+        },
+      ]),
+    ).toThrow(message);
+  });
+
   it("normalizes strict playback commands", () => {
     const result = flattenAudioNodes([
       {
@@ -260,6 +309,35 @@ describe("normalizeAudioRenderState", () => {
       ]),
     ).toThrow(
       "audio[0].children[0].playback is not allowed when audio[0].loop is true",
+    );
+  });
+
+  it("rejects independent sound commands inside a controlled channel", () => {
+    expect(() =>
+      flattenAudioNodes([
+        {
+          id: "music",
+          type: "audio-channel",
+          playback: {
+            commandId: 1,
+            operation: "resume",
+          },
+          children: [
+            {
+              id: "track",
+              type: "sound",
+              src: "theme",
+              playback: {
+                commandId: 1,
+                operation: "play",
+                positionMs: 0,
+              },
+            },
+          ],
+        },
+      ]),
+    ).toThrow(
+      "audio[0].children[0].playback is not allowed when audio[0].playback is present",
     );
   });
 

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -476,6 +476,13 @@ const createChannelInstance = (channel, outputNode) => {
     pan: channel.pan ?? 0,
     loop: channel.loop ?? false,
     interruption: channel.interruption ?? "immediate",
+    playback: channel.playback ?? null,
+    control: channel.playback
+      ? {
+          commandId: -1,
+          status: "playing",
+        }
+      : null,
     outputNode,
     cleanupTimeoutId: null,
     deferredRemovalToken: null,
@@ -517,6 +524,9 @@ const createSoundInstance = ({ sound, channelNode, internalId }) => {
     playbackRateTransition: null,
     playbackPending: false,
     pendingTimeoutId: null,
+    pendingDelayMs: 0,
+    delayDeadlineMs: null,
+    channelPauseState: null,
     cleanupTimeoutId: null,
     playRequestId: 0,
     playback: sound.playback ?? null,
@@ -549,7 +559,7 @@ const createSoundInstance = ({ sound, channelNode, internalId }) => {
   };
 };
 
-const createSourceForSound = (sound) => {
+const createSourceForSound = (sound, startOffset = sound.startAt ?? 0) => {
   const context = getAudioContext();
   const audioBuffer = AudioAsset.getAsset(sound.src);
   debugAudio("asset lookup", {
@@ -587,7 +597,7 @@ const createSourceForSound = (sound) => {
     sound.onSourceEnded?.();
   };
 
-  const offset = sound.startAt ?? 0;
+  const offset = startOffset;
   const duration =
     sound.endAt !== null && sound.endAt !== undefined
       ? Math.max(sound.endAt - offset, 0)
@@ -597,7 +607,7 @@ const createSourceForSound = (sound) => {
   sound.sourceStartOffset = offset;
 
   if (source.loop && sound.endAt !== null && sound.endAt !== undefined) {
-    source.loopStart = offset;
+    source.loopStart = sound.startAt ?? 0;
     source.loopEnd = sound.endAt;
     source.start(startTime, offset);
   } else if (duration !== undefined) {
@@ -620,11 +630,17 @@ const createSourceForSound = (sound) => {
   return source;
 };
 
-const playSound = (sound) => {
+const playSound = (
+  sound,
+  { startOffset = sound.startAt ?? 0, startDelayMs = sound.startDelayMs } = {},
+) => {
   if (sound.pendingTimeoutId !== null) {
     clearTimeout(sound.pendingTimeoutId);
     sound.pendingTimeoutId = null;
   }
+  sound.delayDeadlineMs = null;
+  sound.pendingDelayMs = Math.max(0, startDelayMs ?? 0);
+  sound.channelPauseState = null;
 
   const context = getAudioContext();
   const playRequestId = (sound.playRequestId ?? 0) + 1;
@@ -637,7 +653,8 @@ const playSound = (sound) => {
     loop: sound.loop,
     volume: sound.volume,
     muted: sound.muted,
-    startDelayMs: sound.startDelayMs,
+    startDelayMs: sound.pendingDelayMs,
+    startOffset,
     contextState: context.state,
   });
   const needsResume =
@@ -649,8 +666,10 @@ const playSound = (sound) => {
     }
 
     sound.pendingTimeoutId = null;
+    sound.delayDeadlineMs = null;
+    sound.pendingDelayMs = 0;
     const previousSource = sound.source;
-    sound.source = createSourceForSound(sound);
+    sound.source = createSourceForSound(sound, startOffset);
     sound.playbackPending = false;
     if (previousSource && previousSource !== sound.source) {
       disconnect(previousSource);
@@ -668,8 +687,9 @@ const playSound = (sound) => {
       return;
     }
 
-    if (sound.startDelayMs > 0) {
-      sound.pendingTimeoutId = setTimeout(start, sound.startDelayMs);
+    if (sound.pendingDelayMs > 0) {
+      sound.delayDeadlineMs = Date.now() + sound.pendingDelayMs;
+      sound.pendingTimeoutId = setTimeout(start, sound.pendingDelayMs);
       return;
     }
 
@@ -688,6 +708,8 @@ const playSound = (sound) => {
 const stopSource = (sound, delayMs = 0) => {
   sound.playRequestId = (sound.playRequestId ?? 0) + 1;
   sound.playbackPending = false;
+  sound.pendingDelayMs = 0;
+  sound.delayDeadlineMs = null;
 
   if (sound.pendingTimeoutId !== null) {
     clearTimeout(sound.pendingTimeoutId);
@@ -1717,9 +1739,205 @@ export const createAudioStage = () => {
     return channelSounds;
   };
 
+  const getRemainingLegacyDelayMs = (sound) => {
+    if (sound.delayDeadlineMs === null) {
+      return Math.max(0, sound.pendingDelayMs);
+    }
+
+    return Math.max(0, sound.delayDeadlineMs - Date.now());
+  };
+
+  const getLegacyPlaybackOffset = (sound, context = getAudioContext()) => {
+    const source = sound.source;
+    const segmentStart = Math.max(0, toFiniteParamValue(sound.startAt, 0));
+    if (!source || sound.sourceStartedAt === null) {
+      return Math.max(
+        segmentStart,
+        toFiniteParamValue(sound.sourceStartOffset, segmentStart),
+      );
+    }
+
+    const startedAt = toFiniteParamValue(
+      sound.sourceStartedAt,
+      context.currentTime,
+    );
+    const elapsedSourceSeconds = integrateAudioParamValue(
+      source.playbackRate,
+      startedAt,
+      context.currentTime,
+    );
+    const startOffset = toFiniteParamValue(
+      sound.sourceStartOffset,
+      segmentStart,
+    );
+    const configuredEnd =
+      sound.endAt === null || sound.endAt === undefined
+        ? Number.NaN
+        : toFiniteParamValue(sound.endAt, Number.NaN);
+    const bufferEnd = toFiniteParamValue(
+      source.buffer?.duration,
+      Number.POSITIVE_INFINITY,
+    );
+    const segmentEnd = Number.isFinite(configuredEnd)
+      ? configuredEnd
+      : bufferEnd;
+    const absoluteOffset = startOffset + elapsedSourceSeconds;
+
+    if (source.loop && Number.isFinite(segmentEnd)) {
+      const loopDuration = segmentEnd - segmentStart;
+      if (loopDuration > 0) {
+        const relativeOffset =
+          (((absoluteOffset - segmentStart) % loopDuration) + loopDuration) %
+          loopDuration;
+        return segmentStart + relativeOffset;
+      }
+      return segmentStart;
+    }
+
+    return Math.max(segmentStart, Math.min(absoluteOffset, segmentEnd));
+  };
+
+  const stopLegacySourceForChannelPause = (sound) => {
+    const source = sound.source;
+    sound.playRequestId = (sound.playRequestId ?? 0) + 1;
+    sound.playbackPending = false;
+    sound.pendingDelayMs = 0;
+    sound.delayDeadlineMs = null;
+    if (sound.pendingTimeoutId !== null) {
+      clearTimeout(sound.pendingTimeoutId);
+      sound.pendingTimeoutId = null;
+    }
+    if (!source) return;
+
+    source.onended = null;
+    sound.source = null;
+    sound.sourceStartedAt = null;
+    try {
+      source.stop(getAudioContext().currentTime);
+    } catch {
+      // Stopping an already-stopped source is harmless while pausing.
+    }
+    disconnect(source);
+  };
+
+  const pauseSoundForChannel = (sound) => {
+    if (sound.control || sound.channelPauseState) {
+      return;
+    }
+
+    if (sound.source && !sound.sourceEnded) {
+      const offset = getLegacyPlaybackOffset(sound);
+      sound.channelPauseState = {
+        kind: "active",
+        offset,
+        remainingDelayMs: 0,
+      };
+      stopLegacySourceForChannelPause(sound);
+      sound.sourceEnded = false;
+      return;
+    }
+
+    if (sound.playbackPending || sound.pendingTimeoutId !== null) {
+      const remainingDelayMs = getRemainingLegacyDelayMs(sound);
+      sound.channelPauseState = {
+        kind: "pending",
+        offset: sound.startAt,
+        remainingDelayMs,
+      };
+      stopLegacySourceForChannelPause(sound);
+      sound.sourceEnded = false;
+      return;
+    }
+
+    sound.channelPauseState = { kind: "ended" };
+  };
+
+  const stageSoundForPausedChannel = (sound) => {
+    sound.sourceEnded = false;
+    sound.playbackPending = false;
+    sound.channelPauseState = {
+      kind: "pending",
+      offset: sound.startAt,
+      remainingDelayMs: sound.startDelayMs,
+    };
+  };
+
+  const resumeSoundFromChannelPause = (sound) => {
+    const pauseState = sound.channelPauseState;
+    if (!pauseState) {
+      return;
+    }
+
+    sound.channelPauseState = null;
+    if (pauseState.kind === "ended") {
+      return;
+    }
+
+    const segmentEnd =
+      sound.endAt === null || sound.endAt === undefined
+        ? Number.POSITIVE_INFINITY
+        : sound.endAt;
+    if (!sound.loop && pauseState.offset >= segmentEnd) {
+      sound.sourceEnded = true;
+      return;
+    }
+
+    playSound(sound, {
+      startOffset: pauseState.offset,
+      startDelayMs: pauseState.remainingDelayMs,
+    });
+  };
+
+  const syncSoundWithChannelPlayback = (sound) => {
+    if (sound.control) {
+      return;
+    }
+
+    const channel = sound.channelId ? channels.get(sound.channelId) : null;
+    if (channel?.control?.status === "paused") {
+      if (
+        !sound.source &&
+        !sound.playbackPending &&
+        !sound.channelPauseState &&
+        !sound.sourceEnded
+      ) {
+        stageSoundForPausedChannel(sound);
+      } else {
+        pauseSoundForChannel(sound);
+      }
+      return;
+    }
+
+    resumeSoundFromChannelPause(sound);
+  };
+
+  const acceptChannelPlaybackCommand = (channel, command) => {
+    const control = channel.control;
+    if (!control || command.commandId <= control.commandId) {
+      return false;
+    }
+
+    control.commandId = command.commandId;
+    channel.playback = command;
+    const nextStatus = command.operation === "pause" ? "paused" : "playing";
+    if (nextStatus === control.status) {
+      return true;
+    }
+
+    if (command.operation === "pause") {
+      control.status = "paused";
+      getCurrentChannelSounds(channel.id).forEach(pauseSoundForChannel);
+      return true;
+    }
+
+    control.status = "playing";
+    getCurrentChannelSounds(channel.id).forEach(resumeSoundFromChannelPause);
+    return true;
+  };
+
   const restartLoopingChannelIfComplete = (channelId) => {
     const channel = channels.get(channelId);
-    if (!channel?.loop) {
+    if (!channel?.loop || channel.control?.status === "paused") {
       return;
     }
 
@@ -1749,6 +1967,12 @@ export const createAudioStage = () => {
 
   const finishChannelLoop = (channelId) => {
     for (const sound of getCurrentChannelSounds(channelId)) {
+      if (sound.channelPauseState?.kind === "pending") {
+        sound.channelPauseState = { kind: "ended" };
+        sound.sourceEnded = true;
+        continue;
+      }
+
       if (!sound.playbackPending) {
         continue;
       }
@@ -1805,6 +2029,9 @@ export const createAudioStage = () => {
         targetValue: channel.pan,
         transition: panTransition,
       });
+      if (created.control) {
+        acceptChannelPlaybackCommand(created, channel.playback);
+      }
       return created;
     }
 
@@ -1824,6 +2051,9 @@ export const createAudioStage = () => {
 
       if (loopInterrupted) {
         finishChannelLoop(channel.id);
+      }
+      if (existing.control) {
+        acceptChannelPlaybackCommand(existing, channel.playback);
       }
 
       if (volumeChanged && volumeTransition) {
@@ -1865,6 +2095,9 @@ export const createAudioStage = () => {
       targetValue: channel.pan,
       transition: panTransition,
     });
+    if (created.control) {
+      acceptChannelPlaybackCommand(created, channel.playback);
+    }
     return created;
   };
 
@@ -1963,6 +2196,8 @@ export const createAudioStage = () => {
     );
     if (instance.control) {
       acceptControlledCommand(instance, sound.playback);
+    } else if (parentChannel.control?.status === "paused") {
+      stageSoundForPausedChannel(instance);
     } else {
       playSound(instance);
     }
@@ -2272,6 +2507,8 @@ export const createAudioStage = () => {
         stopControlledSource(instance);
         startControlledPlayback(instance, 0);
       }
+    } else {
+      syncSoundWithChannelPlayback(instance);
     }
   };
 
@@ -2314,6 +2551,19 @@ export const createAudioStage = () => {
       if (nextChannelById.has(id)) {
         throw new Error(
           `Input error: audio node "${id}" cannot change type from "sound" to "audio-channel" between render states.`,
+        );
+      }
+    }
+
+    for (const [id, prevChannel] of prevChannelById) {
+      const nextChannel = nextChannelById.get(id);
+      if (!nextChannel) continue;
+
+      const wasControlled = prevChannel.playback !== undefined;
+      const isControlled = nextChannel.playback !== undefined;
+      if (wasControlled !== isControlled) {
+        throw new Error(
+          `Input error: audio-channel "${id}" cannot change command-controlled playback mode while retained.`,
         );
       }
     }

--- a/src/schemas/audio/audio-channel.yaml
+++ b/src/schemas/audio/audio-channel.yaml
@@ -37,6 +37,23 @@ properties:
     enum: [immediate, loopEnd]
     description: How active channel playback stops when the channel is interrupted.
     default: immediate
+  playback:
+    type: object
+    description: Optional cursor-preserving channel transport instruction
+    additionalProperties: false
+    required:
+      - commandId
+      - operation
+    properties:
+      commandId:
+        type: integer
+        minimum: 0
+        maximum: 9007199254740991
+        description: Monotonically increasing command identity
+      operation:
+        type: string
+        enum: [pause, resume]
+        description: Channel transport operation
   children:
     type: array
     description: Sound nodes owned by this channel

--- a/src/types.js
+++ b/src/types.js
@@ -665,6 +665,12 @@
  */
 
 /**
+ * @typedef {Object} AudioChannelPlaybackCommand
+ * @property {number} commandId - Monotonically increasing command identity
+ * @property {'pause' | 'resume'} operation - Channel transport operation
+ */
+
+/**
  * @typedef {Object} AudioChannelElement
  * @property {string} id - Unique identifier
  * @property {string} type - Should be "audio-channel"
@@ -673,6 +679,7 @@
  * @property {number} [pan=0] - Stereo pan from -1 to 1
  * @property {boolean} [loop=false] - Whether to repeat the complete child sound schedule
  * @property {'immediate' | 'loopEnd'} [interruption='immediate'] - Whether interruption stops immediately or finishes the active schedule iteration
+ * @property {AudioChannelPlaybackCommand} [playback] - Optional cursor-preserving channel transport instruction
  * @property {SoundElement[]} [children=[]] - Sound nodes owned by the channel
  */
 

--- a/src/util/normalizeAudio.js
+++ b/src/util/normalizeAudio.js
@@ -9,7 +9,9 @@ const AUDIO_PLAYBACK_OPERATIONS = new Set([
   "stop",
   "seek",
 ]);
+const AUDIO_CHANNEL_PLAYBACK_OPERATIONS = new Set(["pause", "resume"]);
 const AUDIO_PLAYBACK_POSITION_OPERATIONS = new Set(["play", "seek"]);
+const NO_AUDIO_PLAYBACK_POSITION_OPERATIONS = new Set();
 const AUDIO_PLAYBACK_KEYS = new Set(["commandId", "operation", "positionMs"]);
 const AUDIO_TRANSITION_TYPE = "audio-transition";
 const AUDIO_EFFECT_TYPES = new Set([AUDIO_TRANSITION_TYPE]);
@@ -103,7 +105,15 @@ const assertUniqueId = (ids, id, path) => {
   ids.add(id);
 };
 
-const normalizePlaybackCommand = (playback, path) => {
+const normalizePlaybackCommand = (
+  playback,
+  path,
+  {
+    operations = AUDIO_PLAYBACK_OPERATIONS,
+    operationList = "play, pause, resume, stop, seek",
+    positionOperations = AUDIO_PLAYBACK_POSITION_OPERATIONS,
+  } = {},
+) => {
   assertRecord(playback, path);
 
   for (const key of Object.keys(playback)) {
@@ -120,15 +130,13 @@ const normalizePlaybackCommand = (playback, path) => {
     );
   }
 
-  if (!AUDIO_PLAYBACK_OPERATIONS.has(playback.operation)) {
+  if (!operations.has(playback.operation)) {
     throw new Error(
-      `Input error: ${path}.operation must be one of play, pause, resume, stop, seek.`,
+      `Input error: ${path}.operation must be one of ${operationList}.`,
     );
   }
 
-  const requiresPosition = AUDIO_PLAYBACK_POSITION_OPERATIONS.has(
-    playback.operation,
-  );
+  const requiresPosition = positionOperations.has(playback.operation);
   if (requiresPosition) {
     if (
       typeof playback.positionMs !== "number" ||
@@ -230,6 +238,15 @@ const validateChannel = (
     throw new Error(`Input error: ${path}.children must be an array.`);
   }
 
+  const playback =
+    node.playback === undefined
+      ? undefined
+      : normalizePlaybackCommand(node.playback, `${path}.playback`, {
+          operations: AUDIO_CHANNEL_PLAYBACK_OPERATIONS,
+          operationList: "pause, resume",
+          positionOperations: NO_AUDIO_PLAYBACK_POSITION_OPERATIONS,
+        });
+
   flattenedChannels.push({
     id: node.id,
     type: "audio-channel",
@@ -238,6 +255,7 @@ const validateChannel = (
     pan: node.pan ?? 0,
     loop: node.loop ?? false,
     interruption,
+    ...(playback ? { playback } : {}),
   });
 
   for (const [index, child] of (node.children ?? []).entries()) {
@@ -263,6 +281,12 @@ const validateChannel = (
     if (node.loop === true && child.playback !== undefined) {
       throw new Error(
         `Input error: ${childPath}.playback is not allowed when ${path}.loop is true.`,
+      );
+    }
+
+    if (playback && child.playback !== undefined) {
+      throw new Error(
+        `Input error: ${childPath}.playback is not allowed when ${path}.playback is present.`,
       );
     }
 

--- a/vt/specs/audio/channel-playback-controls.yaml
+++ b/vt/specs/audio/channel-playback-controls.yaml
@@ -1,0 +1,65 @@
+---
+title: Audio Manual - Channel Pause and Resume
+description: Browser fixture for cursor-preserving transport across a looping multi-sound channel.
+skipScreenshot: true
+specs:
+  - state 1 is silent so the first playback starts from a user gesture
+  - state 2 starts the looping channel with the second sound delayed by one second
+  - state 3 pauses both active cursors and any remaining delay
+  - remain paused for several seconds; no sound or new schedule iteration should start
+  - state 4 resumes from the captured cursors and remaining delay instead of restarting
+  - state 5 removes the complete channel
+---
+states:
+  - id: channel-playback-ready
+    audio: []
+  - id: channel-playback-playing
+    audio:
+      - id: channel-playback-music
+        type: audio-channel
+        loop: true
+        playback:
+          commandId: 1
+          operation: resume
+        children:
+          - id: channel-playback-first
+            type: sound
+            src: bgm-1
+          - id: channel-playback-second
+            type: sound
+            src: bgm-2
+            startDelayMs: 1000
+  - id: channel-playback-paused
+    audio:
+      - id: channel-playback-music
+        type: audio-channel
+        loop: true
+        playback:
+          commandId: 2
+          operation: pause
+        children:
+          - id: channel-playback-first
+            type: sound
+            src: bgm-1
+          - id: channel-playback-second
+            type: sound
+            src: bgm-2
+            startDelayMs: 1000
+  - id: channel-playback-resumed
+    audio:
+      - id: channel-playback-music
+        type: audio-channel
+        loop: true
+        playback:
+          commandId: 3
+          operation: resume
+        children:
+          - id: channel-playback-first
+            type: sound
+            src: bgm-1
+          - id: channel-playback-second
+            type: sound
+            src: bgm-2
+            startDelayMs: 1000
+  - id: channel-playback-stopped
+    audio: []


### PR DESCRIPTION
## Summary

- add strict monotonic pause/resume commands to audio channels
- preserve every active child cursor and pending start delay while paused, including looping channel schedules
- reject mixed channel/sound transport ownership and retained playback-mode changes before reconciliation
- document the contract, add a real browser audio fixture, and bump the patch version to 1.31.1

## Verification

- bun run test — 764 tests passed
- bun run lint
- bun run build
- Chromium/Web Audio fixture — no source starts during a 1.2s pause; active audio resumed at its captured cursor and the delayed child used only its remaining delay