### PR TITLE
feat(animations): support non-blocking update loops

### DIFF
--- a/docs/animation-implementation-plan.md
+++ b/docs/animation-implementation-plan.md
@@ -1,6 +1,6 @@
 # Animation Implementation Plan
 
-Last updated: 2026-04-23
+Last updated: 2026-07-29
 
 ## Goal
 
@@ -25,6 +25,8 @@ Current runtime shape:
 - transition supports `prev` and `next` tween composition with optional `mask`
 - transition supports shader `compositor` with top-level `tween.uProgress`
 - element shader filters are supported through `elements[].filters`
+- update playback supports positive speed multipliers and infinite,
+  non-blocking loops
 
 Primary files involved today:
 
@@ -98,6 +100,8 @@ Key rules:
   `translateX` / `translateY`
 - a single tween cannot combine `x` with `translateX`, or `y` with `translateY`
 - `update` and `transition` support optional `playback.continuity: persistent`
+- `update` and `transition` support optional positive `playback.speed`
+- `update` supports optional `playback.loop: true`
 - `transition` uses `prev`, `next`, and optional `mask`
 - `transition` may define:
   - `prev` only
@@ -234,8 +238,7 @@ animations:
 Implemented contract:
 
 - `playback` is optional on `update` and `transition`
-- `playback.continuity` currently supports one value:
-  - `persistent`
+- `playback.continuity` supports `render` and `persistent`
 - when omitted, `update` keeps current render-scoped behavior
 - when omitted, `transition` keeps current render-scoped behavior
 - when present on `update`, the same animation should continue across later
@@ -274,6 +277,48 @@ Primary runtime files:
 - `src/plugins/animations/planAnimations.js`
 - `src/plugins/animations/updateAnimationDispatch.js`
 - `src/util/diffElements.js`
+
+## Step 5B: Add Looping Update Playback
+
+Status:
+
+- complete
+
+Public interface:
+
+```yaml
+animations:
+  - id: "ambient-pulse"
+    targetId: "portrait"
+    type: "update"
+    playback:
+      continuity: "persistent"
+      speed: 1.5
+      loop: true
+    tween:
+      scaleX:
+        initialValue: 1
+        keyframes:
+          - duration: 600
+            value: 1.05
+            easing: "easeInOutSine"
+          - duration: 600
+            value: 1
+            easing: "easeInOutSine"
+```
+
+Implemented contract:
+
+- looping is valid only for `type: update`
+- the timeline wraps by its finite positive duration after applying playback
+  speed
+- ticked and manually sampled playback use the same deterministic phase
+- loops never enter render completion tracking
+- loops never emit animation completion
+- cancellation or omission stops a loop without synthesizing completion
+- looping transitions and loop-plus-`complete` configurations are rejected
+- persistent continuity may carry the same loop across compatible renders;
+  changed tween or playback configuration restarts it
 
 ## Step 6: Keep Mask Transition As The Reveal Primitive
 

--- a/docs/animation-model.md
+++ b/docs/animation-model.md
@@ -1,6 +1,6 @@
 # Animation Model
 
-Last updated: 2026-04-23
+Last updated: 2026-07-29
 
 See also:
 
@@ -26,6 +26,8 @@ The runtime now exposes:
 - `tween` as the motion payload
 - `mask` only inside `transition`
 - optional `playback.continuity: render | persistent` on `update` and `transition`
+- optional positive `playback.speed` on `update` and `transition`
+- optional infinite `playback.loop` on `update`
 
 Current known runtime limitations are tracked in
 `docs/animation-implementation-plan.md`.
@@ -106,6 +108,8 @@ handoff, including masked reveals, dissolves, exits, and replacements.
 
 - `tween`
 - `playback.continuity`
+- `playback.speed`
+- `playback.loop`
 
 `update` does not support:
 
@@ -138,6 +142,7 @@ Use it for:
 - `next.tween`
 - `mask`
 - `playback.continuity`
+- `playback.speed`
 - `compositor`
 
 `transition` may define:
@@ -240,7 +245,7 @@ animations:
           easing: "easeOutQuad"
 ```
 
-## Playback Continuity
+## Playback
 
 ```yaml
 animations:
@@ -249,6 +254,8 @@ animations:
     type: "update"
     playback:
       continuity: "persistent"
+      speed: 1
+      loop: true
     tween:
       scaleX:
         keyframes:
@@ -275,8 +282,39 @@ animations:
 - `playback.continuity` currently supports two values:
   - `render`
   - `persistent`
+- `playback.speed` is an optional finite number greater than zero:
+  - `1` is authored speed
+  - `2` is twice as fast
+  - `0.5` is half speed
+- `playback.loop` is an optional boolean that defaults to `false`
+- `playback.loop: true` is valid only on `type: update`
 - `render` is explicit render-scoped behavior and is equivalent to omitting
   `playback`
+
+### Looping Updates
+
+`playback.loop: true` repeats the complete update timeline indefinitely. Speed
+is applied before the timeline wraps, so looping and playback speed compose
+deterministically.
+
+A looping update is ambient playback:
+
+- it is considered settled as soon as it starts
+- it never blocks the render's `renderComplete` event
+- it does not emit animation completion after an iteration
+- removing, replacing, or invalidating it cancels the loop without turning
+  cancellation into completion
+- changing its tween or playback configuration restarts it from the beginning
+
+Looping transitions are rejected. A transition owns a previous/next visual
+handoff and must settle into the next render state; repeating that handoff would
+leave ownership and completion ambiguous.
+
+A looping animation also cannot define `complete`. Infinite playback has no
+reachable completion point. A future finite repetition contract, if needed,
+must use a separate iteration count and complete only after its last iteration.
+
+Looping requires a finite authored duration greater than zero.
 
 ### Meaning For `update`
 
@@ -342,14 +380,16 @@ normal `transition`:
 
 ### Render Completion Rule
 
-Persistent continuity should not keep the current render open forever.
+Persistent and looping playback must not keep a render open indefinitely.
 
 So the contract is:
 
-- a persistent animation still starts as tracked work for the render that started it
-- if that animation finishes before any later render carries it forward, it completes normally and contributes to that render's `renderComplete`
-- if a later render reuses that in-flight animation through `playback.continuity: persistent`, that animation stops contributing to render completion from that point onward
-- after continuity has carried it into a later render, its eventual finish must not trigger `renderComplete` for either the old render or the newer render
+- finite render-scoped animations contribute to `renderComplete`
+- persistent animations do not contribute to `renderComplete`
+- looping animations do not contribute to `renderComplete`, regardless of
+  continuity mode
+- `renderComplete` fires after all other tracked work settles while ambient
+  animations continue independently
 
 ## Transition Examples
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -2022,6 +2022,238 @@ describe("RouteGraphics public API", () => {
     expect(eventHandler.mock.calls).toHaveLength(eventCountAfterRender);
   });
 
