### PR TITLE
fix(audio): preserve channel playback state

### DIFF
--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -1963,6 +1963,114 @@ describe("AudioStage graph rendering", () => {
     expect(findCurrentSound(stage, "outro").pendingTimeoutId).not.toBeNull();
   });
 
+  it("preserves a delayed child's remaining delay after a channel loop restarts", async () => {
+    const { stage, context } = await setupAudioStage({
+      assetMap: new Map([
+        ["intro", { duration: 10 }],
+        ["outro", { duration: 10 }],
+      ]),
+    });
+    const channel = (commandId, operation) => [
+      {
+        id: "music",
+        type: "audio-channel",
+        loop: true,
+        playback: { commandId, operation },
+        children: [
+          { id: "intro", type: "sound", src: "intro" },
+          {
+            id: "outro",
+            type: "sound",
+            src: "outro",
+            startDelayMs: 100,
+          },
+        ],
+      },
+    ];
+    const playing = channel(1, "resume");
+    const paused = channel(2, "pause");
+    const resumed = channel(3, "resume");
+
+    stage.renderGraph({ nextAudio: playing });
+    context.sources[0].onended();
+    vi.advanceTimersByTime(100);
+    context.sources[1].onended();
+
+    expect(context.sources).toHaveLength(3);
+    vi.advanceTimersByTime(40);
+    context.currentTime = 10.04;
+    stage.renderGraph({ prevAudio: playing, nextAudio: paused });
+
+    expect(findCurrentSound(stage, "outro").channelPauseState).toEqual({
+      kind: "pending",
+      offset: 0,
+      remainingDelayMs: 60,
+    });
+
+    context.currentTime = 20;
+    stage.renderGraph({ prevAudio: paused, nextAudio: resumed });
+    vi.advanceTimersByTime(59);
+    expect(context.sources).toHaveLength(4);
+    vi.advanceTimersByTime(1);
+    expect(context.sources).toHaveLength(5);
+    expect(context.sources[4].start).toHaveBeenCalledWith(20, 0);
+  });
+
+  it("preserves a resumed cursor when a channel is paused before the audio context resumes", async () => {
+    const { stage, context } = await setupAudioStage({
+      assetMap: new Map([["theme", { duration: 10 }]]),
+    });
+    const channel = (commandId, operation) => [
+      {
+        id: "music",
+        type: "audio-channel",
+        playback: { commandId, operation },
+        children: [{ id: "theme", type: "sound", src: "theme" }],
+      },
+    ];
+    const playing = channel(1, "resume");
+    const paused = channel(2, "pause");
+    const pendingResume = channel(3, "resume");
+    const pausedAgain = channel(4, "pause");
+    const resumed = channel(5, "resume");
+
+    stage.renderGraph({ nextAudio: playing });
+    context.currentTime = 10.5;
+    stage.renderGraph({ prevAudio: playing, nextAudio: paused });
+
+    let resolveResume;
+    context.state = "suspended";
+    context.resume.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveResume = () => {
+            context.state = "running";
+            resolve();
+          };
+        }),
+    );
+    stage.renderGraph({ prevAudio: paused, nextAudio: pendingResume });
+    stage.renderGraph({
+      prevAudio: pendingResume,
+      nextAudio: pausedAgain,
+    });
+
+    expect(findCurrentSound(stage, "theme").channelPauseState).toEqual({
+      kind: "pending",
+      offset: 0.5,
+      remainingDelayMs: 0,
+    });
+
+    resolveResume();
+    await flushPromises();
+    expect(context.sources).toHaveLength(1);
+
+    context.currentTime = 20;
+    stage.renderGraph({ prevAudio: pausedAgain, nextAudio: resumed });
+    expect(context.sources).toHaveLength(2);
+    expect(context.sources[1].start).toHaveBeenCalledWith(20, 0.5);
+  });
+
   it("starts children only after an initially paused channel resumes", async () => {
     const { stage, context, getAsset } = await setupAudioStage();
     const paused = [
@@ -2106,6 +2214,121 @@ describe("AudioStage graph rendering", () => {
     stage.renderGraph({ prevAudio: paused, nextAudio: resumed });
 
     expect(context.sources[1].start).toHaveBeenCalledWith(20, 4.5, 3.5);
+  });
+
+  it("preserves playback-rate history when capturing a channel cursor", async () => {
+    const { stage, context } = await setupAudioStage({
+      assetMap: new Map([["theme", { duration: 10 }]]),
+    });
+    const channel = (commandId, operation, playbackRate) => [
+      {
+        id: "music",
+        type: "audio-channel",
+        playback: { commandId, operation },
+        children: [
+          {
+            id: "theme",
+            type: "sound",
+            src: "theme",
+            playbackRate,
+          },
+        ],
+      },
+    ];
+    const playing = channel(1, "resume", 1);
+    const faster = channel(1, "resume", 2);
+    const paused = channel(2, "pause", 2);
+
+    stage.renderGraph({ nextAudio: playing });
+    context.currentTime = 12;
+    stage.renderGraph({ prevAudio: playing, nextAudio: faster });
+    context.currentTime = 13;
+    stage.renderGraph({ prevAudio: faster, nextAudio: paused });
+
+    expect(
+      findCurrentSound(stage, "theme").channelPauseState.offset,
+    ).toBeCloseTo(4);
+  });
+
+  it("uses the source's effective loop points when capturing a channel cursor", async () => {
+    const { stage, context } = await setupAudioStage({
+      assetMap: new Map([["theme", { duration: 10 }]]),
+    });
+    const channel = (commandId, operation) => [
+      {
+        id: "music",
+        type: "audio-channel",
+        playback: { commandId, operation },
+        children: [
+          {
+            id: "theme",
+            type: "sound",
+            src: "theme",
+            loop: true,
+            startAt: 5,
+          },
+        ],
+      },
+    ];
+    const playing = channel(1, "resume");
+    const paused = channel(2, "pause");
+    const resumed = channel(3, "resume");
+
+    stage.renderGraph({ nextAudio: playing });
+    expect(context.sources[0].loopStart).toBe(0);
+    context.currentTime = 16;
+    stage.renderGraph({ prevAudio: playing, nextAudio: paused });
+
+    expect(
+      findCurrentSound(stage, "theme").channelPauseState.offset,
+    ).toBeCloseTo(1);
+
+    context.currentTime = 20;
+    stage.renderGraph({ prevAudio: paused, nextAudio: resumed });
+    expect(context.sources[1].start).toHaveBeenCalledTimes(1);
+    expect(context.sources[1].start.mock.calls[0][0]).toBe(20);
+    expect(context.sources[1].start.mock.calls[0][1]).toBeCloseTo(1);
+  });
+
+  it("preserves a wrapped channel cursor when child looping is disabled", async () => {
+    const { stage, context } = await setupAudioStage({
+      assetMap: new Map([["theme", { duration: 10 }]]),
+    });
+    const channel = (commandId, operation, loop) => [
+      {
+        id: "music",
+        type: "audio-channel",
+        playback: { commandId, operation },
+        children: [
+          {
+            id: "theme",
+            type: "sound",
+            src: "theme",
+            loop,
+          },
+        ],
+      },
+    ];
+    const looping = channel(1, "resume", true);
+    const notLooping = channel(1, "resume", false);
+    const paused = channel(2, "pause", false);
+    const resumed = channel(3, "resume", false);
+
+    stage.renderGraph({ nextAudio: looping });
+    context.currentTime = 22;
+    stage.renderGraph({ prevAudio: looping, nextAudio: notLooping });
+    context.currentTime = 23;
+    stage.renderGraph({ prevAudio: notLooping, nextAudio: paused });
+
+    expect(
+      findCurrentSound(stage, "theme").channelPauseState.offset,
+    ).toBeCloseTo(3);
+
+    context.currentTime = 30;
+    stage.renderGraph({ prevAudio: paused, nextAudio: resumed });
+    expect(context.sources[1].start).toHaveBeenCalledTimes(1);
+    expect(context.sources[1].start.mock.calls[0][0]).toBe(30);
+    expect(context.sources[1].start.mock.calls[0][1]).toBeCloseTo(3);
   });
 
   it("keeps continuing sounds synchronized when they move across a paused channel", async () => {

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -525,6 +525,7 @@ const createSoundInstance = ({ sound, channelNode, internalId }) => {
     playbackPending: false,
     pendingTimeoutId: null,
     pendingDelayMs: 0,
+    pendingStartOffset: null,
     delayDeadlineMs: null,
     channelPauseState: null,
     cleanupTimeoutId: null,
@@ -640,6 +641,7 @@ const playSound = (
   }
   sound.delayDeadlineMs = null;
   sound.pendingDelayMs = Math.max(0, startDelayMs ?? 0);
+  sound.pendingStartOffset = startOffset;
   sound.channelPauseState = null;
 
   const context = getAudioContext();
@@ -671,6 +673,7 @@ const playSound = (
     const previousSource = sound.source;
     sound.source = createSourceForSound(sound, startOffset);
     sound.playbackPending = false;
+    sound.pendingStartOffset = null;
     if (previousSource && previousSource !== sound.source) {
       disconnect(previousSource);
     }
@@ -709,6 +712,7 @@ const stopSource = (sound, delayMs = 0) => {
   sound.playRequestId = (sound.playRequestId ?? 0) + 1;
   sound.playbackPending = false;
   sound.pendingDelayMs = 0;
+  sound.pendingStartOffset = null;
   sound.delayDeadlineMs = null;
 
   if (sound.pendingTimeoutId !== null) {
@@ -1784,17 +1788,29 @@ export const createAudioStage = () => {
     const absoluteOffset = startOffset + elapsedSourceSeconds;
 
     if (source.loop && Number.isFinite(segmentEnd)) {
-      const loopDuration = segmentEnd - segmentStart;
+      const loopStart = Math.max(0, toFiniteParamValue(source.loopStart, 0));
+      const configuredLoopEnd = toFiniteParamValue(source.loopEnd, 0);
+      const loopEnd =
+        configuredLoopEnd > loopStart ? configuredLoopEnd : segmentEnd;
+      const loopDuration = loopEnd - loopStart;
       if (loopDuration > 0) {
         const relativeOffset =
-          (((absoluteOffset - segmentStart) % loopDuration) + loopDuration) %
+          (((absoluteOffset - loopStart) % loopDuration) + loopDuration) %
           loopDuration;
-        return segmentStart + relativeOffset;
+        return loopStart + relativeOffset;
       }
-      return segmentStart;
+      return loopStart;
     }
 
     return Math.max(segmentStart, Math.min(absoluteOffset, segmentEnd));
+  };
+
+  const checkpointLegacyPlaybackOffset = (
+    sound,
+    context = getAudioContext(),
+  ) => {
+    sound.sourceStartOffset = getLegacyPlaybackOffset(sound, context);
+    sound.sourceStartedAt = context.currentTime;
   };
 
   const stopLegacySourceForChannelPause = (sound) => {
@@ -1802,6 +1818,7 @@ export const createAudioStage = () => {
     sound.playRequestId = (sound.playRequestId ?? 0) + 1;
     sound.playbackPending = false;
     sound.pendingDelayMs = 0;
+    sound.pendingStartOffset = null;
     sound.delayDeadlineMs = null;
     if (sound.pendingTimeoutId !== null) {
       clearTimeout(sound.pendingTimeoutId);
@@ -1825,6 +1842,18 @@ export const createAudioStage = () => {
       return;
     }
 
+    if (sound.playbackPending || sound.pendingTimeoutId !== null) {
+      const remainingDelayMs = getRemainingLegacyDelayMs(sound);
+      sound.channelPauseState = {
+        kind: "pending",
+        offset: sound.pendingStartOffset ?? sound.startAt,
+        remainingDelayMs,
+      };
+      stopLegacySourceForChannelPause(sound);
+      sound.sourceEnded = false;
+      return;
+    }
+
     if (sound.source && !sound.sourceEnded) {
       const offset = getLegacyPlaybackOffset(sound);
       sound.channelPauseState = {
@@ -1837,24 +1866,13 @@ export const createAudioStage = () => {
       return;
     }
 
-    if (sound.playbackPending || sound.pendingTimeoutId !== null) {
-      const remainingDelayMs = getRemainingLegacyDelayMs(sound);
-      sound.channelPauseState = {
-        kind: "pending",
-        offset: sound.startAt,
-        remainingDelayMs,
-      };
-      stopLegacySourceForChannelPause(sound);
-      sound.sourceEnded = false;
-      return;
-    }
-
     sound.channelPauseState = { kind: "ended" };
   };
 
   const stageSoundForPausedChannel = (sound) => {
     sound.sourceEnded = false;
     sound.playbackPending = false;
+    sound.pendingStartOffset = null;
     sound.channelPauseState = {
       kind: "pending",
       offset: sound.startAt,
@@ -1979,6 +1997,7 @@ export const createAudioStage = () => {
 
       sound.playRequestId = (sound.playRequestId ?? 0) + 1;
       sound.playbackPending = false;
+      sound.pendingStartOffset = null;
       sound.sourceEnded = true;
       if (sound.pendingTimeoutId !== null) {
         clearTimeout(sound.pendingTimeoutId);
@@ -2419,6 +2438,15 @@ export const createAudioStage = () => {
       (loopChanged || playbackRateChanged)
     ) {
       captureControlledPosition(instance);
+    }
+    if (
+      !instance.control &&
+      (loopChanged || playbackRateChanged) &&
+      instance.source &&
+      !instance.sourceEnded &&
+      !instance.playbackPending
+    ) {
+      checkpointLegacyPlaybackOffset(instance);
     }
 
     if (instance.channelId !== sound.channelId) {


### PR DESCRIPTION
## Summary

- preserve delayed child state across looping channel pause and resume
- retain pending resume offsets while the audio context is suspended
- capture cursors using playback-rate history and effective source loop points
- checkpoint wrapped cursors before changing child loop mode
- add focused regressions for each transport edge case

## Tests

- bun run test (769 tests)