+  it("emits renderComplete immediately while a render-scoped update keeps looping", async () => {
+    const eventHandler = vi.fn();
+    const { app, pixiMock } = await setupRouteGraphics({
+      initOptions: {
+        eventHandler,
+      },
+      pluginsFactory: async () => {
+        const [{ rectPlugin }, { tweenPlugin }] = await Promise.all([
+          import("../src/plugins/elements/rect/index.js"),
+          import("../src/plugins/animations/tween/index.js"),
+        ]);
+
+        return {
+          elements: [rectPlugin],
+          animations: [tweenPlugin],
+          audio: [],
+        };
+      },
+    });
+
+    const frameTick = getAutoAnimationTick(pixiMock);
+
+    app.render({
+      id: "loop-baseline",
+      elements: [
+        {
+          id: "ambient",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+      ],
+    });
+
+    eventHandler.mockClear();
+
+    app.render({
+      id: "loop-active",
+      elements: [
+        {
+          id: "ambient",
+          type: "rect",
+          x: 100,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+      ],
+      animations: [
+        {
+          id: "ambient-drift",
+          targetId: "ambient",
+          type: "update",
+          playback: {
+            speed: 2,
+            loop: true,
+          },
+          tween: {
+            x: {
+              initialValue: 0,
+              keyframes: [{ duration: 1000, value: 100, easing: "linear" }],
+            },
+          },
+        },
+      ],
+    });
+
+    expect(eventHandler).toHaveBeenCalledWith("renderComplete", {
+      id: "loop-active",
+      aborted: false,
+    });
+
+    const eventCountAfterRender = eventHandler.mock.calls.length;
+
+    frameTick({ deltaMS: 250 });
+    expect(app.findElementByLabel("ambient")?.x).toBeCloseTo(50);
+
+    frameTick({ deltaMS: 250 });
+    expect(app.findElementByLabel("ambient")?.x).toBeCloseTo(0);
+    expect(eventHandler.mock.calls).toHaveLength(eventCountAfterRender);
+
+    frameTick({ deltaMS: 125 });
+    expect(app.findElementByLabel("ambient")?.x).toBeCloseTo(25);
+    expect(eventHandler.mock.calls).toHaveLength(eventCountAfterRender);
+  });
+
+  it("continues a persistent loop across unrelated renders and cancels it when omitted", async () => {
+    const eventHandler = vi.fn();
+    const { app, pixiMock } = await setupRouteGraphics({
+      initOptions: {
+        eventHandler,
+      },
+      pluginsFactory: async () => {
+        const [{ rectPlugin }, { tweenPlugin }] = await Promise.all([
+          import("../src/plugins/elements/rect/index.js"),
+          import("../src/plugins/animations/tween/index.js"),
+        ]);
+
+        return {
+          elements: [rectPlugin],
+          animations: [tweenPlugin],
+          audio: [],
+        };
+      },
+    });
+
+    const frameTick = getAutoAnimationTick(pixiMock);
+    const loopingAnimation = {
+      id: "persistent-loop",
+      targetId: "ambient",
+      type: "update",
+      playback: {
+        continuity: "persistent",
+        loop: true,
+      },
+      tween: {
+        x: {
+          initialValue: 0,
+          keyframes: [{ duration: 1000, value: 100, easing: "linear" }],
+        },
+      },
+    };
+
+    app.render({
+      id: "persistent-loop-baseline",
+      elements: [
+        {
+          id: "ambient",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+        {
+          id: "sibling",
+          type: "rect",
+          x: 200,
+          y: 0,
+          width: 40,
+          height: 40,
+          fill: "#999999",
+        },
+      ],
+    });
+
+    app.render({
+      id: "persistent-loop-active",
+      elements: [
+        {
+          id: "ambient",
+          type: "rect",
+          x: 100,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+        {
+          id: "sibling",
+          type: "rect",
+          x: 200,
+          y: 0,
+          width: 40,
+          height: 40,
+          fill: "#999999",
+        },
+      ],
+      animations: [loopingAnimation],
+    });
+
+    frameTick({ deltaMS: 750 });
+    expect(app.findElementByLabel("ambient")?.x).toBeCloseTo(75);
+
+    app.render({
+      id: "persistent-loop-carried",
+      elements: [
+        {
+          id: "ambient",
+          type: "rect",
+          x: 100,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+        {
+          id: "sibling",
+          type: "rect",
+          x: 240,
+          y: 0,
+          width: 40,
+          height: 40,
+          fill: "#999999",
+        },
+      ],
+      animations: [loopingAnimation],
+    });
+
+    expect(app.findElementByLabel("ambient")?.x).toBeCloseTo(75);
+
+    frameTick({ deltaMS: 500 });
+    expect(app.findElementByLabel("ambient")?.x).toBeCloseTo(25);
+
+    eventHandler.mockClear();
+    app.render({
+      id: "persistent-loop-stopped",
+      elements: [
+        {
+          id: "ambient",
+          type: "rect",
+          x: 100,
+          y: 0,
+          width: 100,
+          height: 100,
+          fill: "#FFFFFF",
+        },
+      ],
+    });
+
+    expect(app.findElementByLabel("ambient")?.x).toBeCloseTo(100);
+    expect(eventHandler).toHaveBeenCalledWith("renderComplete", {
+      id: "persistent-loop-stopped",
+      aborted: false,
+    });
+  });
+
   it("does not abort or re-complete persistent updates after a later render adopts them", async () => {
     const eventHandler = vi.fn();
     const { app, pixiMock } = await setupRouteGraphics({

--- a/spec/animations/animationBus.spec.js
+++ b/spec/animations/animationBus.spec.js
@@ -73,6 +73,53 @@ describe("animationBus auto tween shorthand", () => {
     expect(animationBus.getState().activeCount).toBe(0);
   });
 
+  it("keeps a no-op auto loop active without completing", () => {
+    const animationBus = createAnimationBus();
+    const onComplete = vi.fn();
+    const onBusComplete = vi.fn();
+    const element = {
+      x: 20,
+      scale: { x: 1, y: 1 },
+    };
+    animationBus.on("completed", onBusComplete);
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "auto-noop-loop",
+        loop: true,
+        element,
+        properties: {
+          x: {
+            auto: {
+              duration: 300,
+              easing: "linear",
+            },
+          },
+        },
+        targetState: { x: 20 },
+        onComplete,
+      },
+    });
+
+    animationBus.flush();
+    animationBus.tick(600);
+
+    expect(element.x).toBe(20);
+    expect(animationBus.getState()).toMatchObject({
+      activeCount: 1,
+      animations: [
+        expect.objectContaining({
+          id: "auto-noop-loop",
+          duration: 300,
+          currentTime: 0,
+        }),
+      ],
+    });
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(onBusComplete).not.toHaveBeenCalled();
+  });
+
   it("throws when auto tween cannot resolve a targetState value", () => {
     const animationBus = createAnimationBus();
 

--- a/spec/animations/animationBus.spec.js
+++ b/spec/animations/animationBus.spec.js
@@ -227,6 +227,198 @@ describe("animationBus auto tween shorthand", () => {
     );
   });
 
+  it("loops ticked playback without completing and composes with speed", () => {
+    const animationBus = createAnimationBus();
+    const onComplete = vi.fn();
+    const onBusComplete = vi.fn();
+    const element = {
+      x: 0,
+      scale: { x: 1, y: 1 },
+    };
+    animationBus.on("completed", onBusComplete);
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "looping-fast-x",
+        playbackSpeed: 2,
+        loop: true,
+        element,
+        properties: {
+          x: {
+            initialValue: 0,
+            keyframes: [{ duration: 1000, value: 100, easing: "linear" }],
+          },
+        },
+        onComplete,
+      },
+    });
+
+    animationBus.flush();
+    animationBus.tick(250);
+    expect(element.x).toBeCloseTo(50);
+
+    animationBus.tick(250);
+    expect(element.x).toBeCloseTo(0);
+
+    animationBus.tick(125);
+    expect(element.x).toBeCloseTo(25);
+    expect(animationBus.getState()).toMatchObject({
+      activeCount: 1,
+      animations: [
+        {
+          id: "looping-fast-x",
+          currentTime: 250,
+          duration: 1000,
+          playbackSpeed: 2,
+          progress: 0.25,
+        },
+      ],
+    });
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(onBusComplete).not.toHaveBeenCalled();
+  });
+
+  it("loops manually sampled playback deterministically across large jumps", () => {
+    const animationBus = createAnimationBus();
+    const onComplete = vi.fn();
+    const element = {
+      x: 0,
+      scale: { x: 1, y: 1 },
+    };
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "sampled-loop",
+        playbackSpeed: 2,
+        loop: true,
+        element,
+        properties: {
+          x: {
+            initialValue: 0,
+            keyframes: [{ duration: 1000, value: 100, easing: "linear" }],
+          },
+        },
+        onComplete,
+      },
+    });
+
+    animationBus.setTime(1625);
+
+    expect(element.x).toBeCloseTo(25);
+    expect(animationBus.getState()).toMatchObject({
+      activeCount: 1,
+      animations: [
+        expect.objectContaining({
+          id: "sampled-loop",
+          currentTime: 250,
+          progress: 0.25,
+        }),
+      ],
+    });
+    expect(onComplete).not.toHaveBeenCalled();
+
+    animationBus.setTime(2000);
+    expect(element.x).toBeCloseTo(0);
+    expect(animationBus.getState().activeCount).toBe(1);
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("rejects looping animations without a positive finite duration", () => {
+    const animationBus = createAnimationBus();
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "zero-duration-loop",
+        loop: true,
+        element: {
+          x: 0,
+          scale: { x: 1, y: 1 },
+        },
+        properties: {
+          x: {
+            initialValue: 0,
+            keyframes: [{ duration: 0, value: 100, easing: "linear" }],
+          },
+        },
+      },
+    });
+
+    expect(() => animationBus.flush()).toThrow(
+      'Animation "zero-duration-loop" must have a finite duration greater than 0 when playback loop is enabled.',
+    );
+  });
+
+  it("rejects non-boolean looping metadata at the animation bus boundary", () => {
+    const animationBus = createAnimationBus();
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "invalid-loop",
+        loop: "forever",
+        element: {
+          x: 0,
+          scale: { x: 1, y: 1 },
+        },
+        properties: {
+          x: {
+            keyframes: [{ duration: 100, value: 100, easing: "linear" }],
+          },
+        },
+      },
+    });
+
+    expect(() => animationBus.flush()).toThrow(
+      'Animation "invalid-loop" playback loop must be a boolean.',
+    );
+  });
+
+  it("cancels a loop without emitting completion", () => {
+    const animationBus = createAnimationBus();
+    const onComplete = vi.fn();
+    const onCancel = vi.fn();
+    const onBusComplete = vi.fn();
+    const element = {
+      x: 0,
+      scale: { x: 1, y: 1 },
+    };
+    animationBus.on("completed", onBusComplete);
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "cancelled-loop",
+        loop: true,
+        element,
+        properties: {
+          x: {
+            initialValue: 0,
+            keyframes: [{ duration: 1000, value: 100, easing: "linear" }],
+          },
+        },
+        targetState: { x: 100 },
+        onComplete,
+        onCancel,
+      },
+    });
+
+    animationBus.flush();
+    animationBus.tick(500);
+    expect(element.x).toBeCloseTo(50);
+
+    animationBus.dispatch({ type: "CANCEL", id: "cancelled-loop" });
+    animationBus.flush();
+
+    expect(element.x).toBeCloseTo(100);
+    expect(animationBus.getState().activeCount).toBe(0);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(onBusComplete).not.toHaveBeenCalled();
+  });
+
   it("applies property path mapping for auto scale tweens", () => {
     const animationBus = createAnimationBus();
     const onComplete = vi.fn();

--- a/spec/animations/planAnimations.spec.js
+++ b/spec/animations/planAnimations.spec.js
@@ -565,8 +565,13 @@ describe("dispatchUpdateAnimations", () => {
       complete: vi.fn(),
     };
     const element = {
-      x: 0,
+      x: 10,
+      y: 20,
     };
+    const onComplete = vi.fn(() => {
+      element.x = 30;
+      element.y = 40;
+    });
 
     const dispatched = dispatchUpdateAnimations({
       animations: groupAnimationsByTarget([
@@ -591,10 +596,17 @@ describe("dispatchUpdateAnimations", () => {
       animationBus,
       completionTracker,
       element,
-      targetState: { x: 0 },
+      targetState: { x: 30, y: 40 },
+      onComplete,
     });
 
     expect(dispatched).toBe(true);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "ambient-drift" }),
+    );
+    expect(element.x).toBe(10);
+    expect(element.y).toBe(40);
     expect(completionTracker.getVersion).not.toHaveBeenCalled();
     expect(completionTracker.track).not.toHaveBeenCalled();
     expect(animationBus.dispatch).toHaveBeenCalledWith(
@@ -608,6 +620,49 @@ describe("dispatchUpdateAnimations", () => {
         }),
       }),
     );
+  });
+
+  it("does not settle looping animations used by deletion paths", () => {
+    const animationBus = { dispatch: vi.fn() };
+    const completionTracker = {
+      getVersion: vi.fn(),
+      track: vi.fn(),
+      complete: vi.fn(),
+    };
+    const element = {
+      destroyed: false,
+    };
+    const onComplete = vi.fn(() => {
+      element.destroyed = true;
+    });
+
+    const dispatched = dispatchUpdateAnimations({
+      animations: groupAnimationsByTarget([
+        {
+          id: "looping-exit",
+          targetId: "bg",
+          type: "update",
+          playback: { loop: true },
+          tween: {
+            alpha: {
+              initialValue: 1,
+              keyframes: [{ duration: 300, value: 0, easing: "linear" }],
+            },
+          },
+        },
+      ]),
+      targetId: "bg",
+      animationBus,
+      completionTracker,
+      element,
+      targetState: null,
+      onComplete,
+    });
+
+    expect(dispatched).toBe(true);
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(element.destroyed).toBe(false);
+    expect(animationBus.dispatch).toHaveBeenCalledTimes(1);
   });
 
   it("defers update animations during suppressed mounts and applies initial values", () => {

--- a/spec/animations/planAnimations.spec.js
+++ b/spec/animations/planAnimations.spec.js
@@ -557,6 +557,59 @@ describe("dispatchUpdateAnimations", () => {
     );
   });
 
+  it("dispatches render-scoped loops without tracking render completion", () => {
+    const animationBus = { dispatch: vi.fn() };
+    const completionTracker = {
+      getVersion: vi.fn(),
+      track: vi.fn(),
+      complete: vi.fn(),
+    };
+    const element = {
+      x: 0,
+    };
+
+    const dispatched = dispatchUpdateAnimations({
+      animations: groupAnimationsByTarget([
+        {
+          id: "ambient-drift",
+          targetId: "bg",
+          type: "update",
+          playback: {
+            continuity: "render",
+            speed: 1.5,
+            loop: true,
+          },
+          tween: {
+            x: {
+              initialValue: 0,
+              keyframes: [{ duration: 300, value: 30, easing: "linear" }],
+            },
+          },
+        },
+      ]),
+      targetId: "bg",
+      animationBus,
+      completionTracker,
+      element,
+      targetState: { x: 0 },
+    });
+
+    expect(dispatched).toBe(true);
+    expect(completionTracker.getVersion).not.toHaveBeenCalled();
+    expect(completionTracker.track).not.toHaveBeenCalled();
+    expect(animationBus.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "START",
+        payload: expect.objectContaining({
+          id: "ambient-drift",
+          continuity: "render",
+          playbackSpeed: 1.5,
+          loop: true,
+        }),
+      }),
+    );
+  });
+
   it("defers update animations during suppressed mounts and applies initial values", () => {
     const animationBus = { dispatch: vi.fn() };
     const completionTracker = {

--- a/spec/animations/planAnimations.spec.js
+++ b/spec/animations/planAnimations.spec.js
@@ -9,6 +9,7 @@ import {
   createRenderContext,
   flushDeferredMountOperations,
 } from "../../src/plugins/elements/renderContext.js";
+import { createAnimationBus } from "../../src/plugins/animations/animationBus.js";
 
 describe("buildAnimationContinuityPlan", () => {
   it("continues a persistent update when the target is unchanged", () => {
@@ -620,6 +621,116 @@ describe("dispatchUpdateAnimations", () => {
         }),
       }),
     );
+  });
+
+  it("preserves a looped property when a finite sibling finishes", () => {
+    const animationBus = createAnimationBus();
+    const completionTracker = {
+      getVersion: vi.fn(() => 3),
+      track: vi.fn(),
+      complete: vi.fn(),
+    };
+    const element = {
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 50,
+      scale: { x: 1, y: 1 },
+    };
+    const onComplete = vi.fn(() => {
+      element.x = 100;
+      element.y = 200;
+    });
+
+    dispatchUpdateAnimations({
+      animations: groupAnimationsByTarget([
+        {
+          id: "looping-x",
+          targetId: "mixed",
+          type: "update",
+          playback: { loop: true },
+          tween: {
+            x: {
+              initialValue: 0,
+              keyframes: [{ duration: 1000, value: 100, easing: "linear" }],
+            },
+          },
+        },
+        {
+          id: "finite-y",
+          targetId: "mixed",
+          type: "update",
+          tween: {
+            y: {
+              initialValue: 0,
+              keyframes: [{ duration: 500, value: 200, easing: "linear" }],
+            },
+          },
+        },
+      ]),
+      targetId: "mixed",
+      animationBus,
+      completionTracker,
+      element,
+      targetState: { x: 100, y: 200 },
+      onComplete,
+    });
+
+    animationBus.setTime(500);
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(element.x).toBeCloseTo(50);
+    expect(element.y).toBeCloseTo(200);
+    expect(completionTracker.track).toHaveBeenCalledTimes(1);
+    expect(completionTracker.complete).toHaveBeenCalledTimes(1);
+    expect(animationBus.getState().activeCount).toBe(1);
+  });
+
+  it("recomputes translation geometry after loop state settlement", () => {
+    const animationBus = createAnimationBus();
+    const element = {
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 50,
+      scale: { x: 1, y: 1 },
+    };
+    const onComplete = vi.fn(() => {
+      element.width = 200;
+    });
+
+    dispatchUpdateAnimations({
+      animations: groupAnimationsByTarget([
+        {
+          id: "looping-translate",
+          targetId: "resized",
+          type: "update",
+          playback: { loop: true },
+          tween: {
+            translateX: {
+              initialValue: 0,
+              keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+            },
+          },
+        },
+      ]),
+      targetId: "resized",
+      animationBus,
+      completionTracker: {
+        getVersion: vi.fn(),
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      element,
+      targetState: { x: 10, y: 20 },
+      onComplete,
+    });
+
+    animationBus.setTime(500);
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(element.width).toBe(200);
+    expect(element.x).toBeCloseTo(110);
   });
 
   it("does not settle looping animations used by deletion paths", () => {

--- a/spec/elements/addTextRichContent.spec.js
+++ b/spec/elements/addTextRichContent.spec.js
@@ -4,6 +4,7 @@ import { addText } from "../../src/plugins/elements/text/addText.js";
 import { parseText } from "../../src/plugins/elements/text/parseText.js";
 import { updateText } from "../../src/plugins/elements/text/updateText.js";
 import { hitTestElementBounds } from "../../src/util/hitTestElementBounds.js";
+import { createAnimationBus } from "../../src/plugins/animations/animationBus.js";
 
 const createSharedParams = () => ({
   app: {
@@ -308,6 +309,73 @@ describe("text rich content", () => {
     expect(text.children[0].children[0].text).toBe("Rich");
     expect(text.children[0].children[1].text).toBe("Text");
     expect(text.children[0].children[1].style.fill).toBe("#A6A6A6");
+  });
+
+  it("moves a looping update onto a replacement rich-text display object", () => {
+    const parent = new Container();
+    const shared = createSharedParams();
+    const animationBus = createAnimationBus();
+    const prevElement = parseText({
+      state: {
+        id: "looping-replacement-text",
+        type: "text",
+        x: 20,
+        y: 30,
+        content: "Plain",
+      },
+    });
+    const nextElement = parseText({
+      state: {
+        id: "looping-replacement-text",
+        type: "text",
+        x: 120,
+        y: 30,
+        content: [{ text: "Rich" }, { text: " replacement" }],
+      },
+    });
+
+    addText({
+      ...shared,
+      parent,
+      element: prevElement,
+      zIndex: 0,
+    });
+    const previousDisplayObject = parent.getChildByLabel(
+      "looping-replacement-text",
+    );
+
+    updateText({
+      ...shared,
+      parent,
+      prevElement,
+      nextElement,
+      animations: [
+        {
+          id: "replacement-loop",
+          targetId: prevElement.id,
+          type: "update",
+          playback: { loop: true },
+          tween: {
+            x: {
+              initialValue: 20,
+              keyframes: [{ duration: 1000, value: 120, easing: "linear" }],
+            },
+          },
+        },
+      ],
+      animationBus,
+      zIndex: 0,
+    });
+
+    const replacement = parent.getChildByLabel("looping-replacement-text");
+    animationBus.flush();
+    animationBus.tick(500);
+
+    expect(previousDisplayObject.destroyed).toBe(true);
+    expect(replacement).not.toBe(previousDisplayObject);
+    expect(replacement.destroyed).toBe(false);
+    expect(replacement.x).toBeCloseTo(70);
+    expect(animationBus.getState().activeCount).toBe(1);
   });
 
   it("wraps rich content using textStyle.wordWrapWidth when width is omitted", () => {

--- a/spec/elements/updateRect.spec.js
+++ b/spec/elements/updateRect.spec.js
@@ -2,6 +2,7 @@ import { Container, Graphics } from "pixi.js";
 import { describe, expect, it, vi } from "vitest";
 import { updateRect } from "../../src/plugins/elements/rect/updateRect.js";
 import { parseRect } from "../../src/plugins/elements/rect/parseRect.js";
+import { getElementRenderState } from "../../src/plugins/elements/elementRenderState.js";
 
 describe("updateRect", () => {
   it("resets transient rect scale when returning to an unscaled state", () => {
@@ -226,6 +227,85 @@ describe("updateRect", () => {
     expect(rectElement.scale.y).toBe(1);
     expect(rectElement.width).toBe(nextElement.width);
     expect(rectElement.height).toBe(nextElement.height);
+  });
+
+  it("settles non-tween state once while preserving a looping property", () => {
+    const parent = new Container();
+    const rectElement = new Graphics();
+    rectElement.label = "rect-1";
+    rectElement.x = 100;
+    rectElement.y = 200;
+    rectElement.rect(0, 0, 160, 160).fill("#FFFFFF");
+    parent.addChild(rectElement);
+
+    const animationBus = { dispatch: vi.fn() };
+    const completionTracker = {
+      getVersion: vi.fn(),
+      track: vi.fn(),
+      complete: vi.fn(),
+    };
+    const commitRenderState = vi.fn();
+    const deferRenderStateCommit = vi.fn();
+    const prevElement = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 100,
+        y: 200,
+        width: 160,
+        height: 160,
+        fill: "#FFFFFF",
+      },
+    });
+    const nextElement = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 900,
+        y: 320,
+        width: 220,
+        height: 80,
+        fill: "#FF3355",
+      },
+    });
+
+    updateRect({
+      app: {
+        audioStage: { add: vi.fn() },
+      },
+      parent,
+      prevElement,
+      nextElement,
+      animations: [
+        {
+          id: "rect-loop",
+          targetId: "rect-1",
+          type: "update",
+          playback: { loop: true },
+          tween: {
+            x: {
+              initialValue: 100,
+              keyframes: [{ duration: 1000, value: 900, easing: "linear" }],
+            },
+          },
+        },
+      ],
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+      commitRenderState,
+      deferRenderStateCommit,
+    });
+
+    expect(rectElement.x).toBe(100);
+    expect(rectElement.y).toBe(320);
+    expect(rectElement.width).toBe(220);
+    expect(rectElement.height).toBe(80);
+    expect(getElementRenderState(rectElement)).toBe(nextElement);
+    expect(commitRenderState).toHaveBeenCalledTimes(1);
+    expect(deferRenderStateCommit).toHaveBeenCalledTimes(1);
+    expect(completionTracker.track).not.toHaveBeenCalled();
   });
 
   it("applies updated rotation around the computed anchor origin", () => {

--- a/spec/parser/normalizeRenderState.test.yaml
+++ b/spec/parser/normalizeRenderState.test.yaml
@@ -482,6 +482,44 @@ out:
   audio: []
   audioEffects: []
 ---
+case: Normalize looping update animation playback
+in:
+  - id: state-2-loop-update
+    animations:
+      - id: anim-loop-update
+        targetId: portrait
+        type: update
+        playback:
+          continuity: persistent
+          speed: 2
+          loop: true
+        tween:
+          x:
+            initialValue: 0
+            keyframes:
+              - duration: 1000
+                value: 320
+out:
+  id: state-2-loop-update
+  elements: []
+  animations:
+    - id: anim-loop-update
+      targetId: portrait
+      type: update
+      playback:
+        continuity: persistent
+        speed: 2
+        loop: true
+      tween:
+        x:
+          initialValue: 0
+          keyframes:
+            - duration: 1000
+              value: 320
+              easing: linear
+  audio: []
+  audioEffects: []
+---
 case: Normalize default playback speed away
 in:
   - id: state-2-default-speed-update
@@ -807,6 +845,59 @@ in:
               - duration: 100
                 value: 20
 throws: animations[0].playback.speed must be a finite number greater than 0.
+---
+case: Throw when playback loop is not boolean
+in:
+  - id: state-3c-playback-loop-type
+    animations:
+      - id: anim-playback-loop-type
+        targetId: text-1
+        type: update
+        playback:
+          loop: forever
+        tween:
+          x:
+            keyframes:
+              - duration: 100
+                value: 20
+throws: animations[0].playback.loop must be a boolean.
+---
+case: Throw when transition playback loops
+in:
+  - id: state-3c-transition-loop
+    animations:
+      - id: anim-transition-loop
+        targetId: scene-root
+        type: transition
+        playback:
+          loop: true
+        next:
+          tween:
+            alpha:
+              initialValue: 0
+              keyframes:
+                - duration: 100
+                  value: 1
+throws: animations[0].playback.loop is only supported for type "update".
+---
+case: Throw when looping animation declares completion
+in:
+  - id: state-3c-loop-complete
+    animations:
+      - id: anim-loop-complete
+        targetId: text-1
+        type: update
+        complete:
+          payload:
+            action: unreachable
+        playback:
+          loop: true
+        tween:
+          x:
+            keyframes:
+              - duration: 100
+                value: 20
+throws: animations[0].complete is not allowed when playback.loop is true because a loop never completes.
 ---
 case: Throw when sequence mask uses legacy textures
 in:

--- a/src/plugins/animations/animationBus.js
+++ b/src/plugins/animations/animationBus.js
@@ -15,6 +15,7 @@ import {
 } from "../../util/animationTimeline.js";
 
 const DEFAULT_PLAYBACK_SPEED = 1;
+const DEFAULT_PLAYBACK_LOOP = false;
 
 const hasTranslateProperties = (properties = {}) =>
   Object.keys(properties).some(isTranslateAnimationProperty);
@@ -107,14 +108,17 @@ export const createAnimationBus = () => {
     return Math.min(Math.max(time, 0), Math.max(duration ?? 0, 0));
   };
 
+  const wrapAnimationTime = (time, duration) =>
+    ((Math.max(time, 0) % duration) + duration) % duration;
+
   const applyTimeToContext = (context, timeMS) => {
-    const nextTime = clampAnimationTime(
-      timeMS * context.playbackSpeed,
-      context.duration,
-    );
+    const scaledTime = timeMS * context.playbackSpeed;
+    const nextTime = context.loop
+      ? wrapAnimationTime(scaledTime, context.duration)
+      : clampAnimationTime(scaledTime, context.duration);
     context.currentTime = nextTime;
     context.applyFrame(nextTime);
-    return nextTime >= context.duration;
+    return !context.loop && nextTime >= context.duration;
   };
 
   const normalizePlaybackSpeed = (value, animationId) => {
@@ -125,6 +129,20 @@ export const createAnimationBus = () => {
     if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
       throw new Error(
         `Animation "${animationId}" playback speed must be a finite number greater than 0.`,
+      );
+    }
+
+    return value;
+  };
+
+  const normalizePlaybackLoop = (value, animationId) => {
+    if (value === undefined || value === null) {
+      return DEFAULT_PLAYBACK_LOOP;
+    }
+
+    if (typeof value !== "boolean") {
+      throw new Error(
+        `Animation "${animationId}" playback loop must be a boolean.`,
       );
     }
 
@@ -162,6 +180,10 @@ export const createAnimationBus = () => {
       metadata.playbackSpeed ?? context.playbackSpeed,
       context.id,
     );
+    context.loop = normalizePlaybackLoop(
+      metadata.loop ?? context.loop,
+      context.id,
+    );
     context.onContinuationUpdate =
       metadata.onContinuationUpdate ?? context.onContinuationUpdate;
     return context;
@@ -177,6 +199,15 @@ export const createAnimationBus = () => {
   });
 
   const registerAnimation = (context) => {
+    if (
+      context.loop &&
+      (!Number.isFinite(context.duration) || context.duration <= 0)
+    ) {
+      throw new Error(
+        `Animation "${context.id}" must have a finite duration greater than 0 when playback loop is enabled.`,
+      );
+    }
+
     context.applyFrame(0);
     pendingAnimations.delete(context.id);
     activeAnimations.set(context.id, context);
@@ -463,12 +494,12 @@ export const createAnimationBus = () => {
         continue;
       }
 
-      context.currentTime = clampAnimationTime(
-        context.currentTime + deltaMS * context.playbackSpeed,
-        context.duration,
-      );
+      const elapsedTime = context.currentTime + deltaMS * context.playbackSpeed;
+      context.currentTime = context.loop
+        ? wrapAnimationTime(elapsedTime, context.duration)
+        : clampAnimationTime(elapsedTime, context.duration);
 
-      if (context.currentTime >= context.duration) {
+      if (!context.loop && context.currentTime >= context.duration) {
         context.applyFrame(context.duration);
 
         if (
@@ -571,6 +602,7 @@ export const createAnimationBus = () => {
       signature: pendingContext.signature,
       continuity: pendingContext.continuity,
       playbackSpeed: pendingContext.playbackSpeed,
+      loop: payload.loop ?? pendingContext.loop,
       onContinuationUpdate:
         payload.onContinuationUpdate ?? pendingContext.onContinuationUpdate,
     });

--- a/src/plugins/animations/animationBus.js
+++ b/src/plugins/animations/animationBus.js
@@ -40,6 +40,7 @@ const buildPropertyTimelines = (
   targetState,
   animationId,
   subjectState,
+  preserveNoopAuto,
 ) =>
   Object.entries(properties)
     .map(([property, config]) => {
@@ -64,7 +65,7 @@ const buildPropertyTimelines = (
           animationId,
         );
 
-        if (currentValue === targetValue) {
+        if (currentValue === targetValue && !preserveNoopAuto) {
           return null;
         }
 
@@ -234,6 +235,11 @@ export const createAnimationBus = () => {
       propertyPathMap = TRANSITION_PROPERTY_PATH_MAP,
       animationBaseState,
     } = payload;
+    const normalizedPayload = {
+      ...payload,
+      playbackSpeed: normalizePlaybackSpeed(payload.playbackSpeed, id),
+      loop: normalizePlaybackLoop(payload.loop, id),
+    };
     let subjectState =
       animationBaseState ??
       (hasTranslateProperties(properties)
@@ -255,6 +261,7 @@ export const createAnimationBus = () => {
       targetState,
       id,
       subjectState,
+      normalizedPayload.loop,
     );
 
     if (timelines.length === 0) {
@@ -321,7 +328,7 @@ export const createAnimationBus = () => {
       isValid: () => Boolean(element) && !element.destroyed,
     };
 
-    registerAnimation(attachAnimationMetadata(context, payload));
+    registerAnimation(attachAnimationMetadata(context, normalizedPayload));
   };
 
   const startCustomAnimation = (payload) => {

--- a/src/plugins/animations/planAnimations.test.js
+++ b/src/plugins/animations/planAnimations.test.js
@@ -71,4 +71,30 @@ describe("getAnimationContinuitySignature", () => {
       }),
     );
   });
+
+  it("includes playback loop in persistent signatures", () => {
+    const base = {
+      id: "pulse",
+      targetId: "portrait",
+      type: "update",
+      playback: {
+        continuity: "persistent",
+      },
+      tween: {
+        scaleX: {
+          keyframes: [{ duration: 1000, value: 1.1, easing: "linear" }],
+        },
+      },
+    };
+
+    expect(getAnimationContinuitySignature(base)).not.toBe(
+      getAnimationContinuitySignature({
+        ...base,
+        playback: {
+          continuity: "persistent",
+          loop: true,
+        },
+      }),
+    );
+  });
 });

--- a/src/plugins/animations/updateAnimationDispatch.js
+++ b/src/plugins/animations/updateAnimationDispatch.js
@@ -72,7 +72,9 @@ export const dispatchUpdateAnimationsNow = ({
       }
     }
 
-    const trackCompletion = animation.playback?.continuity !== "persistent";
+    const trackCompletion =
+      animation.playback?.continuity !== "persistent" &&
+      animation.playback?.loop !== true;
     const stateVersion = trackCompletion
       ? completionTracker.getVersion()
       : null;
@@ -89,6 +91,7 @@ export const dispatchUpdateAnimationsNow = ({
         targetId: animation.targetId,
         continuity: animation.playback?.continuity ?? "render",
         playbackSpeed: animation.playback?.speed,
+        loop: animation.playback?.loop === true,
         signature:
           animation.signature ??
           JSON.stringify({

--- a/src/plugins/animations/updateAnimationDispatch.js
+++ b/src/plugins/animations/updateAnimationDispatch.js
@@ -21,6 +21,33 @@ const getLiveTweenProperty = (property) => {
   return property;
 };
 
+const animationsUseTranslate = (animations) =>
+  animations.some((animation) =>
+    Object.keys(animation.tween ?? {}).some(isTranslateAnimationProperty),
+  );
+
+const createCurrentElementResolver = (element) => {
+  const parent = element?.parent;
+  const label = element?.label;
+
+  return () => {
+    if (!element?.destroyed || !parent || label == null) {
+      return element;
+    }
+
+    const labeledChild = parent.getChildByLabel?.(label);
+    const replacement =
+      labeledChild && labeledChild !== element && !labeledChild.destroyed
+        ? labeledChild
+        : parent.children?.find(
+            (child) =>
+              child !== element && !child.destroyed && child.label === label,
+          );
+
+    return replacement && !replacement.destroyed ? replacement : element;
+  };
+};
+
 const captureLiveTweenValues = (
   element,
   animations,
@@ -78,12 +105,15 @@ const settleLoopingUpdateState = ({
     (animation) => animation.playback?.loop === true,
   );
   if (!loopingAnimation || targetState == null || !onComplete) {
-    return;
+    return { didSettle: false, element };
   }
 
+  const resolveCurrentElement = createCurrentElementResolver(element);
   const liveTweenValues = captureLiveTweenValues(element, animations);
+  let currentElement = element;
   const restore = () => {
-    restoreLiveTweenValues(element, liveTweenValues);
+    currentElement = resolveCurrentElement();
+    restoreLiveTweenValues(currentElement, liveTweenValues);
   };
 
   let settlement;
@@ -96,6 +126,8 @@ const settleLoopingUpdateState = ({
   if (settlement && typeof settlement.then === "function") {
     settlement.then(restore, restore);
   }
+
+  return { didSettle: true, element: currentElement };
 };
 
 export const applyInitialUpdateAnimationState = (
@@ -162,12 +194,17 @@ export const dispatchUpdateAnimationsNow = ({
     }
   }
 
-  settleLoopingUpdateState({
+  const settlement = settleLoopingUpdateState({
     animations: animationsToDispatch,
     element,
     targetState,
     onComplete,
   });
+  const dispatchElement = settlement.element;
+  const dispatchAnimationBaseState =
+    settlement.didSettle && animationsUseTranslate(animationsToDispatch)
+      ? createAnimationSubjectState(dispatchElement)
+      : animationBaseState;
 
   for (const animation of animationsToDispatch) {
     const trackCompletion =
@@ -197,16 +234,18 @@ export const dispatchUpdateAnimationsNow = ({
             tween: animation.tween,
             playback: animation.playback ?? null,
           }),
-        element,
+        element: dispatchElement,
         properties: animation.tween,
         targetState,
-        animationBaseState,
+        animationBaseState: dispatchAnimationBaseState,
         onComplete: () => {
           if (trackCompletion) {
             completionTracker.complete(stateVersion);
           }
 
-          onComplete?.(animation);
+          if (!settlement.didSettle) {
+            onComplete?.(animation);
+          }
         },
       },
     });

--- a/src/plugins/animations/updateAnimationDispatch.js
+++ b/src/plugins/animations/updateAnimationDispatch.js
@@ -5,8 +5,98 @@ import {
 import {
   applyAnimationProperty,
   createAnimationSubjectState,
+  getAnimationProperty,
   isTranslateAnimationProperty,
 } from "./animationPropertyUtils.js";
+
+const getLiveTweenProperty = (property) => {
+  if (property === "translateX") {
+    return "x";
+  }
+
+  if (property === "translateY") {
+    return "y";
+  }
+
+  return property;
+};
+
+const captureLiveTweenValues = (
+  element,
+  animations,
+  propertyPathMap = TRANSITION_PROPERTY_PATH_MAP,
+) => {
+  const values = new Map();
+
+  for (const animation of animations) {
+    for (const property of Object.keys(animation.tween)) {
+      const liveProperty = getLiveTweenProperty(property);
+      if (values.has(liveProperty)) {
+        continue;
+      }
+
+      const value = getAnimationProperty(
+        element,
+        liveProperty,
+        propertyPathMap,
+      );
+      if (value !== undefined) {
+        values.set(liveProperty, value);
+      }
+    }
+  }
+
+  return values;
+};
+
+const restoreLiveTweenValues = (
+  element,
+  values,
+  propertyPathMap = TRANSITION_PROPERTY_PATH_MAP,
+) => {
+  if (!element || element.destroyed) {
+    return;
+  }
+
+  for (const [property, value] of values) {
+    applyAnimationProperty({
+      object: element,
+      property,
+      propertyPathMap,
+      value,
+    });
+  }
+};
+
+const settleLoopingUpdateState = ({
+  animations,
+  element,
+  targetState,
+  onComplete,
+}) => {
+  const loopingAnimation = animations.find(
+    (animation) => animation.playback?.loop === true,
+  );
+  if (!loopingAnimation || targetState == null || !onComplete) {
+    return;
+  }
+
+  const liveTweenValues = captureLiveTweenValues(element, animations);
+  const restore = () => {
+    restoreLiveTweenValues(element, liveTweenValues);
+  };
+
+  let settlement;
+  try {
+    settlement = onComplete(loopingAnimation);
+  } finally {
+    restore();
+  }
+
+  if (settlement && typeof settlement.then === "function") {
+    settlement.then(restore, restore);
+  }
+};
 
 export const applyInitialUpdateAnimationState = (
   element,
@@ -52,14 +142,13 @@ export const dispatchUpdateAnimationsNow = ({
   onComplete,
   animationBaseState,
 }) => {
-  for (const animation of animations) {
-    if (
-      typeof animationBus?.hasContext === "function" &&
-      animationBus.hasContext(animation.id)
-    ) {
-      continue;
-    }
+  const animationsToDispatch = animations.filter(
+    (animation) =>
+      typeof animationBus?.hasContext !== "function" ||
+      !animationBus.hasContext(animation.id),
+  );
 
+  for (const animation of animationsToDispatch) {
     for (const [property, config] of Object.entries(animation.tween)) {
       if (
         config.auto &&
@@ -71,7 +160,16 @@ export const dispatchUpdateAnimationsNow = ({
         );
       }
     }
+  }
 
+  settleLoopingUpdateState({
+    animations: animationsToDispatch,
+    element,
+    targetState,
+    onComplete,
+  });
+
+  for (const animation of animationsToDispatch) {
     const trackCompletion =
       animation.playback?.continuity !== "persistent" &&
       animation.playback?.loop !== true;

--- a/src/schemas/animations/animation.yaml
+++ b/src/schemas/animations/animation.yaml
@@ -279,6 +279,10 @@ $defs:
         type: number
         exclusiveMinimum: 0
         description: Playback speed multiplier. 1 is authored speed, 2 is twice as fast, 0.5 is half speed.
+      loop:
+        type: boolean
+        default: false
+        description: Repeat an update animation indefinitely without blocking render completion. Not supported for transitions.
     additionalProperties: false
 properties:
   id:
@@ -331,3 +335,17 @@ allOf:
         - required: [prev]
         - required: [next]
         - required: [mask]
+  - if:
+      required: [playback]
+      properties:
+        playback:
+          required: [loop]
+          properties:
+            loop:
+              const: true
+    then:
+      properties:
+        type:
+          const: update
+      not:
+        required: [complete]

--- a/src/types.js
+++ b/src/types.js
@@ -784,6 +784,13 @@ export const AnimationType = {
 };
 
 /**
+ * @typedef {Object} AnimationPlayback
+ * @property {"render" | "persistent"} [continuity="render"] - Whether an in-flight animation may continue across compatible renders
+ * @property {number} [speed=1] - Positive finite playback speed multiplier
+ * @property {boolean} [loop=false] - Whether an update animation repeats indefinitely without blocking render completion
+ */
+
+/**
  * @readonly
  * @enum {string}
  */
@@ -831,6 +838,7 @@ export const DEFAULT_TEXT_STYLE = {
  * @property {string} id - Unique animation id
  * @property {string} targetId - ID of the element
  * @property {AnimationType[keyof AnimationType]} type - Animation structure
+ * @property {AnimationPlayback} [playback] - Playback behavior
  */
 
 /**

--- a/src/util/normalizeAnimations.js
+++ b/src/util/normalizeAnimations.js
@@ -5,6 +5,7 @@ const ANIMATION_TYPES = new Set(["update", "transition"]);
 const CONTINUITY_MODES = new Set(["render", "persistent"]);
 const DEFAULT_PLAYBACK_CONTINUITY = "render";
 const DEFAULT_PLAYBACK_SPEED = 1;
+const DEFAULT_PLAYBACK_LOOP = false;
 const UPDATE_TWEEN_PROPERTIES = new Set([
   "alpha",
   "x",
@@ -75,6 +76,14 @@ const normalizePlayback = (playback, path) => {
     if (playback.speed !== DEFAULT_PLAYBACK_SPEED) {
       normalized.speed = playback.speed;
     }
+  }
+
+  const loop = playback.loop ?? DEFAULT_PLAYBACK_LOOP;
+  if (typeof loop !== "boolean") {
+    throw new Error(`${path}.loop must be a boolean.`);
+  }
+  if (loop) {
+    normalized.loop = true;
   }
 
   return normalized;
@@ -476,6 +485,19 @@ export const normalizeAnimations = (animations = []) => {
         animation.playback,
         `${path}.playback`,
       );
+    }
+
+    if (normalizedAnimation.playback?.loop === true) {
+      if (animation.type !== "update") {
+        throw new Error(
+          `${path}.playback.loop is only supported for type "update".`,
+        );
+      }
+      if (normalizedAnimation.complete !== undefined) {
+        throw new Error(
+          `${path}.complete is not allowed when playback.loop is true because a loop never completes.`,
+        );
+      }
     }
 
     assertLegacyFieldAbsent(

--- a/vt/reference/recttransition/rect-update-loop-playback-01.webp
+++ b/vt/reference/recttransition/rect-update-loop-playback-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e342b0feee62b9c4e0d65d5a22f42a89934c1a8f4a809b1914a9e39594dc066c
+size 1752

--- a/vt/reference/recttransition/rect-update-loop-playback-02.webp
+++ b/vt/reference/recttransition/rect-update-loop-playback-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45dbd6ccddf8f9baa0c554c2cd59f3fd2170c7d7a49064b3be9bd97ea97b5b83
+size 1752

--- a/vt/reference/recttransition/rect-update-loop-playback-02.webp
+++ b/vt/reference/recttransition/rect-update-loop-playback-02.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45dbd6ccddf8f9baa0c554c2cd59f3fd2170c7d7a49064b3be9bd97ea97b5b83
-size 1752
+oid sha256:790637889e0d4b89d9d9388c5bdcf9a8cec9c2e47b4229f190784d2f3a3eaf62
+size 1800

--- a/vt/reference/recttransition/rect-update-loop-playback-03.webp
+++ b/vt/reference/recttransition/rect-update-loop-playback-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e342b0feee62b9c4e0d65d5a22f42a89934c1a8f4a809b1914a9e39594dc066c
+size 1752

--- a/vt/reference/recttransition/rect-update-loop-playback-03.webp
+++ b/vt/reference/recttransition/rect-update-loop-playback-03.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e342b0feee62b9c4e0d65d5a22f42a89934c1a8f4a809b1914a9e39594dc066c
-size 1752
+oid sha256:90b1ae4c9cf8593f5cc8c66489bdcba14572cf9b969d8bce29d84f5fff786443
+size 1800

--- a/vt/reference/recttransition/rect-update-loop-playback-04.webp
+++ b/vt/reference/recttransition/rect-update-loop-playback-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30a68382fcb80f8d1ef9a593fa32a473cc59da22bd82c255d54b3eb655c7e3d6
+size 1750

--- a/vt/reference/recttransition/rect-update-loop-playback-04.webp
+++ b/vt/reference/recttransition/rect-update-loop-playback-04.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:30a68382fcb80f8d1ef9a593fa32a473cc59da22bd82c255d54b3eb655c7e3d6
-size 1750
+oid sha256:a5a3ad9463d2e57279dd525ef31237f86a2309f986523139da548ceac1b7dd76
+size 1804

--- a/vt/specs/recttransition/rect-update-loop-playback.yaml
+++ b/vt/specs/recttransition/rect-update-loop-playback.yaml
@@ -1,10 +1,11 @@
 ---
 title: Rect Update Loop Playback
-description: A looping update wraps deterministically at the configured speed while render completion remains non-blocking.
+description: A looping update wraps deterministically while the target's non-tween state settles immediately.
 specs:
   - the loop should be halfway through its authored movement after 250ms at speed 2
   - the loop should wrap to its initial position after 500ms at speed 2
   - the loop should continue into the next iteration without another render
+  - non-tween position, dimensions, and fill should update when the loop starts
 steps:
   - action: keypress
     key: "n"
@@ -39,10 +40,10 @@ states:
       - id: loop-target
         type: rect
         x: 900
-        "y": 240
-        width: 160
-        height: 160
-        fill: "#FFFFFF"
+        "y": 320
+        width: 220
+        height: 80
+        fill: "#FF3355"
     animations:
       - id: horizontal-loop
         targetId: loop-target

--- a/vt/specs/recttransition/rect-update-loop-playback.yaml
+++ b/vt/specs/recttransition/rect-update-loop-playback.yaml
@@ -1,0 +1,59 @@
+---
+title: Rect Update Loop Playback
+description: A looping update wraps deterministically at the configured speed while render completion remains non-blocking.
+specs:
+  - the loop should be halfway through its authored movement after 250ms at speed 2
+  - the loop should wrap to its initial position after 500ms at speed 2
+  - the loop should continue into the next iteration without another render
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: snapShotKeyFrame
+    detail:
+      deltaMS: 250
+  - action: screenshot
+  - action: customEvent
+    name: snapShotKeyFrame
+    detail:
+      deltaMS: 250
+  - action: screenshot
+  - action: customEvent
+    name: snapShotKeyFrame
+    detail:
+      deltaMS: 125
+  - action: screenshot
+---
+states:
+  - id: baseline
+    elements:
+      - id: loop-target
+        type: rect
+        x: 100
+        "y": 240
+        width: 160
+        height: 160
+        fill: "#FFFFFF"
+  - id: looping-update
+    elements:
+      - id: loop-target
+        type: rect
+        x: 900
+        "y": 240
+        width: 160
+        height: 160
+        fill: "#FFFFFF"
+    animations:
+      - id: horizontal-loop
+        targetId: loop-target
+        type: update
+        playback:
+          speed: 2
+          loop: true
+        tween:
+          x:
+            initialValue: 100
+            keyframes:
+              - duration: 1000
+                value: 900
+                easing: linear


### PR DESCRIPTION
## Summary

- add strict `playback.loop` support for update animations
- keep infinite loops non-blocking so `renderComplete` fires immediately
- settle non-tween element state and render-state commits once when a loop starts while preserving live tween values
- dispatch loops against replacement display objects and refreshed translation geometry after settlement
- preserve active loop properties when finite sibling animations complete
- keep no-op auto loops active without emitting completion
- reject transition loops, non-boolean values, zero-duration loops, and unreachable completion actions
- preserve loop identity across compatible persistent renders and cancel cleanly when omitted or replaced
- bump the package feature version to `1.33.0`
- document the public contract and add deterministic browser/VT coverage

## Validation

- `bun run lint`
- `bun run test` — 90 files, 810 tests passed
- `bun run build`
- focused update-loop regressions for replacement elements, mixed finite/loop siblings, resized translation subjects, no-op auto loops, and deletion lifecycle protection
- VT capture — 218/218 specs succeeded
- VT report — 770 references, 0 mismatches
- 4 deterministic loop screenshots cover start, midpoint, exact wrap, and next iteration; 3 were refreshed to verify settled position, dimensions, and fill
