### PR TITLE
feat(rect): complete styling and animation support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/pages/docs/nodes/input.md
+++ b/playground/pages/docs/nodes/input.md
@@ -85,6 +85,9 @@ fill:
       color: "#0F766E"
 ```
 
+Gradient fills use renderer-independent options: `resolution` controls
+sampling resolution, and `spread` is `pad` or `repeat`.
+
 ## Example
 
 ```yaml

--- a/playground/pages/docs/nodes/rect.md
+++ b/playground/pages/docs/nodes/rect.md
@@ -5,7 +5,8 @@ tags: documentation
 sidebarId: node-rect
 ---
 
-`rect` renders a Pixi graphics rectangle with optional border, interaction, drag, and scroll hooks.
+`rect` renders a rectangle with solid or gradient fill, independent corner
+radii, optional border and blur, shader filters, animation, and pointer hooks.
 
 Try it in the [Playground](/playground/?template=basic-shapes).
 
@@ -15,29 +16,33 @@ Try it in the [Playground](/playground/?template=basic-shapes).
 
 ## Field Reference
 
-| Field        | Type             | Required | Default     | Notes                                   |
-| ------------ | ---------------- | -------- | ----------- | --------------------------------------- |
-| `id`         | string           | Yes      | -           | Element id.                             |
-| `type`       | string           | Yes      | -           | Must be `rect`.                         |
-| `width`      | number           | Yes      | -           | Render width.                           |
-| `height`     | number           | Yes      | -           | Render height.                          |
-| `x`          | number           | No       | `0`         | Position before anchor transform.       |
-| `y`          | number           | No       | `0`         | Position before anchor transform.       |
-| `anchorX`    | number           | No       | `0`         | Anchor offset ratio.                    |
-| `anchorY`    | number           | No       | `0`         | Anchor offset ratio.                    |
-| `originX`    | number           | No       | anchor      | Transform origin X in pixels.           |
-| `originY`    | number           | No       | anchor      | Transform origin Y in pixels.           |
-| `alpha`      | number           | No       | `1`         | Opacity `0..1`.                         |
-| `fill`       | string \| object | No       | transparent | Fill color or structured gradient fill. |
-| `border`     | object           | No       | -           | Border config.                          |
-| `rotation`   | number           | No       | `0`         | Degrees.                                |
-| `filters`    | array            | No       | `[]`        | Ordered custom shader filters.          |
-| `hover`      | object           | No       | -           | Hover event config.                     |
-| `click`      | object           | No       | -           | Click event config.                     |
-| `rightClick` | object           | No       | -           | Right click event config.               |
-| `drag`       | object           | No       | -           | `start`/`move`/`end` payload hooks.     |
-| `scrollUp`   | object           | No       | -           | Wheel-up payload hook.                  |
-| `scrollDown` | object           | No       | -           | Wheel-down payload hook.                |
+| Field          | Type             | Required | Default     | Notes                                   |
+| -------------- | ---------------- | -------- | ----------- | --------------------------------------- |
+| `id`           | string           | Yes      | -           | Element id.                             |
+| `type`         | string           | Yes      | -           | Must be `rect`.                         |
+| `width`        | number           | Yes      | -           | Render width.                           |
+| `height`       | number           | Yes      | -           | Render height.                          |
+| `x`            | number           | No       | `0`         | Position before anchor transform.       |
+| `y`            | number           | No       | `0`         | Position before anchor transform.       |
+| `anchorX`      | number           | No       | `0`         | Anchor offset ratio.                    |
+| `anchorY`      | number           | No       | `0`         | Anchor offset ratio.                    |
+| `originX`      | number           | No       | anchor      | Transform origin X in pixels.           |
+| `originY`      | number           | No       | anchor      | Transform origin Y in pixels.           |
+| `alpha`        | number           | No       | `1`         | Opacity `0..1`.                         |
+| `fill`         | string \| object | No       | transparent | Fill color or structured gradient fill. |
+| `border`       | object           | No       | -           | Border config.                          |
+| `cornerRadius` | number \| object | No       | `0`         | Uniform or per-corner radii.            |
+| `rotation`     | number           | No       | `0`         | Degrees.                                |
+| `scaleX`       | number           | No       | `1`         | Horizontal geometry scale.              |
+| `scaleY`       | number           | No       | `1`         | Vertical geometry scale.                |
+| `blur`         | object           | No       | -           | Directional Gaussian blur.              |
+| `filters`      | array            | No       | `[]`        | Ordered custom shader filters.          |
+| `hover`        | object           | No       | -           | Hover event config.                     |
+| `click`        | object           | No       | -           | Click event config.                     |
+| `rightClick`   | object           | No       | -           | Right click event config.               |
+| `drag`         | object           | No       | -           | `start`/`move`/`end` payload hooks.     |
+| `scrollUp`     | object           | No       | -           | Wheel-up payload hook.                  |
+| `scrollDown`   | object           | No       | -           | Wheel-down payload hook.                |
 
 `filters` runs after built-in rendering effects. See
 [Shaders](/docs/guides/shaders/) for source, uniform, texture, pipeline, and
@@ -50,6 +55,29 @@ filter parameter animation rules.
 | `width` | number | `0`     |
 | `color` | string | `black` |
 | `alpha` | number | `1`     |
+
+The stroke is centered on the rect outline.
+
+### `cornerRadius`
+
+A number applies the same radius to every corner:
+
+```yaml
+cornerRadius: 20
+```
+
+Use an object to control all four corners independently:
+
+```yaml
+cornerRadius:
+  topLeft: 32
+  topRight: 8
+  bottomRight: 32
+  bottomLeft: 8
+```
+
+Missing corners default to `0`. If adjacent radii are too large for the
+rectangle, they are reduced proportionally so they never overlap.
 
 ### `fill`
 
@@ -98,9 +126,86 @@ fill:
 Gradient notes:
 
 - `stops` must include at least 2 items.
-- Each stop `offset` must be between `0` and `1`.
+- Stop offsets must be strictly increasing values between `0` and `1`.
 - `coordinateSpace` can be `local` or `global`.
-- `textureSize` and `wrapMode` are optional advanced Pixi gradient controls.
+- `resolution` optionally controls gradient sampling resolution in pixels.
+- `spread` can be `pad` (default) or `repeat`.
+
+The public fill contract is renderer-independent. Renderer resources and
+sampling objects are managed internally.
+
+## Rect Style Animation
+
+Rect style timelines live directly below `tween`, beside normal transform
+timelines. Numeric properties support manual keyframes or `auto`. Color
+timelines accept color strings and interpolate their RGBA channels.
+
+```yaml
+animations:
+  - id: reshape-panel
+    targetId: panel
+    type: update
+    tween:
+      width:
+        auto: { duration: 600, easing: easeInOutCubic }
+      height:
+        auto: { duration: 600, easing: easeInOutCubic }
+      fill:
+        color:
+          keyframes:
+            - duration: 600
+              value: "#7c3aed"
+              easing: easeInOutCubic
+      border:
+        width:
+          auto: { duration: 600 }
+        color:
+          auto: { duration: 600 }
+        alpha:
+          auto: { duration: 600 }
+      cornerRadius:
+        topLeft:
+          auto: { duration: 600 }
+        topRight:
+          auto: { duration: 600 }
+        bottomRight:
+          auto: { duration: 600 }
+        bottomLeft:
+          auto: { duration: 600 }
+```
+
+Gradient geometry and stops can also be animated:
+
+```yaml
+tween:
+  fill:
+    start:
+      x:
+        auto: { duration: 800 }
+    end:
+      y:
+        auto: { duration: 800 }
+    stops:
+      - index: 0
+        offset:
+          auto: { duration: 800 }
+        color:
+          auto: { duration: 800 }
+```
+
+The current and destination fills must have compatible types. `fill.color`
+requires a solid fill; gradient point/radius properties require the matching
+gradient type; and stop indices must exist in the destination.
+
+## Validation and Pixel Alignment
+
+Rect input is validated before rendering. Unknown properties, invalid colors,
+non-positive dimensions or scales, malformed gradients, invalid event shapes,
+and non-finite numbers fail with a field-specific error.
+
+Computed rect geometry is aligned to whole logical pixels. Fractional authored
+dimensions, positions, origins, and scaled dimensions are rounded during
+parsing; animation samples may still be fractional between frames.
 
 ## Emitted Events
 

--- a/playground/pages/docs/nodes/tween.md
+++ b/playground/pages/docs/nodes/tween.md
@@ -65,24 +65,33 @@ compositor are present, the mask executes before the custom compositor passes.
 
 These properties are valid under `type: update`:
 
-| Property     | Meaning                                                 |
-| ------------ | ------------------------------------------------------- |
-| `x`, `y`     | Absolute position in the parent coordinate space.       |
-| `translateX` | Offset in units of the target's own width.              |
-| `translateY` | Offset in units of the target's own height.             |
-| `alpha`      | Opacity.                                                |
-| `scaleX`     | Horizontal scale.                                       |
-| `scaleY`     | Vertical scale.                                         |
-| `rotation`   | Rotation in degrees.                                    |
-| `blurX`      | Horizontal `blur.x` strength.                           |
-| `blurY`      | Vertical `blur.y` strength.                             |
-| `filters`    | Parameter timelines grouped by inline shader filter id. |
+| Property       | Meaning                                                 |
+| -------------- | ------------------------------------------------------- |
+| `x`, `y`       | Absolute position in the parent coordinate space.       |
+| `translateX`   | Offset in units of the target's own width.              |
+| `translateY`   | Offset in units of the target's own height.             |
+| `alpha`        | Opacity.                                                |
+| `scaleX`       | Horizontal scale.                                       |
+| `scaleY`       | Vertical scale.                                         |
+| `rotation`     | Rotation in degrees.                                    |
+| `blurX`        | Horizontal `blur.x` strength.                           |
+| `blurY`        | Vertical `blur.y` strength.                             |
+| `width`        | Rect geometry width.                                    |
+| `height`       | Rect geometry height.                                   |
+| `fill`         | Rect fill color, gradient geometry, or gradient stops.  |
+| `border`       | Rect border width, color, or alpha.                     |
+| `cornerRadius` | Rect uniform or independent corner radii.               |
+| `filters`      | Parameter timelines grouped by inline shader filter id. |
 
 `x` cannot be combined with `translateX` in one tween, and `y` cannot be
 combined with `translateY`.
 
 `blurX` and `blurY` animate only blur strength. Static blur settings such as
 `quality`, `kernelSize`, and `repeatEdgePixels` are not tween targets.
+
+`width`, `height`, `fill`, `border`, and `cornerRadius` are valid only for
+`rect` targets. See [Rect Node](/docs/nodes/rect/) for their nested timeline
+shape and gradient-stop indexing.
 
 ## Shader Parameter Tweens
 

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -132,16 +132,39 @@ const createPixiModuleMock = ({ rendererOverrides = {} } = {}) => {
       this.scale = { x: 1, y: 1, set: vi.fn() };
       this.rotation = 0;
       this.sortableChildren = false;
+      this.pathCommands = [];
     }
 
     clear() {
       this.lastFill = undefined;
       this.drawnRect = undefined;
+      this.pathCommands = [];
       return this;
     }
 
     rect(x, y, width, height) {
       this.drawnRect = { x, y, width, height };
+      this.pathCommands.push(["rect", x, y, width, height]);
+      return this;
+    }
+
+    moveTo(x, y) {
+      this.pathCommands.push(["moveTo", x, y]);
+      return this;
+    }
+
+    lineTo(x, y) {
+      this.pathCommands.push(["lineTo", x, y]);
+      return this;
+    }
+
+    quadraticCurveTo(controlX, controlY, x, y) {
+      this.pathCommands.push(["quadraticCurveTo", controlX, controlY, x, y]);
+      return this;
+    }
+
+    closePath() {
+      this.pathCommands.push(["closePath"]);
       return this;
     }
 
@@ -439,6 +462,8 @@ const setupRouteGraphics = async ({
   },
 } = {}) => {
   const pixiMock = createPixiModuleMock({ rendererOverrides });
+  const { Color } = await vi.importActual("pixi.js");
+  pixiMock.Color = Color;
 
   vi.doMock("pixi.js", () => pixiMock);
   vi.doMock("../src/AudioStage.js", () => ({
@@ -2123,6 +2148,109 @@ describe("RouteGraphics public API", () => {
     app.setAnimationTime(150);
 
     expect(app.findElementByLabel("preview-rect")?.x).toBeCloseTo(37.5);
+  });
+
+  it("animates rect styles through the public tween interface", async () => {
+    const { app } = await setupRouteGraphics({
+      pluginsFactory: async () => {
+        const [{ rectPlugin }, { tweenPlugin }] = await Promise.all([
+          import("../src/plugins/elements/rect/index.js"),
+          import("../src/plugins/animations/tween/index.js"),
+        ]);
+
+        return {
+          elements: [rectPlugin],
+          animations: [tweenPlugin],
+          audio: [],
+        };
+      },
+    });
+
+    app.render({
+      id: "rect-style-baseline",
+      elements: [
+        {
+          id: "panel",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 40,
+          height: 20,
+          fill: "#ff0000",
+          border: { width: 2, color: "#ffffff", alpha: 1 },
+          cornerRadius: 0,
+        },
+      ],
+    });
+
+    app.setAnimationPlaybackMode("manual");
+    app.render({
+      id: "rect-style-animated",
+      elements: [
+        {
+          id: "panel",
+          type: "rect",
+          x: 0,
+          y: 0,
+          width: 80,
+          height: 60,
+          fill: "#0000ff",
+          border: { width: 6, color: "#00ff00", alpha: 0.5 },
+          cornerRadius: {
+            topLeft: 10,
+            topRight: 20,
+            bottomRight: 30,
+            bottomLeft: 40,
+          },
+        },
+      ],
+      animations: [
+        {
+          id: "panel-style",
+          targetId: "panel",
+          type: "update",
+          tween: {
+            width: { auto: { duration: 500 } },
+            height: { auto: { duration: 500 } },
+            fill: {
+              color: { auto: { duration: 500 } },
+            },
+            border: {
+              width: { auto: { duration: 500 } },
+              color: { auto: { duration: 500 } },
+              alpha: { auto: { duration: 500 } },
+            },
+            cornerRadius: {
+              topLeft: { auto: { duration: 500 } },
+              topRight: { auto: { duration: 500 } },
+              bottomRight: { auto: { duration: 500 } },
+              bottomLeft: { auto: { duration: 500 } },
+            },
+          },
+        },
+      ],
+    });
+
+    app.setAnimationTime(250);
+
+    const panel = app.findElementByLabel("panel");
+    expect(panel.pathCommands.slice(0, 2)).toEqual([
+      ["moveTo", 5, 0],
+      ["lineTo", 50, 0],
+    ]);
+    expect(panel.pathCommands).toContainEqual([
+      "quadraticCurveTo",
+      60,
+      40,
+      45,
+      40,
+    ]);
+    expect(panel.lastFill).toEqual([0.5, 0, 0.5, 1]);
+    expect(panel.lastStroke).toEqual({
+      color: [0.5, 1, 0.5, 1],
+      alpha: 0.75,
+      width: 4,
+    });
   });
 
   it("continues persistent update animations across unrelated renders without restarting", async () => {

--- a/spec/elements/eventSemantics.spec.js
+++ b/spec/elements/eventSemantics.spec.js
@@ -1,4 +1,4 @@
-import { Container } from "pixi.js";
+import { Container, Graphics } from "pixi.js";
 import hotkeys from "hotkeys-js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { addRect } from "../../src/plugins/elements/rect/addRect.js";
@@ -7,6 +7,7 @@ import { addText } from "../../src/plugins/elements/text/addText.js";
 import { addContainer } from "../../src/plugins/elements/container/addContainer.js";
 import { addSlider } from "../../src/plugins/elements/slider/addSlider.js";
 import { createKeyboardManager } from "../../src/util/keyboardManager.js";
+import { bindRectInteractions } from "../../src/plugins/elements/rect/rectInteractions.js";
 
 const createSharedParams = () => ({
   app: {
@@ -47,6 +48,133 @@ afterEach(() => {
 });
 
 describe("event semantics", () => {
+  it("rect emits configured events even when their payload is omitted", () => {
+    const parent = new Container();
+    const eventHandler = vi.fn();
+    const shared = createSharedParams();
+
+    addRect({
+      ...shared,
+      parent,
+      eventHandler,
+      zIndex: 0,
+      element: {
+        id: "rect-no-payload",
+        type: "rect",
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 60,
+        alpha: 1,
+        fill: "#ffffff",
+        hover: {},
+        click: {},
+        rightClick: {},
+      },
+    });
+
+    const rect = parent.getChildByLabel("rect-no-payload");
+    rect.emit("pointerover");
+    rect.emit("pointerup");
+    rect.emit("rightclick");
+
+    expect(eventHandler.mock.calls).toEqual([
+      ["hover", { _event: { id: "rect-no-payload" } }],
+      ["click", { _event: { id: "rect-no-payload" } }],
+      ["rightClick", { _event: { id: "rect-no-payload" } }],
+    ]);
+  });
+
+  it("fully resets rect interaction state when handlers are removed", () => {
+    const rect = new Graphics();
+    rect.label = "interactive";
+    const eventHandler = vi.fn();
+    const app = {
+      audioStage: { add: vi.fn() },
+      canvas: {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+    };
+
+    bindRectInteractions({
+      app,
+      rect,
+      eventHandler,
+      element: {
+        id: "interactive",
+        width: 100,
+        height: 60,
+        hover: { cursor: "pointer" },
+        click: {},
+        drag: { start: {} },
+        scrollUp: {},
+      },
+    });
+    rect.emit("pointerover");
+    rect.emit("pointerdown");
+
+    expect(rect.eventMode).toBe("static");
+    expect(rect.cursor).toBe("pointer");
+    expect(rect._isDragging).toBe(true);
+
+    bindRectInteractions({
+      app,
+      rect,
+      eventHandler,
+      element: { id: "interactive", width: 100, height: 60 },
+    });
+
+    expect(rect.eventMode).toBe("auto");
+    expect(rect.cursor).toBe("auto");
+    expect(rect._isDragging).toBe(false);
+    expect(rect.hitArea).toBeNull();
+    expect(app.canvas.removeEventListener).toHaveBeenCalledWith(
+      "wheel",
+      expect.any(Function),
+    );
+
+    eventHandler.mockClear();
+    rect.emit("pointerover");
+    rect.emit("pointerup");
+    expect(eventHandler).not.toHaveBeenCalled();
+  });
+
+  it("applies right-click sound volume consistently", () => {
+    const parent = new Container();
+    const shared = createSharedParams();
+
+    addRect({
+      ...shared,
+      parent,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+      element: {
+        id: "rect-context-sound",
+        type: "rect",
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 60,
+        alpha: 1,
+        fill: "#ffffff",
+        rightClick: {
+          soundSrc: "context.mp3",
+          soundVolume: 35,
+        },
+      },
+    });
+
+    parent.getChildByLabel("rect-context-sound").emit("rightclick");
+
+    expect(shared.app.audioStage.add).toHaveBeenCalledWith({
+      id: expect.stringMatching(/^rightClick-/),
+      url: "context.mp3",
+      loop: false,
+      volume: 0.35,
+    });
+  });
+
   it("rect emits hover/click/rightClick/scroll payload events", () => {
     const parent = new Container();
     const eventHandler = vi.fn();

--- a/spec/elements/rectConfig.spec.js
+++ b/spec/elements/rectConfig.spec.js
@@ -1,0 +1,420 @@
+import { describe, expect, it } from "vitest";
+import { parseRect } from "../../src/plugins/elements/rect/parseRect.js";
+
+const createRect = (overrides = {}) => ({
+  id: "panel",
+  type: "rect",
+  width: 200,
+  height: 100,
+  fill: "#ffffff",
+  ...overrides,
+});
+
+describe("rect runtime validation", () => {
+  it("accepts the complete renderer-independent rect contract", () => {
+    expect(() =>
+      parseRect({
+        state: createRect({
+          x: 10.5,
+          y: 20.5,
+          anchorX: 0.5,
+          anchorY: 0.5,
+          originX: 12,
+          originY: 18,
+          alpha: 0.8,
+          scaleX: 1.2,
+          scaleY: 0.9,
+          rotation: 15,
+          fill: {
+            type: "linear-gradient",
+            start: { x: 0, y: 0 },
+            end: { x: 1, y: 1 },
+            stops: [
+              { offset: 0, color: "#ff0000" },
+              { offset: 1, color: "rgba(0, 0, 255, 0.5)" },
+            ],
+            coordinateSpace: "local",
+            resolution: 256,
+            spread: "repeat",
+          },
+          border: { width: 2, color: "white", alpha: 0.5 },
+          cornerRadius: {
+            topLeft: 4,
+            topRight: 8,
+            bottomRight: 12,
+            bottomLeft: 16,
+          },
+          blur: {
+            x: 1,
+            y: 2,
+            quality: 3,
+            kernelSize: 7,
+            repeatEdgePixels: true,
+          },
+          hover: {
+            cursor: "pointer",
+            soundSrc: "hover.mp3",
+            soundVolume: 40,
+            payload: { action: "hover" },
+          },
+          click: { payload: { action: "click" } },
+          rightClick: {
+            soundSrc: "context.mp3",
+            soundVolume: 25,
+          },
+          drag: {
+            start: {},
+            move: { payload: { action: "move" } },
+            end: {},
+          },
+          scrollUp: {},
+          scrollDown: { payload: { action: "down" } },
+        }),
+      }),
+    ).not.toThrow();
+  });
+
+  it.each([
+    ["unknown root property", { mystery: true }, "rect.mystery"],
+    ["missing id", { id: undefined }, "rect.id"],
+    ["empty id", { id: "" }, "rect.id"],
+    ["wrong type", { type: "sprite" }, "rect.type"],
+    ["zero width", { width: 0 }, "rect.width"],
+    ["infinite width", { width: Infinity }, "rect.width"],
+    ["negative height", { height: -1 }, "rect.height"],
+    ["infinite position", { x: Infinity }, "rect.x"],
+    ["infinite anchor", { anchorX: -Infinity }, "rect.anchorX"],
+    ["NaN rotation", { rotation: Number.NaN }, "rect.rotation"],
+    ["zero scale", { scaleX: 0 }, "rect.scaleX"],
+    ["infinite scale", { scaleY: Infinity }, "rect.scaleY"],
+    ["out-of-range alpha", { alpha: 1.1 }, "rect.alpha"],
+    ["invalid solid color", { fill: "not-a-real-color()" }, "rect.fill"],
+    ["non-object border", { border: [] }, "rect.border"],
+    [
+      "unknown border property",
+      { border: { width: 1, placement: "inside" } },
+      "rect.border.placement",
+    ],
+    ["negative border", { border: { width: -1 } }, "rect.border.width"],
+    [
+      "invalid border color",
+      { border: { color: "not-a-real-color()" } },
+      "rect.border.color",
+    ],
+    ["invalid border alpha", { border: { alpha: -0.1 } }, "rect.border.alpha"],
+    ["null corners", { cornerRadius: null }, "rect.cornerRadius"],
+    [
+      "invalid corner",
+      { cornerRadius: { topLeft: -1 } },
+      "rect.cornerRadius.topLeft",
+    ],
+    [
+      "unknown corner",
+      { cornerRadius: { upperLeft: 5 } },
+      "rect.cornerRadius.upperLeft",
+    ],
+    [
+      "unknown hover property",
+      { hover: { opacity: 0.5 } },
+      "rect.hover.opacity",
+    ],
+    ["non-object click", { click: true }, "rect.click"],
+    [
+      "unsupported click cursor",
+      { click: { cursor: "pointer" } },
+      "rect.click.cursor",
+    ],
+    ["empty sound source", { hover: { soundSrc: "" } }, "rect.hover.soundSrc"],
+    ["empty cursor", { hover: { cursor: "" } }, "rect.hover.cursor"],
+    [
+      "non-object pointer payload",
+      { click: { payload: [] } },
+      "rect.click.payload",
+    ],
+    [
+      "invalid sound volume",
+      { rightClick: { soundVolume: 101 } },
+      "rect.rightClick.soundVolume",
+    ],
+    ["empty drag", { drag: {} }, "rect.drag"],
+    ["unknown drag property", { drag: { cancel: {} } }, "rect.drag.cancel"],
+    ["non-object drag phase", { drag: { start: true } }, "rect.drag.start"],
+    [
+      "invalid drag phase",
+      { drag: { move: { payload: [] } } },
+      "rect.drag.move.payload",
+    ],
+    [
+      "invalid scroll payload",
+      { scrollUp: { payload: [] } },
+      "rect.scrollUp.payload",
+    ],
+    ["non-object blur", { blur: [] }, "rect.blur"],
+    [
+      "unknown blur property",
+      { blur: { x: 1, y: 1, radius: 2 } },
+      "rect.blur.radius",
+    ],
+  ])("rejects %s", (_name, overrides, message) => {
+    expect(() => parseRect({ state: createRect(overrides) })).toThrow(message);
+  });
+
+  it.each([
+    ["null fill", null, "rect.fill must be an object"],
+    [
+      "unsupported type",
+      { type: "mesh" },
+      'rect.fill.type must be "solid", "linear-gradient", or "radial-gradient"',
+    ],
+    ["missing solid color", { type: "solid" }, "rect.fill.color is required"],
+    [
+      "unknown solid field",
+      { type: "solid", color: "red", alpha: 0.5 },
+      "rect.fill.alpha",
+    ],
+    ["missing stops", { type: "linear-gradient" }, "rect.fill.stops"],
+    [
+      "one stop",
+      {
+        type: "linear-gradient",
+        stops: [{ offset: 0, color: "red" }],
+      },
+      "at least two stops",
+    ],
+    [
+      "duplicate offsets",
+      {
+        type: "linear-gradient",
+        stops: [
+          { offset: 0, color: "red" },
+          { offset: 0, color: "blue" },
+        ],
+      },
+      "strictly increasing",
+    ],
+    [
+      "descending offsets",
+      {
+        type: "radial-gradient",
+        stops: [
+          { offset: 1, color: "red" },
+          { offset: 0, color: "blue" },
+        ],
+      },
+      "strictly increasing",
+    ],
+    [
+      "out-of-range stop",
+      {
+        type: "linear-gradient",
+        stops: [
+          { offset: -0.1, color: "red" },
+          { offset: 1, color: "blue" },
+        ],
+      },
+      "rect.fill.stops[0].offset",
+    ],
+    [
+      "missing stop color",
+      {
+        type: "linear-gradient",
+        stops: [{ offset: 0 }, { offset: 1, color: "blue" }],
+      },
+      "rect.fill.stops[0].offset and rect.fill.stops[0].color are required",
+    ],
+    [
+      "unknown stop field",
+      {
+        type: "linear-gradient",
+        stops: [
+          { offset: 0, color: "red", midpoint: 0.5 },
+          { offset: 1, color: "blue" },
+        ],
+      },
+      "rect.fill.stops[0].midpoint",
+    ],
+    [
+      "invalid stop color",
+      {
+        type: "linear-gradient",
+        stops: [
+          { offset: 0, color: "not-a-real-color()" },
+          { offset: 1, color: "blue" },
+        ],
+      },
+      "rect.fill.stops[0].color",
+    ],
+    [
+      "invalid point",
+      {
+        type: "linear-gradient",
+        start: { x: 0 },
+        stops: [
+          { offset: 0, color: "red" },
+          { offset: 1, color: "blue" },
+        ],
+      },
+      "rect.fill.start.x and rect.fill.start.y",
+    ],
+    [
+      "unknown point field",
+      {
+        type: "linear-gradient",
+        start: { x: 0, y: 0, z: 0 },
+        stops: [
+          { offset: 0, color: "red" },
+          { offset: 1, color: "blue" },
+        ],
+      },
+      "rect.fill.start.z",
+    ],
+    [
+      "invalid coordinate space",
+      {
+        type: "linear-gradient",
+        coordinateSpace: "screen",
+        stops: [
+          { offset: 0, color: "red" },
+          { offset: 1, color: "blue" },
+        ],
+      },
+      'rect.fill.coordinateSpace must be "local" or "global"',
+    ],
+    [
+      "negative radial radius",
+      {
+        type: "radial-gradient",
+        innerRadius: -1,
+        stops: [
+          { offset: 0, color: "red" },
+          { offset: 1, color: "blue" },
+        ],
+      },
+      "rect.fill.innerRadius",
+    ],
+    [
+      "zero outer radius",
+      {
+        type: "radial-gradient",
+        outerRadius: 0,
+        stops: [
+          { offset: 0, color: "red" },
+          { offset: 1, color: "blue" },
+        ],
+      },
+      "rect.fill.outerRadius",
+    ],
+    [
+      "zero radial scale",
+      {
+        type: "radial-gradient",
+        scale: 0,
+        stops: [
+          { offset: 0, color: "red" },
+          { offset: 1, color: "blue" },
+        ],
+      },
+      "rect.fill.scale",
+    ],
+    [
+      "non-finite radial rotation",
+      {
+        type: "radial-gradient",
+        rotation: Infinity,
+        stops: [
+          { offset: 0, color: "red" },
+          { offset: 1, color: "blue" },
+        ],
+      },
+      "rect.fill.rotation",
+    ],
+    [
+      "invalid spread",
+      {
+        type: "linear-gradient",
+        spread: "reflect",
+        stops: [
+          { offset: 0, color: "red" },
+          { offset: 1, color: "blue" },
+        ],
+      },
+      'rect.fill.spread must be "pad" or "repeat"',
+    ],
+    [
+      "non-positive resolution",
+      {
+        type: "linear-gradient",
+        resolution: 0,
+        stops: [
+          { offset: 0, color: "red" },
+          { offset: 1, color: "blue" },
+        ],
+      },
+      "rect.fill.resolution",
+    ],
+    [
+      "legacy textureSize",
+      {
+        type: "linear-gradient",
+        textureSize: 128,
+        stops: [
+          { offset: 0, color: "red" },
+          { offset: 1, color: "blue" },
+        ],
+      },
+      "use rect.fill.resolution",
+    ],
+    [
+      "legacy wrapMode",
+      {
+        type: "linear-gradient",
+        wrapMode: "repeat",
+        stops: [
+          { offset: 0, color: "red" },
+          { offset: 1, color: "blue" },
+        ],
+      },
+      "use rect.fill.spread",
+    ],
+  ])("rejects a gradient with %s", (_name, fill, message) => {
+    expect(() => parseRect({ state: createRect({ fill }) })).toThrow(message);
+  });
+
+  it("normalizes uniform and independent corner radii", () => {
+    const uniform = parseRect({
+      state: createRect({ cornerRadius: 12 }),
+    });
+    const independent = parseRect({
+      state: createRect({
+        cornerRadius: { topLeft: 4, bottomRight: 9 },
+      }),
+    });
+
+    expect(uniform.cornerRadius).toEqual({
+      topLeft: 12,
+      topRight: 12,
+      bottomRight: 12,
+      bottomLeft: 12,
+    });
+    expect(independent.cornerRadius).toEqual({
+      topLeft: 4,
+      topRight: 0,
+      bottomRight: 9,
+      bottomLeft: 0,
+    });
+  });
+
+  it("retains normalized blur instead of silently dropping it", () => {
+    expect(
+      parseRect({
+        state: createRect({ blur: { x: 2, y: 3 } }),
+      }).blur,
+    ).toEqual({
+      x: 2,
+      y: 3,
+      quality: 4,
+      kernelSize: 5,
+      repeatEdgePixels: false,
+    });
+  });
+});

--- a/spec/elements/rectConfig.spec.js
+++ b/spec/elements/rectConfig.spec.js
@@ -74,6 +74,34 @@ describe("rect runtime validation", () => {
     ).not.toThrow();
   });
 
+  it("retains latent border styling when the authored width is zero", () => {
+    expect(
+      parseRect({
+        state: createRect({
+          border: { width: 0, color: "#ff0000", alpha: 0.35 },
+        }),
+      }).border,
+    ).toEqual({
+      width: 0,
+      color: "#ff0000",
+      alpha: 0.35,
+    });
+  });
+
+  it("normalizes an authored border with an omitted width to zero", () => {
+    expect(
+      parseRect({
+        state: createRect({
+          border: { color: "#00ff00", alpha: 0.4 },
+        }),
+      }).border,
+    ).toEqual({
+      width: 0,
+      color: "#00ff00",
+      alpha: 0.4,
+    });
+  });
+
   it.each([
     ["unknown root property", { mystery: true }, "rect.mystery"],
     ["missing id", { id: undefined }, "rect.id"],

--- a/spec/elements/rectDrawing.spec.js
+++ b/spec/elements/rectDrawing.spec.js
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  appendRectPath,
+  resolveRenderedCornerRadius,
+} from "../../src/plugins/elements/rect/rectDrawing.js";
+
+const createGraphicsSpy = () => {
+  const graphics = {};
+  for (const method of [
+    "rect",
+    "moveTo",
+    "lineTo",
+    "quadraticCurveTo",
+    "closePath",
+  ]) {
+    graphics[method] = vi.fn(() => graphics);
+  }
+  return graphics;
+};
+
+describe("rect rounded geometry", () => {
+  it("uses the simple rectangle path when every radius is zero", () => {
+    const graphics = createGraphicsSpy();
+
+    appendRectPath(graphics, 120, 80, 0);
+
+    expect(graphics.rect).toHaveBeenCalledWith(0, 0, 120, 80);
+    expect(graphics.moveTo).not.toHaveBeenCalled();
+  });
+
+  it("draws all four corner radii independently", () => {
+    const graphics = createGraphicsSpy();
+
+    appendRectPath(graphics, 120, 80, {
+      topLeft: 4,
+      topRight: 8,
+      bottomRight: 12,
+      bottomLeft: 16,
+    });
+
+    expect(graphics.moveTo).toHaveBeenCalledWith(4, 0);
+    expect(graphics.lineTo).toHaveBeenNthCalledWith(1, 112, 0);
+    expect(graphics.quadraticCurveTo).toHaveBeenNthCalledWith(
+      1,
+      120,
+      0,
+      120,
+      8,
+    );
+    expect(graphics.quadraticCurveTo).toHaveBeenNthCalledWith(
+      2,
+      120,
+      80,
+      108,
+      80,
+    );
+    expect(graphics.quadraticCurveTo).toHaveBeenNthCalledWith(3, 0, 80, 0, 64);
+    expect(graphics.quadraticCurveTo).toHaveBeenNthCalledWith(4, 0, 0, 4, 0);
+    expect(graphics.closePath).toHaveBeenCalledOnce();
+  });
+
+  it("reduces oversized adjacent radii proportionally", () => {
+    expect(
+      resolveRenderedCornerRadius(
+        {
+          topLeft: 80,
+          topRight: 80,
+          bottomRight: 20,
+          bottomLeft: 20,
+        },
+        100,
+        60,
+      ),
+    ).toEqual({
+      topLeft: 48,
+      topRight: 48,
+      bottomRight: 12,
+      bottomLeft: 12,
+    });
+  });
+
+  it("clamps animated negative dimensions without producing invalid paths", () => {
+    const graphics = createGraphicsSpy();
+
+    appendRectPath(graphics, -20, Number.NaN, 12);
+
+    expect(graphics.rect).toHaveBeenCalledWith(0, 0, 0, 0);
+  });
+});

--- a/spec/elements/rectFill.spec.js
+++ b/spec/elements/rectFill.spec.js
@@ -35,8 +35,8 @@ describe("rectFill", () => {
         { offset: 0, color: "#ff0000" },
       ],
       coordinateSpace: "global",
-      textureSize: 128,
-      wrapMode: "repeat",
+      resolution: 128,
+      spread: "repeat",
     });
 
     expect(fill).toBeInstanceOf(FillGradient);
@@ -44,6 +44,8 @@ describe("rectFill", () => {
     expect(fill.start).toEqual({ x: 1, y: 0 });
     expect(fill.end).toEqual({ x: 0, y: 1 });
     expect(fill.textureSpace).toBe("global");
+    expect(fill._textureSize).toBe(128);
+    expect(fill._wrapMode).toBe("repeat");
     expect(fill.colorStops.map((stop) => stop.offset)).toEqual([0, 1]);
     fill.destroy();
   });
@@ -138,8 +140,8 @@ describe("rectFill", () => {
         { offset: 1, color: "#000000" },
       ],
       coordinateSpace: "local",
-      textureSize: 512,
-      wrapMode: "clamp-to-edge",
+      resolution: 512,
+      spread: "pad",
       scale: 0.8,
       rotation: 0.4,
     });
@@ -152,6 +154,8 @@ describe("rectFill", () => {
     expect(fill.outerRadius).toBe(0.9);
     expect(fill.scale).toBe(0.8);
     expect(fill.rotation).toBe(0.4);
+    expect(fill._textureSize).toBe(512);
+    expect(fill._wrapMode).toBe("clamp-to-edge");
     fill.destroy();
   });
 

--- a/spec/elements/rectStyleAnimation.spec.js
+++ b/spec/elements/rectStyleAnimation.spec.js
@@ -137,6 +137,198 @@ describe("rect style animation", () => {
     ).toBe(50);
   });
 
+  it("composes dimension and scale tweens without applying baked scale twice", () => {
+    const parent = new Container();
+    const animationBus = createAnimationBus();
+    const prevElement = createRect({
+      width: 100,
+      height: 80,
+      scaleX: 2,
+      scaleY: 0.5,
+    });
+    const nextElement = createRect({
+      width: 200,
+      height: 120,
+      scaleX: 3,
+      scaleY: 1.5,
+    });
+    const rect = mountRect(parent, prevElement, animationBus);
+    const animations = normalizeAnimations([
+      {
+        id: "resize-and-scale",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          width: { auto: { duration: 1000 } },
+          height: { auto: { duration: 1000 } },
+          scaleX: { auto: { duration: 1000 } },
+          scaleY: { auto: { duration: 1000 } },
+        },
+      },
+    ]);
+
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations,
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    expect(getRectStyleAnimationValue(rect, "rect.width")).toBe(100);
+    expect(getRectStyleAnimationValue(rect, "rect.height")).toBe(80);
+    expect(rect.scale.x).toBe(2);
+    expect(rect.scale.y).toBe(0.5);
+
+    animationBus.flush();
+    animationBus.tick(500);
+
+    expect(getRectStyleAnimationValue(rect, "rect.width")).toBe(150);
+    expect(getRectStyleAnimationValue(rect, "rect.height")).toBe(100);
+    expect(rect.scale.x).toBe(2.5);
+    expect(rect.scale.y).toBe(1);
+    expect(getRectStyleAnimationValue(rect, "rect.width") * rect.scale.x).toBe(
+      375,
+    );
+    expect(getRectStyleAnimationValue(rect, "rect.height") * rect.scale.y).toBe(
+      100,
+    );
+
+    animationBus.tick(500);
+
+    expect(getRectStyleAnimationValue(rect, "rect.width")).toBe(600);
+    expect(getRectStyleAnimationValue(rect, "rect.height")).toBe(180);
+    expect(rect.scale.x).toBe(1);
+    expect(rect.scale.y).toBe(1);
+  });
+
+  it("settles scale-only tweens to unbaked geometry when cancelled", () => {
+    const parent = new Container();
+    const animationBus = createAnimationBus();
+    const prevElement = createRect({
+      width: 100,
+      height: 80,
+      scaleX: 2,
+      scaleY: 0.5,
+    });
+    const nextElement = createRect({
+      width: 100,
+      height: 80,
+      scaleX: 3,
+      scaleY: 1.5,
+    });
+    const rect = mountRect(parent, prevElement, animationBus);
+    const animations = normalizeAnimations([
+      {
+        id: "scale-only",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          scaleX: { auto: { duration: 1000 } },
+          scaleY: { auto: { duration: 1000 } },
+        },
+      },
+    ]);
+
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations,
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+    animationBus.flush();
+    animationBus.tick(250);
+    animationBus.cancelAllExcept(new Set());
+
+    expect(getRectStyleAnimationValue(rect, "rect.width")).toBe(100);
+    expect(getRectStyleAnimationValue(rect, "rect.height")).toBe(80);
+    expect(rect.scale.x).toBe(3);
+    expect(rect.scale.y).toBe(1.5);
+    expect(getRectStyleAnimationValue(rect, "rect.width") * rect.scale.x).toBe(
+      nextElement.width,
+    );
+    expect(getRectStyleAnimationValue(rect, "rect.height") * rect.scale.y).toBe(
+      nextElement.height,
+    );
+
+    updateRect({
+      app,
+      parent,
+      prevElement: nextElement,
+      nextElement,
+      animations: [],
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    expect(getRectStyleAnimationValue(rect, "rect.width")).toBe(
+      nextElement.width,
+    );
+    expect(getRectStyleAnimationValue(rect, "rect.height")).toBe(
+      nextElement.height,
+    );
+    expect(rect.scale.x).toBe(1);
+    expect(rect.scale.y).toBe(1);
+  });
+
+  it("reveals an authored zero-width border without losing its styling", () => {
+    const parent = new Container();
+    const animationBus = createAnimationBus();
+    const prevElement = createRect({
+      border: { width: 0, color: "#ff0000", alpha: 0.35 },
+    });
+    const nextElement = createRect({
+      border: { width: 8, color: "#ff0000", alpha: 0.35 },
+    });
+    const rect = mountRect(parent, prevElement, animationBus);
+    const animations = normalizeAnimations([
+      {
+        id: "reveal-border",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          border: {
+            width: {
+              initialValue: 0,
+              keyframes: [{ duration: 1000, value: 8 }],
+            },
+          },
+        },
+      },
+    ]);
+
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations,
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+    animationBus.flush();
+    animationBus.tick(500);
+
+    expect(getRectStyleAnimationValue(rect, "rect.border.width")).toBe(4);
+    expect(getRectStyleAnimationValue(rect, "rect.border.color")).toEqual([
+      1, 0, 0, 1,
+    ]);
+    expect(getRectStyleAnimationValue(rect, "rect.border.alpha")).toBe(0.35);
+  });
+
   it("animates gradient geometry, offsets, and colors", () => {
     const parent = new Container();
     const animationBus = createAnimationBus();

--- a/spec/elements/rectStyleAnimation.spec.js
+++ b/spec/elements/rectStyleAnimation.spec.js
@@ -1,0 +1,535 @@
+import { Container } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
+import { createAnimationBus } from "../../src/plugins/animations/animationBus.js";
+import { addRect } from "../../src/plugins/elements/rect/addRect.js";
+import { updateRect } from "../../src/plugins/elements/rect/updateRect.js";
+import { parseRect } from "../../src/plugins/elements/rect/parseRect.js";
+import { getRectStyleAnimationValue } from "../../src/plugins/elements/rect/rectStyleRuntime.js";
+import { normalizeAnimations } from "../../src/util/normalizeAnimations.js";
+
+const app = {
+  audioStage: { add: vi.fn() },
+};
+
+const completionTracker = {
+  getVersion: () => 1,
+  track: vi.fn(),
+  complete: vi.fn(),
+};
+
+const createRect = (overrides = {}) =>
+  parseRect({
+    state: {
+      id: "panel",
+      type: "rect",
+      x: 100,
+      y: 100,
+      width: 200,
+      height: 100,
+      fill: "#ff0000",
+      border: { width: 2, color: "#ffffff", alpha: 1 },
+      cornerRadius: 4,
+      ...overrides,
+    },
+  });
+
+const mountRect = (parent, element, animationBus, animations = []) => {
+  addRect({
+    app,
+    parent,
+    element,
+    animations,
+    animationBus,
+    completionTracker,
+    eventHandler: vi.fn(),
+    zIndex: 0,
+  });
+  animationBus.flush();
+  return parent.getChildByLabel(element.id);
+};
+
+describe("rect style animation", () => {
+  it("animates dimensions, solid colors, border, and independent corners", () => {
+    const parent = new Container();
+    const animationBus = createAnimationBus();
+    const prevElement = createRect();
+    const nextElement = createRect({
+      width: 300,
+      height: 180,
+      fill: "#0000ff",
+      border: { width: 10, color: "#00ff00", alpha: 0.5 },
+      cornerRadius: {
+        topLeft: 20,
+        topRight: 30,
+        bottomRight: 40,
+        bottomLeft: 50,
+      },
+    });
+    const rect = mountRect(parent, prevElement, animationBus);
+    const animations = normalizeAnimations([
+      {
+        id: "reshape",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          width: { auto: { duration: 1000 } },
+          height: { auto: { duration: 1000 } },
+          fill: {
+            color: { auto: { duration: 1000 } },
+          },
+          border: {
+            width: { auto: { duration: 1000 } },
+            color: { auto: { duration: 1000 } },
+            alpha: { auto: { duration: 1000 } },
+          },
+          cornerRadius: {
+            topLeft: { auto: { duration: 1000 } },
+            topRight: { auto: { duration: 1000 } },
+            bottomRight: { auto: { duration: 1000 } },
+            bottomLeft: { auto: { duration: 1000 } },
+          },
+        },
+      },
+    ]);
+
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations,
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+    const clearSpy = vi.spyOn(rect, "clear");
+    animationBus.flush();
+    animationBus.tick(500);
+
+    expect(clearSpy).toHaveBeenCalledTimes(2);
+
+    expect(getRectStyleAnimationValue(rect, "rect.width")).toBe(250);
+    expect(getRectStyleAnimationValue(rect, "rect.height")).toBe(140);
+    expect(getRectStyleAnimationValue(rect, "rect.fill.color")).toEqual([
+      0.5, 0, 0.5, 1,
+    ]);
+    expect(getRectStyleAnimationValue(rect, "rect.border.width")).toBe(6);
+    expect(getRectStyleAnimationValue(rect, "rect.border.color")).toEqual([
+      0.5, 1, 0.5, 1,
+    ]);
+    expect(getRectStyleAnimationValue(rect, "rect.border.alpha")).toBe(0.75);
+    expect(getRectStyleAnimationValue(rect, "rect.cornerRadius.topLeft")).toBe(
+      12,
+    );
+    expect(
+      getRectStyleAnimationValue(rect, "rect.cornerRadius.bottomLeft"),
+    ).toBe(27);
+
+    animationBus.tick(500);
+
+    expect(getRectStyleAnimationValue(rect, "rect.width")).toBe(300);
+    expect(getRectStyleAnimationValue(rect, "rect.fill.color")).toEqual([
+      0, 0, 1, 1,
+    ]);
+    expect(
+      getRectStyleAnimationValue(rect, "rect.cornerRadius.bottomLeft"),
+    ).toBe(50);
+  });
+
+  it("animates gradient geometry, offsets, and colors", () => {
+    const parent = new Container();
+    const animationBus = createAnimationBus();
+    const prevElement = createRect({
+      fill: {
+        type: "linear-gradient",
+        start: { x: 0, y: 0 },
+        end: { x: 1, y: 0 },
+        stops: [
+          { offset: 0, color: "#ff0000" },
+          { offset: 1, color: "#0000ff" },
+        ],
+      },
+    });
+    const nextElement = createRect({
+      fill: {
+        type: "linear-gradient",
+        start: { x: 0.25, y: 0.5 },
+        end: { x: 0.75, y: 1 },
+        stops: [
+          { offset: 0.2, color: "#00ff00" },
+          { offset: 0.8, color: "#ffffff" },
+        ],
+      },
+    });
+    const rect = mountRect(parent, prevElement, animationBus);
+    const animations = normalizeAnimations([
+      {
+        id: "gradient-shift",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          fill: {
+            start: {
+              x: { auto: { duration: 1000 } },
+              y: { auto: { duration: 1000 } },
+            },
+            end: {
+              x: { auto: { duration: 1000 } },
+              y: { auto: { duration: 1000 } },
+            },
+            stops: [
+              {
+                index: 0,
+                offset: { auto: { duration: 1000 } },
+                color: { auto: { duration: 1000 } },
+              },
+              {
+                index: 1,
+                offset: { auto: { duration: 1000 } },
+                color: { auto: { duration: 1000 } },
+              },
+            ],
+          },
+        },
+      },
+    ]);
+
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations,
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+    animationBus.flush();
+    animationBus.tick(500);
+
+    expect(getRectStyleAnimationValue(rect, "rect.fill.start.x")).toBe(0.125);
+    expect(getRectStyleAnimationValue(rect, "rect.fill.start.y")).toBe(0.25);
+    expect(getRectStyleAnimationValue(rect, "rect.fill.end.x")).toBe(0.875);
+    expect(getRectStyleAnimationValue(rect, "rect.fill.end.y")).toBe(0.5);
+    expect(
+      getRectStyleAnimationValue(rect, "rect.fill.stops.0.offset"),
+    ).toBeCloseTo(0.1);
+    expect(
+      getRectStyleAnimationValue(rect, "rect.fill.stops.1.offset"),
+    ).toBeCloseTo(0.9);
+    expect(getRectStyleAnimationValue(rect, "rect.fill.stops.0.color")).toEqual(
+      [0.5, 0.5, 0, 1],
+    );
+    expect(getRectStyleAnimationValue(rect, "rect.fill.stops.1.color")).toEqual(
+      [0.5, 0.5, 1, 1],
+    );
+  });
+
+  it("animates radial-gradient centers, radii, scale, and rotation", () => {
+    const parent = new Container();
+    const animationBus = createAnimationBus();
+    const prevElement = createRect({
+      fill: {
+        type: "radial-gradient",
+        innerCenter: { x: 0.2, y: 0.3 },
+        innerRadius: 0.1,
+        outerCenter: { x: 0.4, y: 0.5 },
+        outerRadius: 0.6,
+        scale: 1,
+        rotation: 0,
+        stops: [
+          { offset: 0, color: "#000000" },
+          { offset: 1, color: "#ffffff" },
+        ],
+      },
+    });
+    const nextElement = createRect({
+      fill: {
+        type: "radial-gradient",
+        innerCenter: { x: 0.4, y: 0.5 },
+        innerRadius: 0.3,
+        outerCenter: { x: 0.8, y: 0.9 },
+        outerRadius: 1,
+        scale: 2,
+        rotation: Math.PI,
+        stops: [
+          { offset: 0, color: "#000000" },
+          { offset: 1, color: "#ffffff" },
+        ],
+      },
+    });
+    const rect = mountRect(parent, prevElement, animationBus);
+    const animations = normalizeAnimations([
+      {
+        id: "radial-shift",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          fill: {
+            innerCenter: {
+              x: { auto: { duration: 1000 } },
+              y: { auto: { duration: 1000 } },
+            },
+            innerRadius: { auto: { duration: 1000 } },
+            outerCenter: {
+              x: { auto: { duration: 1000 } },
+              y: { auto: { duration: 1000 } },
+            },
+            outerRadius: { auto: { duration: 1000 } },
+            scale: { auto: { duration: 1000 } },
+            rotation: { auto: { duration: 1000 } },
+          },
+        },
+      },
+    ]);
+
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations,
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+    animationBus.flush();
+    animationBus.tick(500);
+
+    expect(
+      getRectStyleAnimationValue(rect, "rect.fill.innerCenter.x"),
+    ).toBeCloseTo(0.3);
+    expect(
+      getRectStyleAnimationValue(rect, "rect.fill.innerCenter.y"),
+    ).toBeCloseTo(0.4);
+    expect(
+      getRectStyleAnimationValue(rect, "rect.fill.innerRadius"),
+    ).toBeCloseTo(0.2);
+    expect(
+      getRectStyleAnimationValue(rect, "rect.fill.outerCenter.x"),
+    ).toBeCloseTo(0.6);
+    expect(
+      getRectStyleAnimationValue(rect, "rect.fill.outerCenter.y"),
+    ).toBeCloseTo(0.7);
+    expect(
+      getRectStyleAnimationValue(rect, "rect.fill.outerRadius"),
+    ).toBeCloseTo(0.8);
+    expect(getRectStyleAnimationValue(rect, "rect.fill.scale")).toBeCloseTo(
+      1.5,
+    );
+    expect(getRectStyleAnimationValue(rect, "rect.fill.rotation")).toBeCloseTo(
+      Math.PI / 2,
+    );
+  });
+
+  it("settles every rect style channel in one redraw when interrupted", () => {
+    const parent = new Container();
+    const animationBus = createAnimationBus();
+    const prevElement = createRect();
+    const nextElement = createRect({
+      width: 300,
+      fill: "#0000ff",
+      border: { width: 8, color: "#00ff00", alpha: 0.5 },
+      cornerRadius: 24,
+    });
+    const rect = mountRect(parent, prevElement, animationBus);
+    const animations = normalizeAnimations([
+      {
+        id: "interruptible-style",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          width: { auto: { duration: 1000 } },
+          fill: { color: { auto: { duration: 1000 } } },
+          border: {
+            width: { auto: { duration: 1000 } },
+            color: { auto: { duration: 1000 } },
+            alpha: { auto: { duration: 1000 } },
+          },
+          cornerRadius: { auto: { duration: 1000 } },
+        },
+      },
+    ]);
+
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations,
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+    animationBus.flush();
+    animationBus.tick(250);
+
+    const clearSpy = vi.spyOn(rect, "clear");
+    animationBus.cancelAllExcept(new Set());
+
+    expect(clearSpy).toHaveBeenCalledOnce();
+    expect(getRectStyleAnimationValue(rect, "rect.width")).toBe(300);
+    expect(getRectStyleAnimationValue(rect, "rect.fill.color")).toEqual([
+      0, 0, 1, 1,
+    ]);
+    expect(getRectStyleAnimationValue(rect, "rect.border.width")).toBe(8);
+    expect(getRectStyleAnimationValue(rect, "rect.border.color")).toEqual([
+      0, 1, 0, 1,
+    ]);
+    expect(getRectStyleAnimationValue(rect, "rect.border.alpha")).toBe(0.5);
+    expect(
+      getRectStyleAnimationValue(rect, "rect.cornerRadius.bottomLeft"),
+    ).toBe(24);
+  });
+
+  it("applies explicit rect style initial values on mount", () => {
+    const parent = new Container();
+    const animationBus = createAnimationBus();
+    const element = createRect({
+      width: 300,
+      fill: "#0000ff",
+      cornerRadius: 40,
+    });
+    const animations = normalizeAnimations([
+      {
+        id: "enter-style",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          width: {
+            initialValue: 120,
+            keyframes: [{ duration: 1000, value: 300 }],
+          },
+          fill: {
+            color: {
+              initialValue: "#ff0000",
+              keyframes: [{ duration: 1000, value: "#0000ff" }],
+            },
+          },
+          cornerRadius: {
+            initialValue: 0,
+            keyframes: [{ duration: 1000, value: 40 }],
+          },
+        },
+      },
+    ]);
+
+    const rect = mountRect(parent, element, animationBus, animations);
+
+    expect(getRectStyleAnimationValue(rect, "rect.width")).toBe(120);
+    expect(getRectStyleAnimationValue(rect, "rect.fill.color")).toEqual([
+      1, 0, 0, 1,
+    ]);
+    expect(getRectStyleAnimationValue(rect, "rect.cornerRadius.topRight")).toBe(
+      0,
+    );
+  });
+
+  it("fails before playback when the current fill shape is incompatible", () => {
+    const parent = new Container();
+    const animationBus = createAnimationBus();
+    const prevElement = createRect({ fill: "#ff0000" });
+    const nextElement = createRect({
+      fill: {
+        type: "linear-gradient",
+        stops: [
+          { offset: 0, color: "#000000" },
+          { offset: 1, color: "#ffffff" },
+        ],
+      },
+    });
+    mountRect(parent, prevElement, animationBus);
+    const animations = normalizeAnimations([
+      {
+        id: "incompatible-fill",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          fill: {
+            start: {
+              x: { auto: { duration: 100 } },
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(() =>
+      updateRect({
+        app,
+        parent,
+        prevElement,
+        nextElement,
+        animations,
+        animationBus,
+        completionTracker,
+        eventHandler: vi.fn(),
+        zIndex: 0,
+      }),
+    ).toThrow(
+      'Animation "incompatible-fill" property "fill.start.x" is incompatible with the current rect fill.',
+    );
+  });
+
+  it("fails before playback when a gradient stop target is missing", () => {
+    const parent = new Container();
+    const animationBus = createAnimationBus();
+    const prevElement = createRect({
+      fill: {
+        type: "linear-gradient",
+        stops: [
+          { offset: 0, color: "#000000" },
+          { offset: 1, color: "#ffffff" },
+        ],
+      },
+    });
+    const nextElement = createRect({
+      fill: {
+        type: "linear-gradient",
+        stops: [
+          { offset: 0, color: "#ff0000" },
+          { offset: 0.5, color: "#00ff00" },
+          { offset: 1, color: "#0000ff" },
+        ],
+      },
+    });
+    mountRect(parent, prevElement, animationBus);
+    const animations = normalizeAnimations([
+      {
+        id: "missing-stop",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          fill: {
+            stops: [
+              {
+                index: 2,
+                color: { auto: { duration: 100 } },
+              },
+            ],
+          },
+        },
+      },
+    ]);
+
+    expect(() =>
+      updateRect({
+        app,
+        parent,
+        prevElement,
+        nextElement,
+        animations,
+        animationBus,
+        completionTracker,
+        eventHandler: vi.fn(),
+        zIndex: 0,
+      }),
+    ).toThrow(
+      'Animation "missing-stop" property "fill.stops.2.color" is incompatible with the current rect fill.',
+    );
+  });
+});

--- a/spec/elements/rectStyleRuntime.spec.js
+++ b/spec/elements/rectStyleRuntime.spec.js
@@ -226,6 +226,38 @@ describe("rect style animation runtime", () => {
     });
   });
 
+  it("removes baked geometry scale only on axes using a live scale tween", () => {
+    expect(
+      getRectStyleTargetState(
+        createElement({
+          width: 300,
+          height: 50,
+          scaleX: 1.5,
+          scaleY: 0.5,
+        }),
+        { liveScaleX: true },
+      ),
+    ).toMatchObject({
+      "rect.width": 200,
+      "rect.height": 50,
+    });
+
+    expect(
+      getRectStyleTargetState(
+        createElement({
+          width: 300,
+          height: 50,
+          scaleX: 1.5,
+          scaleY: 0.5,
+        }),
+        { liveScaleY: true },
+      ),
+    ).toMatchObject({
+      "rect.width": 300,
+      "rect.height": 100,
+    });
+  });
+
   it("exposes gradient geometry and indexed stop targets", () => {
     const targets = getRectStyleTargetState(
       createElement({

--- a/spec/elements/rectStyleRuntime.spec.js
+++ b/spec/elements/rectStyleRuntime.spec.js
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getRectStyleAnimationBatchHooks,
+  getRectStyleAnimationValue,
+  getRectStyleTargetState,
+  isRectAnimationProperty,
+  installRectStyleRuntime,
+  setRectStyleAnimationValue,
+  syncRectStyleRuntime,
+  validateRectStyleAnimationTarget,
+} from "../../src/plugins/elements/rect/rectStyleRuntime.js";
+import {
+  getAnimationProperty,
+  setAnimationProperty,
+} from "../../src/plugins/animations/animationPropertyUtils.js";
+import { TRANSITION_PROPERTY_PATH_MAP } from "../../src/types.js";
+
+const createElement = (overrides = {}) => ({
+  id: "panel",
+  type: "rect",
+  width: 200,
+  height: 100,
+  fill: "#ff0000",
+  border: { width: 2, color: "#ffffff", alpha: 0.8 },
+  cornerRadius: {
+    topLeft: 4,
+    topRight: 8,
+    bottomRight: 12,
+    bottomLeft: 16,
+  },
+  ...overrides,
+});
+
+describe("rect style animation runtime", () => {
+  it("recognizes only supported private rect property paths", () => {
+    expect(isRectAnimationProperty("rect.width")).toBe(true);
+    expect(isRectAnimationProperty("rect.fill.stops.12.color")).toBe(true);
+    expect(isRectAnimationProperty("rect.cornerRadius.bottomLeft")).toBe(true);
+    expect(isRectAnimationProperty("rect.fill.stops.-1.color")).toBe(false);
+    expect(isRectAnimationProperty("rect.fill.textureSize")).toBe(false);
+    expect(isRectAnimationProperty("rect.unknown")).toBe(false);
+  });
+
+  it("routes flattened animation properties through the private style proxy", () => {
+    const displayObject = {};
+    const onChange = vi.fn();
+    const runtime = installRectStyleRuntime(
+      displayObject,
+      createElement(),
+      onChange,
+    );
+
+    expect(
+      getAnimationProperty(
+        displayObject,
+        "rect.width",
+        TRANSITION_PROPERTY_PATH_MAP,
+      ),
+    ).toBe(200);
+
+    setAnimationProperty(
+      displayObject,
+      "rect.cornerRadius.topRight",
+      TRANSITION_PROPERTY_PATH_MAP,
+      24,
+    );
+    setAnimationProperty(
+      displayObject,
+      "rect.fill.color",
+      TRANSITION_PROPERTY_PATH_MAP,
+      [0, 0, 1, 1],
+    );
+
+    expect(runtime.state.cornerRadius.topRight).toBe(24);
+    expect(runtime.state.fill).toEqual([0, 0, 1, 1]);
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("batches multiple animated style writes into one redraw notification", () => {
+    const displayObject = {};
+    const onChange = vi.fn();
+    const runtime = installRectStyleRuntime(
+      displayObject,
+      createElement(),
+      onChange,
+    );
+    const hooks = getRectStyleAnimationBatchHooks(displayObject);
+
+    hooks.beforeApplyFrame();
+    runtime["rect.width"] = 240;
+    runtime["rect.height"] = 140;
+    runtime["rect.cornerRadius.topLeft"] = 20;
+
+    expect(onChange).not.toHaveBeenCalled();
+    hooks.afterApplyFrame();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(
+      new Set(["rect.width", "rect.height", "rect.cornerRadius.topLeft"]),
+    );
+  });
+
+  it("keeps nested animation batches pending until the outer frame ends", () => {
+    const displayObject = {};
+    const onChange = vi.fn();
+    const runtime = installRectStyleRuntime(
+      displayObject,
+      createElement(),
+      onChange,
+    );
+
+    runtime.beginBatch();
+    runtime.beginBatch();
+    runtime["rect.width"] = 240;
+    runtime.endBatch();
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    runtime["rect.height"] = 140;
+    runtime.endBatch();
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange.mock.calls[0][0]).toEqual(
+      new Set(["rect.width", "rect.height"]),
+    );
+  });
+
+  it("synchronizes a reused rect runtime and discards pending old changes", () => {
+    const displayObject = {};
+    const onChange = vi.fn();
+    const runtime = installRectStyleRuntime(
+      displayObject,
+      createElement(),
+      onChange,
+    );
+
+    runtime.beginBatch();
+    runtime["rect.width"] = 240;
+    syncRectStyleRuntime(
+      displayObject,
+      createElement({
+        width: 320,
+        fill: "#0000ff",
+        cornerRadius: 24,
+      }),
+    );
+    runtime.endBatch();
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(getRectStyleAnimationValue(displayObject, "rect.width")).toBe(320);
+    expect(
+      getRectStyleAnimationValue(
+        displayObject,
+        "rect.cornerRadius.bottomRight",
+      ),
+    ).toBe(24);
+    expect(
+      getRectStyleAnimationValue(displayObject, "rect.fill.color"),
+    ).toEqual([0, 0, 1, 1]);
+  });
+
+  it("rejects incompatible writes and missing rect animation targets", () => {
+    const solidDisplayObject = {};
+    installRectStyleRuntime(solidDisplayObject, createElement());
+
+    expect(() =>
+      setRectStyleAnimationValue(solidDisplayObject, "rect.fill.start.x", 0.25),
+    ).toThrow(
+      'Animation property "rect.fill.start.x" is incompatible with the current rect fill',
+    );
+    expect(() => setRectStyleAnimationValue({}, "rect.width", 240)).toThrow(
+      "Rect style animation target is not installed",
+    );
+    expect(() =>
+      validateRectStyleAnimationTarget(
+        {},
+        {
+          id: "not-a-rect",
+          tween: {
+            "rect.width": { auto: { duration: 100 } },
+          },
+        },
+      ),
+    ).toThrow(
+      'Animation "not-a-rect" can only target rect style properties on a mounted rect.',
+    );
+  });
+
+  it("rejects writes to gradient stops that do not exist", () => {
+    const displayObject = {};
+    installRectStyleRuntime(
+      displayObject,
+      createElement({
+        fill: {
+          type: "linear-gradient",
+          stops: [
+            { offset: 0, color: "#000000" },
+            { offset: 1, color: "#ffffff" },
+          ],
+        },
+      }),
+    );
+
+    expect(() =>
+      setRectStyleAnimationValue(
+        displayObject,
+        "rect.fill.stops.2.color",
+        [1, 0, 0, 1],
+      ),
+    ).toThrow(
+      'Animation property "rect.fill.stops.2.color" targets a missing gradient stop',
+    );
+  });
+
+  it("exposes complete auto targets for solid rect styles", () => {
+    expect(getRectStyleTargetState(createElement())).toMatchObject({
+      "rect.width": 200,
+      "rect.height": 100,
+      "rect.fill.color": [1, 0, 0, 1],
+      "rect.border.width": 2,
+      "rect.border.color": [1, 1, 1, 1],
+      "rect.border.alpha": 0.8,
+      "rect.cornerRadius.topLeft": 4,
+      "rect.cornerRadius.topRight": 8,
+      "rect.cornerRadius.bottomRight": 12,
+      "rect.cornerRadius.bottomLeft": 16,
+    });
+  });
+
+  it("exposes gradient geometry and indexed stop targets", () => {
+    const targets = getRectStyleTargetState(
+      createElement({
+        fill: {
+          type: "radial-gradient",
+          innerCenter: { x: 0.2, y: 0.3 },
+          innerRadius: 0.1,
+          outerCenter: { x: 0.7, y: 0.8 },
+          outerRadius: 0.9,
+          scale: 1.4,
+          rotation: 0.2,
+          stops: [
+            { offset: 0, color: "#000000" },
+            { offset: 1, color: "#ffffff" },
+          ],
+        },
+      }),
+    );
+
+    expect(targets).toMatchObject({
+      "rect.fill.innerCenter.x": 0.2,
+      "rect.fill.innerCenter.y": 0.3,
+      "rect.fill.outerCenter.x": 0.7,
+      "rect.fill.outerCenter.y": 0.8,
+      "rect.fill.innerRadius": 0.1,
+      "rect.fill.outerRadius": 0.9,
+      "rect.fill.scale": 1.4,
+      "rect.fill.rotation": 0.2,
+      "rect.fill.stops.0.offset": 0,
+      "rect.fill.stops.0.color": [0, 0, 0, 1],
+      "rect.fill.stops.1.offset": 1,
+      "rect.fill.stops.1.color": [1, 1, 1, 1],
+    });
+  });
+
+  it("uses authored defaults for omitted border and radial-gradient fields", () => {
+    expect(
+      getRectStyleTargetState(
+        createElement({
+          border: undefined,
+          fill: {
+            type: "radial-gradient",
+            stops: [
+              { offset: 0, color: "#000000" },
+              { offset: 1, color: "#ffffff" },
+            ],
+          },
+          cornerRadius: undefined,
+        }),
+      ),
+    ).toMatchObject({
+      "rect.border.width": 0,
+      "rect.border.color": [0, 0, 0, 1],
+      "rect.border.alpha": 1,
+      "rect.cornerRadius.topLeft": 0,
+      "rect.cornerRadius.topRight": 0,
+      "rect.cornerRadius.bottomRight": 0,
+      "rect.cornerRadius.bottomLeft": 0,
+      "rect.fill.innerCenter.x": 0.5,
+      "rect.fill.innerCenter.y": 0.5,
+      "rect.fill.outerCenter.x": 0.5,
+      "rect.fill.outerCenter.y": 0.5,
+      "rect.fill.innerRadius": 0,
+      "rect.fill.outerRadius": 0.5,
+      "rect.fill.scale": 1,
+      "rect.fill.rotation": 0,
+    });
+  });
+});

--- a/spec/elements/updateRect.spec.js
+++ b/spec/elements/updateRect.spec.js
@@ -138,6 +138,8 @@ describe("updateRect", () => {
           targetState: expect.objectContaining({
             scaleX: 1.5,
             scaleY: 0.6,
+            "rect.width": 200,
+            "rect.height": 200,
           }),
         }),
       }),

--- a/spec/parser/parseRect.test.yaml
+++ b/spec/parser/parseRect.test.yaml
@@ -131,6 +131,10 @@ out:
   fill: red
   scaleX: 1.2
   scaleY: 0.8
+  border:
+    width: 0
+    color: black
+    alpha: 0.8
   rotation: 90
   alpha: 1
 ---
@@ -160,6 +164,39 @@ out:
   originY: 40
   scaleX: 1.2
   scaleY: 0.8
+  border:
+    width: 0
+    color: black
+    alpha: 0.8
+  rotation: 0
+  alpha: 1
+---
+case: Test parsing rect preserves an authored zero-width border
+in:
+  - state:
+      id: rect-latent-border
+      type: rect
+      width: 80
+      height: 100
+      x: 10
+      "y": 20
+      border:
+        width: 0
+        color: red
+        alpha: 0.4
+out:
+  id: rect-latent-border
+  type: rect
+  width: 80
+  height: 100
+  x: 10
+  "y": 20
+  originX: 0
+  originY: 0
+  border:
+    width: 0
+    color: red
+    alpha: 0.4
   rotation: 0
   alpha: 1
 ---

--- a/src/plugins/animations/animationBus.js
+++ b/src/plugins/animations/animationBus.js
@@ -1,6 +1,6 @@
 import {
   TRANSITION_PROPERTY_PATH_MAP,
-  WhiteListAnimationProps,
+  isSupportedAnimationProperty,
 } from "../../types.js";
 import {
   applyAnimationProperty,
@@ -19,6 +19,30 @@ const DEFAULT_PLAYBACK_LOOP = false;
 
 const hasTranslateProperties = (properties = {}) =>
   Object.keys(properties).some(isTranslateAnimationProperty);
+
+const applyWithGroupFrameHooks = (groups, apply) => {
+  const startedGroups = [];
+  for (const group of groups) {
+    try {
+      group.beforeApplyFrame?.();
+      startedGroups.push(group);
+    } catch {
+      // Frame hooks are an internal optimization and must not stop playback.
+    }
+  }
+
+  try {
+    apply();
+  } finally {
+    for (let index = startedGroups.length - 1; index >= 0; index--) {
+      try {
+        startedGroups[index].afterApplyFrame?.();
+      } catch {
+        // Keep other groups consistent even if one hook fails.
+      }
+    }
+  }
+};
 
 const resolveAutoTargetValue = (targetState, property, animationId) => {
   if (
@@ -45,7 +69,7 @@ const buildPropertyTimelines = (
 ) =>
   Object.entries(properties)
     .map(([property, config]) => {
-      if (validateProperty && !WhiteListAnimationProps[property]) {
+      if (validateProperty && !isSupportedAnimationProperty(property)) {
         throw new Error(
           `${property} is not a supported property for animation.`,
         );
@@ -283,6 +307,7 @@ export const createAnimationBus = () => {
         group.validateProperty !== false,
       ).map((timeline) => ({ ...timeline, group })),
     );
+    const timelineGroups = [...new Set(timelines.map(({ group }) => group))];
 
     if (timelines.length === 0) {
       fireCompleteEvent({ id, onComplete });
@@ -302,35 +327,9 @@ export const createAnimationBus = () => {
       onComplete,
       onCancel,
       applyFrame: (time) => {
-        for (const { property, timeline, group } of timelines) {
-          const value = getValueAtTime(timeline, time);
-          try {
-            applyAnimationProperty({
-              object: group.element,
-              property,
-              propertyPathMap: group.propertyPathMap,
-              subjectState: isTranslateAnimationProperty(property)
-                ? group.getSubjectState()
-                : group.subjectState,
-              value,
-            });
-          } catch (_error) {
-            // Element might be mid-destroy or otherwise invalid.
-          }
-        }
-      },
-      applyTargetState: () => {
-        for (const group of propertyGroups) {
-          if (!group.element || group.element.destroyed) continue;
-
-          if (group.targetState === null) {
-            group.element.destroy?.();
-            continue;
-          }
-
-          if (!group.targetState) continue;
-
-          for (const [property, value] of Object.entries(group.targetState)) {
+        applyWithGroupFrameHooks(timelineGroups, () => {
+          for (const { property, timeline, group } of timelines) {
+            const value = getValueAtTime(timeline, time);
             try {
               applyAnimationProperty({
                 object: group.element,
@@ -342,10 +341,40 @@ export const createAnimationBus = () => {
                 value,
               });
             } catch (_error) {
-              // Skip properties that fail to apply.
+              // Element might be mid-destroy or otherwise invalid.
             }
           }
-        }
+        });
+      },
+      applyTargetState: () => {
+        applyWithGroupFrameHooks(propertyGroups, () => {
+          for (const group of propertyGroups) {
+            if (!group.element || group.element.destroyed) continue;
+
+            if (group.targetState === null) {
+              group.element.destroy?.();
+              continue;
+            }
+
+            if (!group.targetState) continue;
+
+            for (const [property, value] of Object.entries(group.targetState)) {
+              try {
+                applyAnimationProperty({
+                  object: group.element,
+                  property,
+                  propertyPathMap: group.propertyPathMap,
+                  subjectState: isTranslateAnimationProperty(property)
+                    ? group.getSubjectState()
+                    : group.subjectState,
+                  value,
+                });
+              } catch (_error) {
+                // Skip properties that fail to apply.
+              }
+            }
+          }
+        });
       },
       isValid: () =>
         propertyGroups.every(

--- a/src/plugins/animations/animationPropertyUtils.js
+++ b/src/plugins/animations/animationPropertyUtils.js
@@ -12,6 +12,10 @@ const getMappedPath = (propertyPathMap, path) => {
     return path;
   }
 
+  if (path.startsWith("rect.")) {
+    return ["_routeGraphicsRectStyle", path];
+  }
+
   return propertyPathMap[path] ?? path;
 };
 

--- a/src/plugins/animations/updateAnimationDispatch.js
+++ b/src/plugins/animations/updateAnimationDispatch.js
@@ -1,6 +1,6 @@
 import {
   TRANSITION_PROPERTY_PATH_MAP,
-  WhiteListAnimationProps,
+  isSupportedAnimationProperty,
 } from "../../types.js";
 import {
   applyAnimationProperty,
@@ -9,6 +9,10 @@ import {
   isTranslateAnimationProperty,
 } from "./animationPropertyUtils.js";
 import { validateShaderFilterAnimationTarget } from "../elements/util/shaderFilterEffect.js";
+import {
+  getRectStyleAnimationBatchHooks,
+  validateRectStyleAnimationTarget,
+} from "../elements/rect/rectStyleRuntime.js";
 
 const getLiveTweenProperty = (property) => {
   if (property === "translateX") {
@@ -140,8 +144,9 @@ export const applyInitialUpdateAnimationState = (
   let subjectState = animationBaseState;
 
   for (const animation of animations) {
+    validateRectStyleAnimationTarget(element, animation);
     for (const [property, config] of Object.entries(animation.tween ?? {})) {
-      if (!WhiteListAnimationProps[property]) {
+      if (!isSupportedAnimationProperty(property)) {
         throw new Error(
           `${property} is not a supported property for animation.`,
         );
@@ -199,6 +204,7 @@ export const dispatchUpdateAnimationsNow = ({
   );
 
   for (const animation of animationsToDispatch) {
+    validateRectStyleAnimationTarget(element, animation);
     for (const [property, config] of Object.entries(animation.tween ?? {})) {
       if (
         config.auto &&
@@ -231,6 +237,7 @@ export const dispatchUpdateAnimationsNow = ({
         properties: animation.tween ?? {},
         targetState,
         animationBaseState: dispatchAnimationBaseState,
+        ...getRectStyleAnimationBatchHooks(dispatchElement),
       },
     ];
     for (const [filterId, tween] of Object.entries(

--- a/src/plugins/elements/input/parseInput.js
+++ b/src/plugins/elements/input/parseInput.js
@@ -7,8 +7,12 @@ import {
   resolveInputTextStyle,
   resolvePadding,
 } from "./inputShared.js";
+import { validateRectFill } from "../rect/rectConfig.js";
 
 export const parseInput = ({ state }) => {
+  if (state.fill !== undefined) {
+    validateRectFill(state.fill, "input.fill");
+  }
   const computedObj = parseCommonObject(state);
   const value = String(state.value ?? "");
   const placeholder = String(state.placeholder ?? "");

--- a/src/plugins/elements/rect/addRect.js
+++ b/src/plugins/elements/rect/addRect.js
@@ -1,18 +1,26 @@
 import { Graphics } from "pixi.js";
-import { normalizeVolume } from "../../../util/normalizeVolume.js";
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
-import { setupScrollInteraction } from "../util/setupScrollInteraction.js";
-import { isPrimaryPointerEvent } from "../util/isPrimaryPointerEvent.js";
-import { destroyRectFillResource, resolveRectFill } from "./rectFill.js";
+import { destroyRectFillResource } from "./rectFill.js";
 import {
   applyElementTransform,
   getElementTransformTargetState,
 } from "../util/transform.js";
 import {
+  getBlurTargetState,
+  hasBlurUpdateAnimation,
+  syncBlurEffect,
+} from "../util/blurEffect.js";
+import {
   getShaderFilterTargetState,
   hasShaderProgressUpdateAnimation,
   syncShaderFilters,
 } from "../util/shaderFilterEffect.js";
+import { drawRectVisual } from "./rectDrawing.js";
+import { bindRectInteractions } from "./rectInteractions.js";
+import {
+  getRectStyleTargetState,
+  installRectStyleRuntime,
+} from "./rectStyleRuntime.js";
 
 /**
  * Add rectangle element to the stage (synchronous)
@@ -29,7 +37,8 @@ export const addRect = ({
   completionTracker,
   renderContext,
 }) => {
-  const { id, width, height, fill, border, alpha, scaleX, scaleY } = element;
+  const { id, width, height, alpha, scaleX, scaleY } = element;
+  const shouldForceBlur = hasBlurUpdateAnimation(animations, id);
   const shouldForceShaderProgress = hasShaderProgressUpdateAnimation(
     animations,
     id,
@@ -41,6 +50,30 @@ export const addRect = ({
   rect.on("destroyed", () => {
     destroyRectFillResource(rect);
   });
+  const styleRuntime = installRectStyleRuntime(
+    rect,
+    element,
+    (property, runtime) => {
+      drawRectVisual(rect, runtime.state, {
+        ...runtime.element,
+        ...runtime.state,
+      });
+      const dimensionChanged =
+        property === "rect.width" ||
+        property === "rect.height" ||
+        property?.has?.("rect.width") ||
+        property?.has?.("rect.height");
+      if (dimensionChanged) {
+        syncShaderFilters(rect, runtime.element.filters, {
+          width: runtime.state.width,
+          height: runtime.state.height,
+          force: shouldForceShaderProgress,
+          animations,
+          targetId: id,
+        });
+      }
+    },
+  );
   const targetState = getElementTransformTargetState(element, { alpha });
 
   if (scaleX !== undefined) {
@@ -52,10 +85,7 @@ export const addRect = ({
   }
 
   const drawRect = () => {
-    rect.clear();
-    rect
-      .rect(0, 0, Math.round(width), Math.round(height))
-      .fill(resolveRectFill(rect, fill, element));
+    drawRectVisual(rect, styleRuntime.state, element);
     rect.alpha = alpha;
     // Rect computed nodes already bake scale into width/height for layout.
     // Reset the live transform so update tweens do not double-apply scale.
@@ -63,14 +93,7 @@ export const addRect = ({
     rect.scale.y = 1;
     applyElementTransform(rect, element);
 
-    if (border) {
-      rect.stroke({
-        color: border.color,
-        alpha: border.alpha,
-        width: Math.round(border.width),
-      });
-    }
-
+    syncBlurEffect(rect, element.blur, { force: shouldForceBlur });
     syncShaderFilters(rect, element.filters, {
       width,
       height,
@@ -79,153 +102,7 @@ export const addRect = ({
   };
 
   drawRect();
-
-  const hoverEvents = element?.hover;
-  const clickEvents = element?.click;
-  const rightClickEvents = element?.rightClick;
-  const scrollUpEvent = element?.scrollUp;
-  const scrollDownEvent = element?.scrollDown;
-  const dragEvent = element?.drag;
-
-  if (hoverEvents) {
-    const { cursor, soundSrc, soundVolume, payload } = hoverEvents;
-    rect.eventMode = "static";
-
-    const overListener = () => {
-      if (payload && eventHandler)
-        eventHandler(`hover`, {
-          _event: {
-            id: rect.label,
-          },
-          ...payload,
-        });
-      if (cursor) rect.cursor = cursor;
-      if (soundSrc)
-        app.audioStage.add({
-          id: `hover-${Date.now()}`,
-          url: soundSrc,
-          loop: false,
-          volume: normalizeVolume(soundVolume),
-        });
-    };
-
-    const outListener = () => {
-      rect.cursor = "auto";
-    };
-
-    rect.on("pointerover", overListener);
-    rect.on("pointerout", outListener);
-  }
-
-  if (clickEvents) {
-    const { soundSrc, soundVolume, payload } = clickEvents;
-    rect.eventMode = "static";
-
-    const releaseListener = (event) => {
-      if (!isPrimaryPointerEvent(event)) {
-        return;
-      }
-
-      if (payload && eventHandler)
-        eventHandler(`click`, {
-          _event: {
-            id: rect.label,
-          },
-          ...payload,
-        });
-      if (soundSrc)
-        app.audioStage.add({
-          id: `click-${Date.now()}`,
-          url: soundSrc,
-          loop: false,
-          volume: normalizeVolume(soundVolume),
-        });
-    };
-
-    rect.on("pointerup", releaseListener);
-  }
-
-  if (rightClickEvents) {
-    const { soundSrc, payload } = rightClickEvents;
-    rect.eventMode = "static";
-
-    const rightClickListener = () => {
-      if (payload && eventHandler)
-        eventHandler(`rightClick`, {
-          _event: {
-            id: rect.label,
-          },
-          ...payload,
-        });
-      if (soundSrc)
-        app.audioStage.add({
-          id: `rightClick-${Date.now()}`,
-          url: soundSrc,
-          loop: false,
-        });
-    };
-
-    rect.on("rightclick", rightClickListener);
-  }
-
-  if (scrollUpEvent || scrollDownEvent) {
-    setupScrollInteraction({
-      canvas: app.canvas,
-      displayObject: rect,
-      width,
-      height,
-      scrollUpEvent,
-      scrollDownEvent,
-      eventHandler,
-    });
-  }
-
-  if (dragEvent) {
-    const { start, end, move } = dragEvent;
-    rect.eventMode = "static";
-
-    const downListener = () => {
-      rect._isDragging = true;
-      if (start && eventHandler) {
-        eventHandler("dragStart", {
-          _event: {
-            id: rect.label,
-          },
-          ...(typeof start?.payload === "object" ? start.payload : {}),
-        });
-      }
-    };
-
-    const upListener = () => {
-      rect._isDragging = false;
-      if (end && eventHandler) {
-        eventHandler("dragEnd", {
-          _event: {
-            id: rect.label,
-          },
-          ...(typeof end?.payload === "object" ? end.payload : {}),
-        });
-      }
-    };
-
-    const moveListener = (e) => {
-      if (move && eventHandler && rect._isDragging) {
-        eventHandler("dragMove", {
-          _event: {
-            id: rect.label,
-            x: e.global.x,
-            y: e.global.y,
-          },
-          ...(typeof move?.payload === "object" ? move.payload : {}),
-        });
-      }
-    };
-
-    rect.on("pointerdown", downListener);
-    rect.on("pointerup", upListener);
-    rect.on("globalpointermove", moveListener);
-    rect.on("pointerupoutside", upListener);
-  }
+  bindRectInteractions({ app, rect, element, eventHandler });
 
   parent.addChild(rect);
 
@@ -237,6 +114,8 @@ export const addRect = ({
     element: rect,
     targetState: {
       ...targetState,
+      ...getRectStyleTargetState(element),
+      ...getBlurTargetState(element, { force: shouldForceBlur }),
       ...getShaderFilterTargetState(element, {
         force: shouldForceShaderProgress,
       }),

--- a/src/plugins/elements/rect/deleteRect.js
+++ b/src/plugins/elements/rect/deleteRect.js
@@ -1,5 +1,6 @@
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
 import { destroyRectFillResource } from "./rectFill.js";
+import { cleanupRectInteractions } from "./rectInteractions.js";
 
 /**
  * Delete rectangle element (synchronous)
@@ -25,7 +26,7 @@ export const deleteRect = ({
     targetState: null,
     onComplete: () => {
       if (rect && !rect.destroyed) {
-        rect._cleanupScrollInteraction?.();
+        cleanupRectInteractions(rect);
         destroyRectFillResource(rect);
         rect.destroy();
       }
@@ -34,7 +35,7 @@ export const deleteRect = ({
 
   if (!dispatched) {
     // No animation, destroy immediately
-    rect._cleanupScrollInteraction?.();
+    cleanupRectInteractions(rect);
     destroyRectFillResource(rect);
     rect.destroy();
   }

--- a/src/plugins/elements/rect/parseRect.js
+++ b/src/plugins/elements/rect/parseRect.js
@@ -15,24 +15,19 @@ import { normalizeCornerRadius, validateRectState } from "./rectConfig.js";
 export const parseRect = ({ state }) => {
   validateRectState(state);
   const computedObj = parseCommonObject(state);
-  const borderWidth = state.border?.width;
-
-  let finalObj = computedObj;
-
-  if (typeof borderWidth === "number" && borderWidth > 0) {
-    finalObj = {
-      ...computedObj,
-      border: {
-        alpha: state.border?.alpha ?? 1,
-        color: state.border?.color ?? "black",
-        width: borderWidth,
-      },
-    };
-  }
+  const border =
+    state.border === undefined
+      ? undefined
+      : {
+          alpha: state.border.alpha ?? 1,
+          color: state.border.color ?? "black",
+          width: state.border.width ?? 0,
+        };
 
   return {
-    ...finalObj,
+    ...computedObj,
     ...(state.fill !== undefined ? { fill: state.fill } : {}),
+    ...(border !== undefined ? { border } : {}),
     ...(state.scaleX !== undefined ? { scaleX: state.scaleX } : {}),
     ...(state.scaleY !== undefined ? { scaleY: state.scaleY } : {}),
     ...(state.cornerRadius !== undefined

--- a/src/plugins/elements/rect/parseRect.js
+++ b/src/plugins/elements/rect/parseRect.js
@@ -1,4 +1,6 @@
 import { parseCommonObject } from "../util/parseCommonObject.js";
+import { normalizeBlurConfig } from "../util/blurEffect.js";
+import { normalizeCornerRadius, validateRectState } from "./rectConfig.js";
 /**
  *  @typedef {import('../../../types.js').BaseElement}
  *  @typedef {import('../../../types.js').RectComputedNode}
@@ -11,6 +13,7 @@ import { parseCommonObject } from "../util/parseCommonObject.js";
  * @return {RectComputedNode}
  */
 export const parseRect = ({ state }) => {
+  validateRectState(state);
   const computedObj = parseCommonObject(state);
   const borderWidth = state.border?.width;
 
@@ -32,6 +35,12 @@ export const parseRect = ({ state }) => {
     ...(state.fill !== undefined ? { fill: state.fill } : {}),
     ...(state.scaleX !== undefined ? { scaleX: state.scaleX } : {}),
     ...(state.scaleY !== undefined ? { scaleY: state.scaleY } : {}),
+    ...(state.cornerRadius !== undefined
+      ? { cornerRadius: normalizeCornerRadius(state.cornerRadius) }
+      : {}),
+    ...(state.blur !== undefined && {
+      blur: normalizeBlurConfig(state.blur),
+    }),
     rotation: state.rotation ?? 0,
     ...(state.drag && { drag: state.drag }),
     ...(state.rightClick && { rightClick: state.rightClick }),

--- a/src/plugins/elements/rect/rectConfig.js
+++ b/src/plugins/elements/rect/rectConfig.js
@@ -1,0 +1,442 @@
+import { Color } from "pixi.js";
+
+export const RECT_CORNER_NAMES = Object.freeze([
+  "topLeft",
+  "topRight",
+  "bottomRight",
+  "bottomLeft",
+]);
+
+export const ZERO_CORNER_RADIUS = Object.freeze({
+  topLeft: 0,
+  topRight: 0,
+  bottomRight: 0,
+  bottomLeft: 0,
+});
+
+const RECT_FIELDS = new Set([
+  "id",
+  "type",
+  "width",
+  "height",
+  "x",
+  "y",
+  "anchorX",
+  "anchorY",
+  "originX",
+  "originY",
+  "alpha",
+  "scaleX",
+  "scaleY",
+  "rotation",
+  "fill",
+  "border",
+  "cornerRadius",
+  "blur",
+  "filters",
+  "hover",
+  "click",
+  "rightClick",
+  "drag",
+  "scrollUp",
+  "scrollDown",
+]);
+
+const FILL_TYPES = new Set(["solid", "linear-gradient", "radial-gradient"]);
+const COORDINATE_SPACES = new Set(["local", "global"]);
+const GRADIENT_SPREADS = new Set(["pad", "repeat"]);
+
+const isPlainObject = (value) =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+const assertPlainObject = (value, path) => {
+  if (!isPlainObject(value)) {
+    throw new Error(`Input Error: ${path} must be an object`);
+  }
+};
+
+const assertKnownFields = (value, fields, path) => {
+  for (const key of Object.keys(value)) {
+    if (!fields.has(key)) {
+      throw new Error(`Input Error: ${path}.${key} is not supported`);
+    }
+  }
+};
+
+const assertFiniteNumber = (value, path) => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`Input Error: ${path} must be a finite number`);
+  }
+};
+
+const assertOptionalFiniteNumber = (value, path) => {
+  if (value !== undefined) {
+    assertFiniteNumber(value, path);
+  }
+};
+
+const assertRange = (value, path, minimum, maximum) => {
+  assertFiniteNumber(value, path);
+  if (value < minimum || value > maximum) {
+    throw new Error(
+      `Input Error: ${path} must be between ${minimum} and ${maximum}`,
+    );
+  }
+};
+
+const assertNonNegativeNumber = (value, path) => {
+  assertFiniteNumber(value, path);
+  if (value < 0) {
+    throw new Error(`Input Error: ${path} must be greater than or equal to 0`);
+  }
+};
+
+const assertPositiveNumber = (value, path) => {
+  assertFiniteNumber(value, path);
+  if (value <= 0) {
+    throw new Error(`Input Error: ${path} must be greater than 0`);
+  }
+};
+
+export const assertRectColor = (value, path) => {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Input Error: ${path} must be a non-empty color string`);
+  }
+
+  // Some embedders replace Pixi with a renderer adapter that does not expose
+  // its Color helper. Rendering still owns the final conversion in that case.
+  if (typeof Color !== "function") {
+    return;
+  }
+
+  try {
+    new Color(value);
+  } catch {
+    throw new Error(`Input Error: ${path} is not a valid color`);
+  }
+};
+
+const validatePoint = (point, path) => {
+  assertPlainObject(point, path);
+  assertKnownFields(point, new Set(["x", "y"]), path);
+  if (point.x === undefined || point.y === undefined) {
+    throw new Error(`Input Error: ${path}.x and ${path}.y are required`);
+  }
+  assertFiniteNumber(point.x, `${path}.x`);
+  assertFiniteNumber(point.y, `${path}.y`);
+};
+
+const validateStops = (stops, path) => {
+  if (!Array.isArray(stops) || stops.length < 2) {
+    throw new Error(
+      `Input Error: ${path} must be an array with at least two stops`,
+    );
+  }
+
+  let previousOffset = -Infinity;
+  stops.forEach((stop, index) => {
+    const stopPath = `${path}[${index}]`;
+    assertPlainObject(stop, stopPath);
+    assertKnownFields(stop, new Set(["offset", "color"]), stopPath);
+    if (stop.offset === undefined || stop.color === undefined) {
+      throw new Error(
+        `Input Error: ${stopPath}.offset and ${stopPath}.color are required`,
+      );
+    }
+    assertRange(stop.offset, `${stopPath}.offset`, 0, 1);
+    assertRectColor(stop.color, `${stopPath}.color`);
+    if (stop.offset <= previousOffset) {
+      throw new Error(
+        `Input Error: ${path} offsets must be strictly increasing`,
+      );
+    }
+    previousOffset = stop.offset;
+  });
+};
+
+const validateGradientSampling = (fill, path) => {
+  if (fill.textureSize !== undefined) {
+    throw new Error(
+      `Input Error: ${path}.textureSize is no longer supported; use ${path}.resolution`,
+    );
+  }
+  if (fill.wrapMode !== undefined) {
+    throw new Error(
+      `Input Error: ${path}.wrapMode is no longer supported; use ${path}.spread with "pad" or "repeat"`,
+    );
+  }
+  if (fill.coordinateSpace !== undefined) {
+    if (!COORDINATE_SPACES.has(fill.coordinateSpace)) {
+      throw new Error(
+        `Input Error: ${path}.coordinateSpace must be "local" or "global"`,
+      );
+    }
+  }
+  if (fill.resolution !== undefined) {
+    assertPositiveNumber(fill.resolution, `${path}.resolution`);
+  }
+  if (fill.spread !== undefined && !GRADIENT_SPREADS.has(fill.spread)) {
+    throw new Error(`Input Error: ${path}.spread must be "pad" or "repeat"`);
+  }
+};
+
+export const validateRectFill = (fill, path = "fill") => {
+  if (typeof fill === "string") {
+    assertRectColor(fill, path);
+    return;
+  }
+
+  assertPlainObject(fill, path);
+  if (!FILL_TYPES.has(fill.type)) {
+    throw new Error(
+      `Input Error: ${path}.type must be "solid", "linear-gradient", or "radial-gradient"`,
+    );
+  }
+
+  if (fill.type === "solid") {
+    assertKnownFields(fill, new Set(["type", "color"]), path);
+    if (fill.color === undefined) {
+      throw new Error(`Input Error: ${path}.color is required`);
+    }
+    assertRectColor(fill.color, `${path}.color`);
+    return;
+  }
+
+  if (fill.type === "linear-gradient") {
+    assertKnownFields(
+      fill,
+      new Set([
+        "type",
+        "start",
+        "end",
+        "stops",
+        "coordinateSpace",
+        "resolution",
+        "spread",
+        "textureSize",
+        "wrapMode",
+      ]),
+      path,
+    );
+    if (fill.start !== undefined) validatePoint(fill.start, `${path}.start`);
+    if (fill.end !== undefined) validatePoint(fill.end, `${path}.end`);
+    validateStops(fill.stops, `${path}.stops`);
+    validateGradientSampling(fill, path);
+    return;
+  }
+
+  assertKnownFields(
+    fill,
+    new Set([
+      "type",
+      "innerCenter",
+      "innerRadius",
+      "outerCenter",
+      "outerRadius",
+      "stops",
+      "coordinateSpace",
+      "resolution",
+      "spread",
+      "scale",
+      "rotation",
+      "textureSize",
+      "wrapMode",
+    ]),
+    path,
+  );
+  if (fill.innerCenter !== undefined) {
+    validatePoint(fill.innerCenter, `${path}.innerCenter`);
+  }
+  if (fill.outerCenter !== undefined) {
+    validatePoint(fill.outerCenter, `${path}.outerCenter`);
+  }
+  if (fill.innerRadius !== undefined) {
+    assertNonNegativeNumber(fill.innerRadius, `${path}.innerRadius`);
+  }
+  if (fill.outerRadius !== undefined) {
+    assertPositiveNumber(fill.outerRadius, `${path}.outerRadius`);
+  }
+  if (fill.scale !== undefined) {
+    assertPositiveNumber(fill.scale, `${path}.scale`);
+  }
+  assertOptionalFiniteNumber(fill.rotation, `${path}.rotation`);
+  validateStops(fill.stops, `${path}.stops`);
+  validateGradientSampling(fill, path);
+};
+
+export const normalizeCornerRadius = (value) => {
+  if (value === undefined) {
+    return { ...ZERO_CORNER_RADIUS };
+  }
+
+  if (typeof value === "number") {
+    return Object.fromEntries(
+      RECT_CORNER_NAMES.map((corner) => [corner, value]),
+    );
+  }
+
+  return Object.fromEntries(
+    RECT_CORNER_NAMES.map((corner) => [corner, value[corner] ?? 0]),
+  );
+};
+
+const validateCornerRadius = (value, path) => {
+  if (typeof value === "number") {
+    assertNonNegativeNumber(value, path);
+    return;
+  }
+
+  assertPlainObject(value, path);
+  assertKnownFields(value, new Set(RECT_CORNER_NAMES), path);
+  for (const corner of RECT_CORNER_NAMES) {
+    if (value[corner] !== undefined) {
+      assertNonNegativeNumber(value[corner], `${path}.${corner}`);
+    }
+  }
+};
+
+const validatePayload = (payload, path) => {
+  if (payload !== undefined) {
+    assertPlainObject(payload, path);
+  }
+};
+
+const validateSoundFields = (event, path, { cursor = false } = {}) => {
+  if (event.soundSrc !== undefined) {
+    if (typeof event.soundSrc !== "string" || event.soundSrc.length === 0) {
+      throw new Error(
+        `Input Error: ${path}.soundSrc must be a non-empty string`,
+      );
+    }
+  }
+  if (event.soundVolume !== undefined) {
+    assertRange(event.soundVolume, `${path}.soundVolume`, 0, 100);
+  }
+  if (cursor && event.cursor !== undefined) {
+    if (typeof event.cursor !== "string" || event.cursor.length === 0) {
+      throw new Error(`Input Error: ${path}.cursor must be a non-empty string`);
+    }
+  }
+  validatePayload(event.payload, `${path}.payload`);
+};
+
+const validatePointerEvent = (event, path, { cursor = false } = {}) => {
+  assertPlainObject(event, path);
+  assertKnownFields(
+    event,
+    new Set([
+      "soundSrc",
+      "soundVolume",
+      "payload",
+      ...(cursor ? ["cursor"] : []),
+    ]),
+    path,
+  );
+  validateSoundFields(event, path, { cursor });
+};
+
+const validatePayloadEvent = (event, path) => {
+  assertPlainObject(event, path);
+  assertKnownFields(event, new Set(["payload"]), path);
+  validatePayload(event.payload, `${path}.payload`);
+};
+
+const validateDrag = (drag, path) => {
+  assertPlainObject(drag, path);
+  assertKnownFields(drag, new Set(["start", "move", "end"]), path);
+  if (!drag.start && !drag.move && !drag.end) {
+    throw new Error(`Input Error: ${path} must define start, move, or end`);
+  }
+  for (const phase of ["start", "move", "end"]) {
+    if (drag[phase] !== undefined) {
+      validatePayloadEvent(drag[phase], `${path}.${phase}`);
+    }
+  }
+};
+
+const validateBorder = (border, path) => {
+  assertPlainObject(border, path);
+  assertKnownFields(border, new Set(["width", "color", "alpha"]), path);
+  if (border.width !== undefined) {
+    assertNonNegativeNumber(border.width, `${path}.width`);
+  }
+  if (border.color !== undefined) {
+    assertRectColor(border.color, `${path}.color`);
+  }
+  if (border.alpha !== undefined) {
+    assertRange(border.alpha, `${path}.alpha`, 0, 1);
+  }
+};
+
+const validateBlurShape = (blur, path) => {
+  assertPlainObject(blur, path);
+  assertKnownFields(
+    blur,
+    new Set(["x", "y", "quality", "kernelSize", "repeatEdgePixels"]),
+    path,
+  );
+};
+
+export const validateRectState = (state, path = "rect") => {
+  assertPlainObject(state, path);
+  assertKnownFields(state, RECT_FIELDS, path);
+
+  if (typeof state.id !== "string" || state.id.length === 0) {
+    throw new Error(`Input Error: ${path}.id must be a non-empty string`);
+  }
+  if (state.type !== "rect") {
+    throw new Error(`Input Error: ${path}.type must be "rect"`);
+  }
+
+  assertPositiveNumber(state.width, `${path}.width`);
+  assertPositiveNumber(state.height, `${path}.height`);
+  for (const key of [
+    "x",
+    "y",
+    "anchorX",
+    "anchorY",
+    "originX",
+    "originY",
+    "rotation",
+  ]) {
+    assertOptionalFiniteNumber(state[key], `${path}.${key}`);
+  }
+  for (const key of ["scaleX", "scaleY"]) {
+    if (state[key] !== undefined) {
+      assertPositiveNumber(state[key], `${path}.${key}`);
+    }
+  }
+  if (state.alpha !== undefined) {
+    assertRange(state.alpha, `${path}.alpha`, 0, 1);
+  }
+  if (state.fill !== undefined) {
+    validateRectFill(state.fill, `${path}.fill`);
+  }
+  if (state.border !== undefined) {
+    validateBorder(state.border, `${path}.border`);
+  }
+  if (state.cornerRadius !== undefined) {
+    validateCornerRadius(state.cornerRadius, `${path}.cornerRadius`);
+  }
+  if (state.blur !== undefined) {
+    validateBlurShape(state.blur, `${path}.blur`);
+  }
+  if (state.hover !== undefined) {
+    validatePointerEvent(state.hover, `${path}.hover`, { cursor: true });
+  }
+  if (state.click !== undefined) {
+    validatePointerEvent(state.click, `${path}.click`);
+  }
+  if (state.rightClick !== undefined) {
+    validatePointerEvent(state.rightClick, `${path}.rightClick`);
+  }
+  if (state.drag !== undefined) {
+    validateDrag(state.drag, `${path}.drag`);
+  }
+  if (state.scrollUp !== undefined) {
+    validatePayloadEvent(state.scrollUp, `${path}.scrollUp`);
+  }
+  if (state.scrollDown !== undefined) {
+    validatePayloadEvent(state.scrollDown, `${path}.scrollDown`);
+  }
+};

--- a/src/plugins/elements/rect/rectDrawing.js
+++ b/src/plugins/elements/rect/rectDrawing.js
@@ -1,0 +1,77 @@
+import { resolveRectFill } from "./rectFill.js";
+import { normalizeCornerRadius } from "./rectConfig.js";
+
+const clampDimension = (value) =>
+  typeof value === "number" && Number.isFinite(value) ? Math.max(0, value) : 0;
+
+export const resolveRenderedCornerRadius = (cornerRadius, width, height) => {
+  const normalized = normalizeCornerRadius(cornerRadius);
+  const safeWidth = clampDimension(width);
+  const safeHeight = clampDimension(height);
+  const top = normalized.topLeft + normalized.topRight;
+  const bottom = normalized.bottomLeft + normalized.bottomRight;
+  const left = normalized.topLeft + normalized.bottomLeft;
+  const right = normalized.topRight + normalized.bottomRight;
+  const scale = Math.min(
+    1,
+    top > 0 ? safeWidth / top : 1,
+    bottom > 0 ? safeWidth / bottom : 1,
+    left > 0 ? safeHeight / left : 1,
+    right > 0 ? safeHeight / right : 1,
+  );
+
+  return Object.fromEntries(
+    Object.entries(normalized).map(([corner, radius]) => [
+      corner,
+      Math.max(0, radius * scale),
+    ]),
+  );
+};
+
+export const appendRectPath = (graphics, width, height, cornerRadius) => {
+  const safeWidth = clampDimension(width);
+  const safeHeight = clampDimension(height);
+  const radius = resolveRenderedCornerRadius(
+    cornerRadius,
+    safeWidth,
+    safeHeight,
+  );
+
+  if (Object.values(radius).every((value) => value === 0)) {
+    graphics.rect(0, 0, safeWidth, safeHeight);
+    return graphics;
+  }
+
+  graphics
+    .moveTo(radius.topLeft, 0)
+    .lineTo(safeWidth - radius.topRight, 0)
+    .quadraticCurveTo(safeWidth, 0, safeWidth, radius.topRight)
+    .lineTo(safeWidth, safeHeight - radius.bottomRight)
+    .quadraticCurveTo(
+      safeWidth,
+      safeHeight,
+      safeWidth - radius.bottomRight,
+      safeHeight,
+    )
+    .lineTo(radius.bottomLeft, safeHeight)
+    .quadraticCurveTo(0, safeHeight, 0, safeHeight - radius.bottomLeft)
+    .lineTo(0, radius.topLeft)
+    .quadraticCurveTo(0, 0, radius.topLeft, 0)
+    .closePath();
+
+  return graphics;
+};
+
+export const drawRectVisual = (graphics, style, element = style) => {
+  graphics.clear();
+  appendRectPath(graphics, style.width, style.height, style.cornerRadius);
+  graphics.fill(resolveRectFill(graphics, style.fill, element));
+
+  if (style.border?.width > 0) {
+    graphics.stroke({
+      color: style.border.color,
+      alpha: style.border.alpha,
+      width: style.border.width,
+    });
+  }
+};

--- a/src/plugins/elements/rect/rectFill.js
+++ b/src/plugins/elements/rect/rectFill.js
@@ -78,8 +78,8 @@ export const normalizeRectFill = (fill, element) => {
       end: normalizeGradientPoint(fill.end, fill, element, DEFAULT_LINEAR_END),
       colorStops: sortStops(fill.stops),
       textureSpace: fill.coordinateSpace,
-      textureSize: fill.textureSize,
-      wrapMode: fill.wrapMode,
+      textureSize: fill.resolution,
+      wrapMode: fill.spread === "repeat" ? "repeat" : "clamp-to-edge",
     });
   }
 
@@ -97,8 +97,8 @@ export const normalizeRectFill = (fill, element) => {
       outerRadius: fill.outerRadius,
       colorStops: sortStops(fill.stops),
       textureSpace: fill.coordinateSpace,
-      textureSize: fill.textureSize,
-      wrapMode: fill.wrapMode,
+      textureSize: fill.resolution,
+      wrapMode: fill.spread === "repeat" ? "repeat" : "clamp-to-edge",
       scale: fill.scale,
       rotation: fill.rotation,
     });

--- a/src/plugins/elements/rect/rectInteractions.js
+++ b/src/plugins/elements/rect/rectInteractions.js
@@ -1,0 +1,130 @@
+import { normalizeVolume } from "../../../util/normalizeVolume.js";
+import { isPrimaryPointerEvent } from "../util/isPrimaryPointerEvent.js";
+import { setupScrollInteraction } from "../util/setupScrollInteraction.js";
+
+const LISTENER_EVENTS = [
+  "pointerover",
+  "pointerout",
+  "pointerup",
+  "rightclick",
+  "wheel",
+  "pointerdown",
+  "globalpointermove",
+  "pointerupoutside",
+];
+
+const getPayload = (config) =>
+  config?.payload && typeof config.payload === "object" ? config.payload : {};
+
+const emit = (eventHandler, eventName, rect, config, eventData = {}) => {
+  eventHandler?.(eventName, {
+    _event: {
+      id: rect.label,
+      ...eventData,
+    },
+    ...getPayload(config),
+  });
+};
+
+const playSound = (app, eventName, config) => {
+  if (!config?.soundSrc) return;
+  app.audioStage.add({
+    id: `${eventName}-${Date.now()}`,
+    url: config.soundSrc,
+    loop: false,
+    volume: normalizeVolume(config.soundVolume),
+  });
+};
+
+export const cleanupRectInteractions = (rect) => {
+  rect._cleanupScrollInteraction?.();
+  for (const eventName of LISTENER_EVENTS) {
+    rect.removeAllListeners(eventName);
+  }
+  rect.eventMode = "auto";
+  rect.cursor = "auto";
+  rect.hitArea = null;
+  rect._isDragging = false;
+};
+
+export const bindRectInteractions = ({ app, rect, element, eventHandler }) => {
+  cleanupRectInteractions(rect);
+
+  const hover = element.hover;
+  const click = element.click;
+  const rightClick = element.rightClick;
+  const scrollUp = element.scrollUp;
+  const scrollDown = element.scrollDown;
+  const drag = element.drag;
+  const hasInteraction = Boolean(
+    hover || click || rightClick || scrollUp || scrollDown || drag,
+  );
+
+  if (!hasInteraction) {
+    return;
+  }
+
+  rect.eventMode = "static";
+
+  if (hover) {
+    rect.on("pointerover", () => {
+      emit(eventHandler, "hover", rect, hover);
+      if (hover.cursor) rect.cursor = hover.cursor;
+      playSound(app, "hover", hover);
+    });
+    rect.on("pointerout", () => {
+      rect.cursor = "auto";
+    });
+  }
+
+  if (click) {
+    rect.on("pointerup", (event) => {
+      if (!isPrimaryPointerEvent(event)) return;
+      emit(eventHandler, "click", rect, click);
+      playSound(app, "click", click);
+    });
+  }
+
+  if (rightClick) {
+    rect.on("rightclick", () => {
+      emit(eventHandler, "rightClick", rect, rightClick);
+      playSound(app, "rightClick", rightClick);
+    });
+  }
+
+  if (scrollUp || scrollDown) {
+    setupScrollInteraction({
+      canvas: app.canvas,
+      displayObject: rect,
+      width: element.width,
+      height: element.height,
+      scrollUpEvent: scrollUp,
+      scrollDownEvent: scrollDown,
+      eventHandler,
+    });
+  }
+
+  if (drag) {
+    const { start, end, move } = drag;
+    const endDrag = (event) => {
+      if (!isPrimaryPointerEvent(event) || !rect._isDragging) return;
+      rect._isDragging = false;
+      if (end) emit(eventHandler, "dragEnd", rect, end);
+    };
+
+    rect.on("pointerdown", (event) => {
+      if (!isPrimaryPointerEvent(event)) return;
+      rect._isDragging = true;
+      if (start) emit(eventHandler, "dragStart", rect, start);
+    });
+    rect.on("pointerup", endDrag);
+    rect.on("pointerupoutside", endDrag);
+    rect.on("globalpointermove", (event) => {
+      if (!move || !rect._isDragging) return;
+      emit(eventHandler, "dragMove", rect, move, {
+        x: event.global.x,
+        y: event.global.y,
+      });
+    });
+  }
+};

--- a/src/plugins/elements/rect/rectStyleRuntime.js
+++ b/src/plugins/elements/rect/rectStyleRuntime.js
@@ -1,0 +1,372 @@
+import { Color } from "pixi.js";
+import { isRectStyleAnimationProperty } from "../../../types.js";
+import { normalizeCornerRadius, RECT_CORNER_NAMES } from "./rectConfig.js";
+
+export const RECT_STYLE_STATE_KEY = "_routeGraphicsRectStyle";
+export const RECT_ANIMATION_PROPERTY_PREFIX = "rect.";
+
+const DEFAULT_LINEAR_START = { x: 0, y: 0 };
+const DEFAULT_LINEAR_END = { x: 0, y: 1 };
+const DEFAULT_RADIAL_CENTER = { x: 0.5, y: 0.5 };
+const DEFAULT_BORDER = { width: 0, color: "black", alpha: 1 };
+
+const clonePoint = (point) => (point ? { ...point } : point);
+const cloneFill = (fill) => {
+  if (!fill || typeof fill !== "object" || Array.isArray(fill)) {
+    return fill;
+  }
+
+  return {
+    ...fill,
+    ...(fill.start ? { start: clonePoint(fill.start) } : {}),
+    ...(fill.end ? { end: clonePoint(fill.end) } : {}),
+    ...(fill.innerCenter ? { innerCenter: clonePoint(fill.innerCenter) } : {}),
+    ...(fill.outerCenter ? { outerCenter: clonePoint(fill.outerCenter) } : {}),
+    ...(fill.stops ? { stops: fill.stops.map((stop) => ({ ...stop })) } : {}),
+  };
+};
+
+const createStyleState = (element) => ({
+  width: element.width,
+  height: element.height,
+  fill: cloneFill(element.fill),
+  border: {
+    ...DEFAULT_BORDER,
+    ...element.border,
+  },
+  cornerRadius: normalizeCornerRadius(element.cornerRadius),
+});
+
+const colorToArray = (value) => new Color(value).toArray();
+
+const getFillPoint = (fill, key) => {
+  if (fill?.type === "linear-gradient") {
+    if (key === "start") return fill.start ?? DEFAULT_LINEAR_START;
+    if (key === "end") return fill.end ?? DEFAULT_LINEAR_END;
+  }
+
+  if (fill?.type === "radial-gradient") {
+    if (key === "innerCenter") {
+      return fill.innerCenter ?? DEFAULT_RADIAL_CENTER;
+    }
+    if (key === "outerCenter") {
+      return fill.outerCenter ?? fill.innerCenter ?? DEFAULT_RADIAL_CENTER;
+    }
+  }
+
+  return null;
+};
+
+const getFillScalarDefault = (fill, key) => {
+  if (fill?.type === "radial-gradient") {
+    if (key === "innerRadius") return fill.innerRadius ?? 0;
+    if (key === "outerRadius") return fill.outerRadius ?? 0.5;
+    if (key === "scale") return fill.scale ?? 1;
+    if (key === "rotation") return fill.rotation ?? 0;
+  }
+  return undefined;
+};
+
+const getStyleValue = (state, property) => {
+  if (property === "rect.width") return state.width;
+  if (property === "rect.height") return state.height;
+  if (property === "rect.fill.color") {
+    const color =
+      typeof state.fill === "string" || Array.isArray(state.fill)
+        ? state.fill
+        : state.fill?.type === "solid"
+          ? state.fill.color
+          : undefined;
+    return color === undefined ? undefined : colorToArray(color);
+  }
+  if (property === "rect.border.width") return state.border.width;
+  if (property === "rect.border.color") {
+    return colorToArray(state.border.color);
+  }
+  if (property === "rect.border.alpha") return state.border.alpha;
+
+  const cornerMatch = /^rect\.cornerRadius\.(.+)$/.exec(property);
+  if (cornerMatch) {
+    return state.cornerRadius[cornerMatch[1]];
+  }
+
+  const pointMatch =
+    /^rect\.fill\.(start|end|innerCenter|outerCenter)\.(x|y)$/.exec(property);
+  if (pointMatch) {
+    return getFillPoint(state.fill, pointMatch[1])?.[pointMatch[2]];
+  }
+
+  const scalarMatch =
+    /^rect\.fill\.(innerRadius|outerRadius|scale|rotation)$/.exec(property);
+  if (scalarMatch) {
+    return getFillScalarDefault(state.fill, scalarMatch[1]);
+  }
+
+  const stopMatch = /^rect\.fill\.stops\.(\d+)\.(offset|color)$/.exec(property);
+  if (stopMatch) {
+    const value = state.fill?.stops?.[Number(stopMatch[1])]?.[stopMatch[2]];
+    return stopMatch[2] === "color" && value !== undefined
+      ? colorToArray(value)
+      : value;
+  }
+
+  return undefined;
+};
+
+const requireFillObject = (state, property) => {
+  if (
+    !state.fill ||
+    typeof state.fill !== "object" ||
+    Array.isArray(state.fill)
+  ) {
+    throw new Error(
+      `Animation property "${property}" is incompatible with the current rect fill`,
+    );
+  }
+  return state.fill;
+};
+
+const setStyleValue = (state, property, value) => {
+  if (property === "rect.width") {
+    state.width = value;
+    return;
+  }
+  if (property === "rect.height") {
+    state.height = value;
+    return;
+  }
+  if (property === "rect.fill.color") {
+    if (
+      typeof state.fill === "string" ||
+      Array.isArray(state.fill) ||
+      state.fill === undefined
+    ) {
+      state.fill = value;
+      return;
+    }
+    if (state.fill?.type === "solid") {
+      state.fill.color = value;
+      return;
+    }
+    throw new Error(
+      `Animation property "${property}" requires a solid rect fill`,
+    );
+  }
+  if (property === "rect.border.width") {
+    state.border.width = value;
+    return;
+  }
+  if (property === "rect.border.color") {
+    state.border.color = value;
+    return;
+  }
+  if (property === "rect.border.alpha") {
+    state.border.alpha = value;
+    return;
+  }
+
+  const cornerMatch = /^rect\.cornerRadius\.(.+)$/.exec(property);
+  if (cornerMatch) {
+    state.cornerRadius[cornerMatch[1]] = value;
+    return;
+  }
+
+  const pointMatch =
+    /^rect\.fill\.(start|end|innerCenter|outerCenter)\.(x|y)$/.exec(property);
+  if (pointMatch) {
+    const fill = requireFillObject(state, property);
+    const [key, axis] = pointMatch.slice(1);
+    fill[key] = { ...getFillPoint(fill, key), [axis]: value };
+    return;
+  }
+
+  const scalarMatch =
+    /^rect\.fill\.(innerRadius|outerRadius|scale|rotation)$/.exec(property);
+  if (scalarMatch) {
+    requireFillObject(state, property)[scalarMatch[1]] = value;
+    return;
+  }
+
+  const stopMatch = /^rect\.fill\.stops\.(\d+)\.(offset|color)$/.exec(property);
+  if (stopMatch) {
+    const fill = requireFillObject(state, property);
+    const index = Number(stopMatch[1]);
+    if (!fill.stops?.[index]) {
+      throw new Error(
+        `Animation property "${property}" targets a missing gradient stop`,
+      );
+    }
+    fill.stops[index][stopMatch[2]] = value;
+    return;
+  }
+
+  throw new Error(`Unknown rect animation property "${property}"`);
+};
+
+export const isRectAnimationProperty = isRectStyleAnimationProperty;
+
+export const installRectStyleRuntime = (
+  displayObject,
+  element,
+  onChange = () => {},
+) => {
+  let runtime = displayObject[RECT_STYLE_STATE_KEY];
+
+  if (!runtime) {
+    const target = {
+      state: createStyleState(element),
+      element,
+      onChange,
+      batchDepth: 0,
+      pendingChanges: new Set(),
+      beginBatch() {
+        this.batchDepth += 1;
+      },
+      endBatch() {
+        if (this.batchDepth === 0) return;
+        this.batchDepth -= 1;
+        if (this.batchDepth > 0 || this.pendingChanges.size === 0) return;
+
+        const changes = new Set(this.pendingChanges);
+        this.pendingChanges.clear();
+        this.onChange(changes, runtime);
+      },
+      sync(nextElement) {
+        this.state = createStyleState(nextElement);
+        this.element = nextElement;
+        this.pendingChanges.clear();
+      },
+    };
+    runtime = new Proxy(target, {
+      get(current, property, receiver) {
+        if (isRectAnimationProperty(property)) {
+          return getStyleValue(current.state, property);
+        }
+        return Reflect.get(current, property, receiver);
+      },
+      set(current, property, value, receiver) {
+        if (isRectAnimationProperty(property)) {
+          setStyleValue(current.state, property, value);
+          if (current.batchDepth > 0) {
+            current.pendingChanges.add(property);
+          } else {
+            current.onChange(property, receiver);
+          }
+          return true;
+        }
+        return Reflect.set(current, property, value, receiver);
+      },
+    });
+    displayObject[RECT_STYLE_STATE_KEY] = runtime;
+  } else {
+    runtime.onChange = onChange;
+  }
+
+  return runtime;
+};
+
+export const syncRectStyleRuntime = (displayObject, element) => {
+  const runtime = displayObject[RECT_STYLE_STATE_KEY];
+  if (!runtime) {
+    return installRectStyleRuntime(displayObject, element);
+  }
+  runtime.sync(element);
+  return runtime;
+};
+
+export const getRectStyleAnimationValue = (displayObject, property) =>
+  getStyleValue(displayObject?.[RECT_STYLE_STATE_KEY]?.state, property);
+
+export const setRectStyleAnimationValue = (displayObject, property, value) => {
+  const runtime = displayObject?.[RECT_STYLE_STATE_KEY];
+  if (!runtime) {
+    throw new Error("Rect style animation target is not installed");
+  }
+  runtime[property] = value;
+};
+
+export const getRectStyleAnimationBatchHooks = (displayObject) => {
+  const runtime = displayObject?.[RECT_STYLE_STATE_KEY];
+  if (!runtime) return {};
+
+  return {
+    beforeApplyFrame: () => runtime.beginBatch(),
+    afterApplyFrame: () => runtime.endBatch(),
+  };
+};
+
+export const validateRectStyleAnimationTarget = (displayObject, animation) => {
+  const properties = Object.keys(animation?.tween ?? {}).filter(
+    isRectAnimationProperty,
+  );
+  if (properties.length === 0) return;
+
+  const runtime = displayObject?.[RECT_STYLE_STATE_KEY];
+  if (!runtime) {
+    throw new Error(
+      `Animation "${animation.id}" can only target rect style properties on a mounted rect.`,
+    );
+  }
+
+  for (const property of properties) {
+    if (getStyleValue(runtime.state, property) === undefined) {
+      throw new Error(
+        `Animation "${animation.id}" property "${property.slice(RECT_ANIMATION_PROPERTY_PREFIX.length)}" is incompatible with the current rect fill.`,
+      );
+    }
+  }
+};
+
+const addFillTargetState = (targetState, fill) => {
+  if (typeof fill === "string" || fill?.type === "solid") {
+    const color = typeof fill === "string" ? fill : fill?.color;
+    if (color !== undefined) {
+      targetState["rect.fill.color"] = colorToArray(color);
+    }
+    return;
+  }
+
+  if (fill?.type === "linear-gradient") {
+    const start = fill.start ?? DEFAULT_LINEAR_START;
+    const end = fill.end ?? DEFAULT_LINEAR_END;
+    targetState["rect.fill.start.x"] = start.x;
+    targetState["rect.fill.start.y"] = start.y;
+    targetState["rect.fill.end.x"] = end.x;
+    targetState["rect.fill.end.y"] = end.y;
+  }
+
+  if (fill?.type === "radial-gradient") {
+    const innerCenter = fill.innerCenter ?? DEFAULT_RADIAL_CENTER;
+    const outerCenter = fill.outerCenter ?? innerCenter;
+    targetState["rect.fill.innerCenter.x"] = innerCenter.x;
+    targetState["rect.fill.innerCenter.y"] = innerCenter.y;
+    targetState["rect.fill.outerCenter.x"] = outerCenter.x;
+    targetState["rect.fill.outerCenter.y"] = outerCenter.y;
+    targetState["rect.fill.innerRadius"] = fill.innerRadius ?? 0;
+    targetState["rect.fill.outerRadius"] = fill.outerRadius ?? 0.5;
+    targetState["rect.fill.scale"] = fill.scale ?? 1;
+    targetState["rect.fill.rotation"] = fill.rotation ?? 0;
+  }
+
+  fill?.stops?.forEach((stop, index) => {
+    targetState[`rect.fill.stops.${index}.offset`] = stop.offset;
+    targetState[`rect.fill.stops.${index}.color`] = colorToArray(stop.color);
+  });
+};
+
+export const getRectStyleTargetState = (element) => {
+  const targetState = {
+    "rect.width": element.width,
+    "rect.height": element.height,
+    "rect.border.width": element.border?.width ?? 0,
+    "rect.border.color": colorToArray(element.border?.color ?? "black"),
+    "rect.border.alpha": element.border?.alpha ?? 1,
+  };
+  const cornerRadius = normalizeCornerRadius(element.cornerRadius);
+
+  for (const corner of RECT_CORNER_NAMES) {
+    targetState[`rect.cornerRadius.${corner}`] = cornerRadius[corner];
+  }
+  addFillTargetState(targetState, element.fill);
+  return targetState;
+};

--- a/src/plugins/elements/rect/rectStyleRuntime.js
+++ b/src/plugins/elements/rect/rectStyleRuntime.js
@@ -354,10 +354,20 @@ const addFillTargetState = (targetState, fill) => {
   });
 };
 
-export const getRectStyleTargetState = (element) => {
+const removeBakedScale = (dimension, scale) =>
+  typeof scale === "number" && scale !== 0 ? dimension / scale : dimension;
+
+export const getRectStyleTargetState = (
+  element,
+  { liveScaleX = false, liveScaleY = false } = {},
+) => {
   const targetState = {
-    "rect.width": element.width,
-    "rect.height": element.height,
+    "rect.width": liveScaleX
+      ? removeBakedScale(element.width, element.scaleX)
+      : element.width,
+    "rect.height": liveScaleY
+      ? removeBakedScale(element.height, element.scaleY)
+      : element.height,
     "rect.border.width": element.border?.width ?? 0,
     "rect.border.color": colorToArray(element.border?.color ?? "black"),
     "rect.border.alpha": element.border?.alpha ?? 1,

--- a/src/plugins/elements/rect/updateRect.js
+++ b/src/plugins/elements/rect/updateRect.js
@@ -1,13 +1,14 @@
 import { isDeepEqual } from "../../../util/isDeepEqual.js";
-import { normalizeVolume } from "../../../util/normalizeVolume.js";
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
-import { setupScrollInteraction } from "../util/setupScrollInteraction.js";
-import { isPrimaryPointerEvent } from "../util/isPrimaryPointerEvent.js";
-import { resolveRectFill } from "./rectFill.js";
 import {
   applyElementTransform,
   getElementTransformTargetState,
 } from "../util/transform.js";
+import {
+  getBlurTargetState,
+  hasBlurUpdateAnimation,
+  syncBlurEffect,
+} from "../util/blurEffect.js";
 import {
   getShaderFilterTargetState,
   hasShaderProgressUpdateAnimation,
@@ -16,6 +17,13 @@ import {
   syncShaderFilters,
 } from "../util/shaderFilterEffect.js";
 import { setElementRenderState } from "../elementRenderState.js";
+import { drawRectVisual } from "./rectDrawing.js";
+import { bindRectInteractions } from "./rectInteractions.js";
+import {
+  getRectStyleTargetState,
+  installRectStyleRuntime,
+  syncRectStyleRuntime,
+} from "./rectStyleRuntime.js";
 
 /**
  * Update rectangle element (synchronous)
@@ -42,7 +50,11 @@ export const updateRect = ({
 
   rectElement.zIndex = zIndex;
 
-  const { width, height, fill, border, alpha, scaleX, scaleY } = nextElement;
+  const { width, height, alpha, scaleX, scaleY } = nextElement;
+  const shouldForceBlur = hasBlurUpdateAnimation(animations, prevElement.id);
+  if (shouldForceBlur) {
+    syncBlurEffect(rectElement, prevElement.blur, { force: true });
+  }
   const shouldForceShaderProgress = hasShaderProgressUpdateAnimation(
     animations,
     prevElement.id,
@@ -64,6 +76,26 @@ export const updateRect = ({
     animations,
     targetId: prevElement.id,
   });
+  installRectStyleRuntime(rectElement, prevElement, (property, runtime) => {
+    drawRectVisual(rectElement, runtime.state, {
+      ...runtime.element,
+      ...runtime.state,
+    });
+    const dimensionChanged =
+      property === "rect.width" ||
+      property === "rect.height" ||
+      property?.has?.("rect.width") ||
+      property?.has?.("rect.height");
+    if (dimensionChanged) {
+      syncShaderFilters(rectElement, runtime.element.filters, {
+        width: runtime.state.width,
+        height: runtime.state.height,
+        force: shouldForceShaderProgress,
+        animations,
+        targetId: prevElement.id,
+      });
+    }
+  });
   const targetState = getElementTransformTargetState(nextElement, { alpha });
 
   if (scaleX !== undefined) {
@@ -76,12 +108,8 @@ export const updateRect = ({
 
   const updateElement = () => {
     if (!isDeepEqual(prevElement, nextElement)) {
-      rectElement._cleanupScrollInteraction?.();
-      rectElement.clear();
-
-      rectElement
-        .rect(0, 0, Math.round(width), Math.round(height))
-        .fill(resolveRectFill(rectElement, fill, nextElement));
+      const styleRuntime = syncRectStyleRuntime(rectElement, nextElement);
+      drawRectVisual(rectElement, styleRuntime.state, nextElement);
       rectElement.alpha = alpha;
       // Rect computed nodes already bake scale into width/height for layout.
       // Reset the live transform so update tweens do not double-apply scale.
@@ -89,14 +117,9 @@ export const updateRect = ({
       rectElement.scale.y = 1;
       applyElementTransform(rectElement, nextElement);
 
-      if (border) {
-        rectElement.stroke({
-          color: border.color,
-          alpha: border.alpha,
-          width: Math.round(border.width),
-        });
-      }
-
+      syncBlurEffect(rectElement, nextElement.blur, {
+        force: shouldForceBlur,
+      });
       syncShaderFilters(rectElement, nextElement.filters, {
         width,
         height,
@@ -104,162 +127,12 @@ export const updateRect = ({
         animations,
         targetId: prevElement.id,
       });
-
-      rectElement.removeAllListeners("pointerover");
-      rectElement.removeAllListeners("pointerout");
-      rectElement.removeAllListeners("pointerup");
-      rectElement.removeAllListeners("rightclick");
-      rectElement.removeAllListeners("wheel");
-      rectElement.removeAllListeners("pointerdown");
-      rectElement.removeAllListeners("globalpointermove");
-      rectElement.removeAllListeners("pointerupoutside");
-
-      const hoverEvents = nextElement?.hover;
-      const clickEvents = nextElement?.click;
-      const rightClickEvents = nextElement?.rightClick;
-      const scrollUpEvent = nextElement?.scrollUp;
-      const scrollDownEvent = nextElement?.scrollDown;
-      const dragEvents = nextElement?.drag;
-
-      if (hoverEvents) {
-        const { cursor, soundSrc, soundVolume, payload } = hoverEvents;
-        rectElement.eventMode = "static";
-
-        const overListener = () => {
-          if (payload && eventHandler)
-            eventHandler(`hover`, {
-              _event: {
-                id: rectElement.label,
-              },
-              ...payload,
-            });
-          if (cursor) rectElement.cursor = cursor;
-          if (soundSrc)
-            app.audioStage.add({
-              id: `hover-${Date.now()}`,
-              url: soundSrc,
-              loop: false,
-              volume: normalizeVolume(soundVolume),
-            });
-        };
-
-        const outListener = () => {
-          rectElement.cursor = "auto";
-        };
-
-        rectElement.on("pointerover", overListener);
-        rectElement.on("pointerout", outListener);
-      }
-
-      if (clickEvents) {
-        const { soundSrc, soundVolume, payload } = clickEvents;
-        rectElement.eventMode = "static";
-
-        const clickListener = (event) => {
-          if (!isPrimaryPointerEvent(event)) {
-            return;
-          }
-
-          if (payload && eventHandler)
-            eventHandler(`click`, {
-              _event: {
-                id: rectElement.label,
-              },
-              ...payload,
-            });
-          if (soundSrc)
-            app.audioStage.add({
-              id: `click-${Date.now()}`,
-              url: soundSrc,
-              loop: false,
-              volume: normalizeVolume(soundVolume),
-            });
-        };
-
-        rectElement.on("pointerup", clickListener);
-      }
-
-      if (rightClickEvents) {
-        const { soundSrc, payload } = rightClickEvents;
-        rectElement.eventMode = "static";
-
-        const rightClickListener = () => {
-          if (payload && eventHandler)
-            eventHandler(`rightClick`, {
-              _event: {
-                id: rectElement.label,
-              },
-              ...payload,
-            });
-          if (soundSrc)
-            app.audioStage.add({
-              id: `rightClick-${Date.now()}`,
-              url: soundSrc,
-              loop: false,
-            });
-        };
-
-        rectElement.on("rightclick", rightClickListener);
-      }
-
-      if (scrollUpEvent || scrollDownEvent) {
-        setupScrollInteraction({
-          canvas: app.canvas,
-          displayObject: rectElement,
-          width,
-          height,
-          scrollUpEvent,
-          scrollDownEvent,
-          eventHandler,
-        });
-      }
-
-      if (dragEvents) {
-        const { start, end, move } = dragEvents;
-        rectElement.eventMode = "static";
-
-        const downListener = () => {
-          rectElement._isDragging = true;
-          if (start && eventHandler) {
-            eventHandler("dragStart", {
-              _event: {
-                id: rectElement.label,
-              },
-              ...(typeof start?.payload === "object" ? start.payload : {}),
-            });
-          }
-        };
-
-        const upListener = () => {
-          rectElement._isDragging = false;
-          if (end && eventHandler) {
-            eventHandler("dragEnd", {
-              _event: {
-                id: rectElement.label,
-              },
-              ...(typeof end?.payload === "object" ? end.payload : {}),
-            });
-          }
-        };
-
-        const moveListener = (e) => {
-          if (move && eventHandler && rectElement._isDragging) {
-            eventHandler("dragMove", {
-              _event: {
-                id: rectElement.label,
-                x: e.global.x,
-                y: e.global.y,
-              },
-              ...(typeof move?.payload === "object" ? move.payload : {}),
-            });
-          }
-        };
-
-        rectElement.on("pointerdown", downListener);
-        rectElement.on("pointerup", upListener);
-        rectElement.on("globalpointermove", moveListener);
-        rectElement.on("pointerupoutside", upListener);
-      }
+      bindRectInteractions({
+        app,
+        rect: rectElement,
+        element: nextElement,
+        eventHandler,
+      });
     }
 
     setElementRenderState(rectElement, nextElement);
@@ -274,6 +147,8 @@ export const updateRect = ({
     element: rectElement,
     targetState: {
       ...targetState,
+      ...getRectStyleTargetState(nextElement),
+      ...getBlurTargetState(nextElement, { force: shouldForceBlur }),
       ...getShaderFilterTargetState(nextElement, {
         force: shouldForceShaderProgress,
       }),

--- a/src/plugins/elements/rect/updateRect.js
+++ b/src/plugins/elements/rect/updateRect.js
@@ -1,8 +1,12 @@
 import { isDeepEqual } from "../../../util/isDeepEqual.js";
-import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import {
+  dispatchLiveAnimations,
+  getLiveAnimations,
+} from "../../animations/planAnimations.js";
 import {
   applyElementTransform,
   getElementTransformTargetState,
+  refreshElementPivot,
 } from "../util/transform.js";
 import {
   getBlurTargetState,
@@ -76,26 +80,80 @@ export const updateRect = ({
     animations,
     targetId: prevElement.id,
   });
-  installRectStyleRuntime(rectElement, prevElement, (property, runtime) => {
-    drawRectVisual(rectElement, runtime.state, {
-      ...runtime.element,
-      ...runtime.state,
-    });
-    const dimensionChanged =
-      property === "rect.width" ||
-      property === "rect.height" ||
-      property?.has?.("rect.width") ||
-      property?.has?.("rect.height");
-    if (dimensionChanged) {
-      syncShaderFilters(rectElement, runtime.element.filters, {
-        width: runtime.state.width,
-        height: runtime.state.height,
-        force: shouldForceShaderProgress,
-        animations,
-        targetId: prevElement.id,
-      });
-    }
+  const liveAnimations = getLiveAnimations(animations, prevElement.id);
+  const liveScaleX = liveAnimations.some(
+    (animation) => animation.tween?.scaleX !== undefined,
+  );
+  const liveScaleY = liveAnimations.some(
+    (animation) => animation.tween?.scaleY !== undefined,
+  );
+  const rectStyleTargetState = getRectStyleTargetState(nextElement, {
+    liveScaleX,
+    liveScaleY,
   });
+  const rectStyleRuntime = installRectStyleRuntime(
+    rectElement,
+    prevElement,
+    (property, runtime) => {
+      drawRectVisual(rectElement, runtime.state, {
+        ...runtime.element,
+        ...runtime.state,
+      });
+      const dimensionChanged =
+        property === "rect.width" ||
+        property === "rect.height" ||
+        property?.has?.("rect.width") ||
+        property?.has?.("rect.height");
+      if (dimensionChanged) {
+        syncShaderFilters(rectElement, runtime.element.filters, {
+          width: runtime.state.width,
+          height: runtime.state.height,
+          force: shouldForceShaderProgress,
+          animations,
+          targetId: prevElement.id,
+        });
+      }
+    },
+  );
+  const rectStyleStartState = getRectStyleTargetState(prevElement, {
+    liveScaleX,
+    liveScaleY,
+  });
+  const hasBakedWidth =
+    liveScaleX &&
+    rectElement.scale.x === 1 &&
+    rectStyleRuntime.state.width === prevElement.width;
+  const hasBakedHeight =
+    liveScaleY &&
+    rectElement.scale.y === 1 &&
+    rectStyleRuntime.state.height === prevElement.height;
+  const shouldFlattenWidth = !liveScaleX && rectElement.scale.x !== 1;
+  const shouldFlattenHeight = !liveScaleY && rectElement.scale.y !== 1;
+
+  if (
+    hasBakedWidth ||
+    hasBakedHeight ||
+    shouldFlattenWidth ||
+    shouldFlattenHeight
+  ) {
+    rectStyleRuntime.beginBatch();
+    if (shouldFlattenWidth) {
+      rectElement.scale.x = 1;
+      rectStyleRuntime["rect.width"] = prevElement.width;
+    } else if (hasBakedWidth) {
+      rectElement.scale.x = prevElement.scaleX ?? 1;
+      rectStyleRuntime["rect.width"] = rectStyleStartState["rect.width"];
+    }
+    if (shouldFlattenHeight) {
+      rectElement.scale.y = 1;
+      rectStyleRuntime["rect.height"] = prevElement.height;
+    } else if (hasBakedHeight) {
+      rectElement.scale.y = prevElement.scaleY ?? 1;
+      rectStyleRuntime["rect.height"] = rectStyleStartState["rect.height"];
+    }
+    refreshElementPivot(rectElement);
+    rectStyleRuntime.endBatch();
+  }
   const targetState = getElementTransformTargetState(nextElement, { alpha });
 
   if (scaleX !== undefined) {
@@ -147,7 +205,7 @@ export const updateRect = ({
     element: rectElement,
     targetState: {
       ...targetState,
-      ...getRectStyleTargetState(nextElement),
+      ...rectStyleTargetState,
       ...getBlurTargetState(nextElement, { force: shouldForceBlur }),
       ...getShaderFilterTargetState(nextElement, {
         force: shouldForceShaderProgress,

--- a/src/plugins/elements/util/shaderStateValidation.js
+++ b/src/plugins/elements/util/shaderStateValidation.js
@@ -1,3 +1,8 @@
+import {
+  getRectStyleTargetState,
+  isRectAnimationProperty,
+} from "../rect/rectStyleRuntime.js";
+
 const getTweenValues = (config) => [
   ...(config.initialValue === undefined ? [] : [config.initialValue]),
   ...config.keyframes.map((keyframe) => keyframe.value),
@@ -77,6 +82,28 @@ export const validateShaderAnimationBindings = ({
   const elementById = indexElementsById(elements);
 
   for (const animation of animations) {
+    const rectProperties = Object.keys(animation.tween ?? {}).filter(
+      isRectAnimationProperty,
+    );
+    if (rectProperties.length > 0) {
+      const element = elementById.get(animation.targetId);
+      if (element && element.type !== "rect") {
+        throw new Error(
+          `Animation "${animation.id}" can only target rect style properties on a rect element.`,
+        );
+      }
+      if (element) {
+        const targetState = getRectStyleTargetState(element);
+        for (const property of rectProperties) {
+          if (!Object.prototype.hasOwnProperty.call(targetState, property)) {
+            throw new Error(
+              `Animation "${animation.id}" property "${property.slice("rect.".length)}" is incompatible with rect "${animation.targetId}".`,
+            );
+          }
+        }
+      }
+    }
+
     if (animation.type === "transition" && animation.compositor) {
       validateTweenParameters({
         animation,

--- a/src/plugins/elements/util/shaderStateValidation.test.js
+++ b/src/plugins/elements/util/shaderStateValidation.test.js
@@ -429,3 +429,122 @@ describe("shader state validation", () => {
     ).not.toThrow();
   });
 });
+
+describe("rect style animation binding validation", () => {
+  const createRectAnimation = (tween) =>
+    normalizeAnimations([
+      {
+        id: "rect-style",
+        targetId: "card",
+        type: "update",
+        tween,
+      },
+    ]);
+
+  it("accepts style properties compatible with the destination rect", () => {
+    const animations = createRectAnimation({
+      width: { auto: { duration: 100 } },
+      fill: {
+        stops: [
+          {
+            index: 1,
+            color: { auto: { duration: 100 } },
+          },
+        ],
+      },
+    });
+
+    expect(() =>
+      validateShaderAnimationBindings({
+        elements: [
+          {
+            id: "card",
+            type: "rect",
+            width: 100,
+            height: 60,
+            fill: {
+              type: "linear-gradient",
+              stops: [
+                { offset: 0, color: "#000000" },
+                { offset: 1, color: "#ffffff" },
+              ],
+            },
+          },
+        ],
+        animations,
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects rect style properties on another element type", () => {
+    expect(() =>
+      validateShaderAnimationBindings({
+        elements: [{ id: "card", type: "sprite" }],
+        animations: createRectAnimation({
+          width: { auto: { duration: 100 } },
+        }),
+      }),
+    ).toThrow(
+      'Animation "rect-style" can only target rect style properties on a rect element.',
+    );
+  });
+
+  it("rejects solid fill color animation on a gradient destination", () => {
+    expect(() =>
+      validateShaderAnimationBindings({
+        elements: [
+          {
+            id: "card",
+            type: "rect",
+            width: 100,
+            height: 60,
+            fill: {
+              type: "linear-gradient",
+              stops: [
+                { offset: 0, color: "#000000" },
+                { offset: 1, color: "#ffffff" },
+              ],
+            },
+          },
+        ],
+        animations: createRectAnimation({
+          fill: {
+            color: { auto: { duration: 100 } },
+          },
+        }),
+      }),
+    ).toThrow('property "fill.color" is incompatible with rect "card"');
+  });
+
+  it("rejects a missing destination gradient stop", () => {
+    expect(() =>
+      validateShaderAnimationBindings({
+        elements: [
+          {
+            id: "card",
+            type: "rect",
+            width: 100,
+            height: 60,
+            fill: {
+              type: "linear-gradient",
+              stops: [
+                { offset: 0, color: "#000000" },
+                { offset: 1, color: "#ffffff" },
+              ],
+            },
+          },
+        ],
+        animations: createRectAnimation({
+          fill: {
+            stops: [
+              {
+                index: 4,
+                color: { auto: { duration: 100 } },
+              },
+            ],
+          },
+        }),
+      }),
+    ).toThrow('property "fill.stops.4.color" is incompatible with rect "card"');
+  });
+});

--- a/src/schemas/animations/animation.yaml
+++ b/src/schemas/animations/animation.yaml
@@ -63,6 +63,69 @@ $defs:
     oneOf:
       - $ref: "#/$defs/manualTweenProperty"
       - $ref: "#/$defs/autoTweenProperty"
+  colorKeyframe:
+    type: object
+    required:
+      - value
+      - duration
+    properties:
+      value:
+        type: string
+        description: Target color value.
+      duration:
+        type: number
+      easing:
+        type: string
+        enum:
+          - linear
+          - easeInQuad
+          - easeOutQuad
+          - easeInOutQuad
+          - easeInCubic
+          - easeOutCubic
+          - easeInOutCubic
+          - easeInQuart
+          - easeOutQuart
+          - easeInOutQuart
+          - easeInQuint
+          - easeOutQuint
+          - easeInOutQuint
+          - easeInSine
+          - easeOutSine
+          - easeInOutSine
+          - easeInExpo
+          - easeOutExpo
+          - easeInOutExpo
+          - easeInCirc
+          - easeOutCirc
+          - easeInOutCirc
+          - easeInBack
+          - easeOutBack
+          - easeInOutBack
+          - easeInBounce
+          - easeOutBounce
+          - easeInOutBounce
+          - easeInElastic
+          - easeOutElastic
+          - easeInOutElastic
+    additionalProperties: false
+  manualColorTweenProperty:
+    type: object
+    required:
+      - keyframes
+    properties:
+      initialValue:
+        type: string
+      keyframes:
+        type: array
+        minItems: 1
+        items:
+          $ref: "#/$defs/colorKeyframe"
+    additionalProperties: false
+  colorTweenProperty:
+    oneOf:
+      - $ref: "#/$defs/manualColorTweenProperty"
+      - $ref: "#/$defs/autoTweenProperty"
   manualTweenProperty:
     type: object
     properties:
@@ -137,6 +200,83 @@ $defs:
       "^.+$":
         $ref: "../shader-config.yaml#/definitions/shaderTween"
     additionalProperties: false
+  rectPointTween:
+    type: object
+    minProperties: 1
+    additionalProperties: false
+    properties:
+      x:
+        $ref: "#/$defs/tweenProperty"
+      y:
+        $ref: "#/$defs/tweenProperty"
+  rectFillStopTween:
+    type: object
+    required:
+      - index
+    minProperties: 2
+    additionalProperties: false
+    properties:
+      index:
+        type: integer
+        minimum: 0
+      offset:
+        $ref: "#/$defs/tweenProperty"
+      color:
+        $ref: "#/$defs/colorTweenProperty"
+  rectFillTween:
+    type: object
+    minProperties: 1
+    additionalProperties: false
+    properties:
+      color:
+        $ref: "#/$defs/colorTweenProperty"
+      start:
+        $ref: "#/$defs/rectPointTween"
+      end:
+        $ref: "#/$defs/rectPointTween"
+      innerCenter:
+        $ref: "#/$defs/rectPointTween"
+      innerRadius:
+        $ref: "#/$defs/tweenProperty"
+      outerCenter:
+        $ref: "#/$defs/rectPointTween"
+      outerRadius:
+        $ref: "#/$defs/tweenProperty"
+      stops:
+        type: array
+        minItems: 1
+        items:
+          $ref: "#/$defs/rectFillStopTween"
+      scale:
+        $ref: "#/$defs/tweenProperty"
+      rotation:
+        $ref: "#/$defs/tweenProperty"
+  rectBorderTween:
+    type: object
+    minProperties: 1
+    additionalProperties: false
+    properties:
+      width:
+        $ref: "#/$defs/tweenProperty"
+      color:
+        $ref: "#/$defs/colorTweenProperty"
+      alpha:
+        $ref: "#/$defs/tweenProperty"
+  rectCornerRadiusTween:
+    oneOf:
+      - $ref: "#/$defs/tweenProperty"
+      - type: object
+        minProperties: 1
+        additionalProperties: false
+        properties:
+          topLeft:
+            $ref: "#/$defs/tweenProperty"
+          topRight:
+            $ref: "#/$defs/tweenProperty"
+          bottomRight:
+            $ref: "#/$defs/tweenProperty"
+          bottomLeft:
+            $ref: "#/$defs/tweenProperty"
   updateTween:
     type: object
     properties:
@@ -160,6 +300,16 @@ $defs:
         $ref: "#/$defs/tweenProperty"
       blurY:
         $ref: "#/$defs/tweenProperty"
+      width:
+        $ref: "#/$defs/tweenProperty"
+      height:
+        $ref: "#/$defs/tweenProperty"
+      fill:
+        $ref: "#/$defs/rectFillTween"
+      border:
+        $ref: "#/$defs/rectBorderTween"
+      cornerRadius:
+        $ref: "#/$defs/rectCornerRadiusTween"
       filters:
         $ref: "#/$defs/filterTweens"
     allOf:

--- a/src/schemas/elements/input.element.yaml
+++ b/src/schemas/elements/input.element.yaml
@@ -71,13 +71,14 @@ $def:
             type: string
             enum: [local, global]
             description: Whether gradient coordinates are relative to the input or the world
-          textureSize:
+          resolution:
             type: number
-            description: Gradient texture resolution hint
-          wrapMode:
+            exclusiveMinimum: 0
+            description: Gradient sampling resolution in pixels
+          spread:
             type: string
-            enum: [clamp-to-edge, repeat]
-            description: Gradient wrap mode
+            enum: [pad, repeat]
+            description: Behavior outside the gradient range
       - type: object
         additionalProperties: false
         required:
@@ -108,13 +109,14 @@ $def:
             type: string
             enum: [local, global]
             description: Whether gradient coordinates are relative to the input or the world
-          textureSize:
+          resolution:
             type: number
-            description: Gradient texture resolution hint
-          wrapMode:
+            exclusiveMinimum: 0
+            description: Gradient sampling resolution in pixels
+          spread:
             type: string
-            enum: [clamp-to-edge, repeat]
-            description: Gradient wrap mode
+            enum: [pad, repeat]
+            description: Behavior outside the gradient range
           scale:
             type: number
             description: Radial gradient ellipse scale

--- a/src/schemas/elements/rect.computed.yaml
+++ b/src/schemas/elements/rect.computed.yaml
@@ -2,6 +2,7 @@ $schema: http://json-schema.org/draft-07/schema#
 title: Rect Computed Node
 description: Schema for rectangle computed node after parsing
 type: object
+additionalProperties: false
 $def:
   point:
     type: object
@@ -65,11 +66,11 @@ $def:
           coordinateSpace:
             type: string
             enum: [local, global]
-          textureSize:
+          resolution:
             type: number
-          wrapMode:
+          spread:
             type: string
-            enum: [clamp-to-edge, repeat]
+            enum: [pad, repeat]
       - type: object
         additionalProperties: false
         required:
@@ -94,11 +95,11 @@ $def:
           coordinateSpace:
             type: string
             enum: [local, global]
-          textureSize:
+          resolution:
             type: number
-          wrapMode:
+          spread:
             type: string
-            enum: [clamp-to-edge, repeat]
+            enum: [pad, repeat]
           scale:
             type: number
           rotation:
@@ -142,6 +143,7 @@ properties:
     description: Optional fill of the rectangle. Supports solid colors and structured gradient fills. When omitted, the rect renders transparent.
   border:
     type: object
+    additionalProperties: false
     description: Border properties
     properties:
       width:
@@ -155,12 +157,58 @@ properties:
         description: Border opacity (0-1)
         minimum: 0
         maximum: 1
+  cornerRadius:
+    type: object
+    additionalProperties: false
+    properties:
+      topLeft:
+        type: number
+        minimum: 0
+      topRight:
+        type: number
+        minimum: 0
+      bottomRight:
+        type: number
+        minimum: 0
+      bottomLeft:
+        type: number
+        minimum: 0
+  scaleX:
+    type: number
+  scaleY:
+    type: number
+  alpha:
+    type: number
+    minimum: 0
+    maximum: 1
+  blur:
+    type: object
+    additionalProperties: false
+    required: [x, y, quality, kernelSize, repeatEdgePixels]
+    properties:
+      x:
+        type: number
+        minimum: 0
+      y:
+        type: number
+        minimum: 0
+      quality:
+        type: number
+        minimum: 1
+      kernelSize:
+        type: number
+        enum: [5, 7, 9, 11, 13, 15]
+      repeatEdgePixels:
+        type: boolean
+  filters:
+    $ref: "../shader-config.yaml#/definitions/elementFilters"
   rotation:
     type: number
     description: Rotation in degrees
     default: 0
   hover:
     type: object
+    additionalProperties: false
     properties:
       soundSrc:
         type: string
@@ -179,6 +227,7 @@ properties:
         description: Payload for hover action event
   click:
     type: object
+    additionalProperties: false
     properties:
       soundSrc:
         type: string
@@ -194,36 +243,51 @@ properties:
         description: Payload for click action event
   drag:
     type: object
+    additionalProperties: false
+    minProperties: 1
     properties:
       start:
-        payload:
-          type: object
-          description: Payload for click action event
+        type: object
+        additionalProperties: false
+        properties:
+          payload:
+            type: object
       end:
-        payload:
-          type: object
-          description: Payload for click action event
+        type: object
+        additionalProperties: false
+        properties:
+          payload:
+            type: object
       move:
-        payload:
-          type: object
-          description: Payload for click action event
+        type: object
+        additionalProperties: false
+        properties:
+          payload:
+            type: object
   rightClick:
     type: object
+    additionalProperties: false
     properties:
       soundSrc:
         type: string
         description: source of sound to be played when the rect is right-clicked
+      soundVolume:
+        type: number
+        minimum: 0
+        maximum: 100
       payload:
         type: object
         description: Payload for right-click action event
   scrollUp:
     type: object
+    additionalProperties: false
     properties:
       payload:
         type: object
         description: Payload for scroll up action event
   scrollDown:
     type: object
+    additionalProperties: false
     properties:
       payload:
         type: object

--- a/src/schemas/elements/rect.element.yaml
+++ b/src/schemas/elements/rect.element.yaml
@@ -2,6 +2,7 @@ $schema: http://json-schema.org/draft-07/schema#
 title: Rect Element
 description: Schema for rectangle element raw input
 type: object
+additionalProperties: false
 $def:
   point:
     type: object
@@ -71,13 +72,14 @@ $def:
             type: string
             enum: [local, global]
             description: Whether gradient coordinates are relative to the rect or the world
-          textureSize:
+          resolution:
             type: number
-            description: Gradient texture resolution hint
-          wrapMode:
+            exclusiveMinimum: 0
+            description: Gradient sampling resolution in pixels
+          spread:
             type: string
-            enum: [clamp-to-edge, repeat]
-            description: Gradient wrap mode
+            enum: [pad, repeat]
+            description: Behavior outside the gradient range
       - type: object
         additionalProperties: false
         required:
@@ -108,13 +110,14 @@ $def:
             type: string
             enum: [local, global]
             description: Whether gradient coordinates are relative to the rect or the world
-          textureSize:
+          resolution:
             type: number
-            description: Gradient texture resolution hint
-          wrapMode:
+            exclusiveMinimum: 0
+            description: Gradient sampling resolution in pixels
+          spread:
             type: string
-            enum: [clamp-to-edge, repeat]
-            description: Gradient wrap mode
+            enum: [pad, repeat]
+            description: Behavior outside the gradient range
           scale:
             type: number
             description: Radial gradient ellipse scale
@@ -135,9 +138,11 @@ properties:
     description: Element type, must be 'rect'
   width:
     type: number
+    exclusiveMinimum: 0
     description: Width of the rectangle in pixels
   height:
     type: number
+    exclusiveMinimum: 0
     description: Height of the rectangle in pixels
   x:
     type: number
@@ -159,6 +164,14 @@ properties:
   originY:
     type: number
     description: Vertical transform origin in pixels from the element's top edge. Defaults to the anchor-derived Y origin.
+  scaleX:
+    type: number
+    exclusiveMinimum: 0
+    description: Horizontal scale baked into rect geometry
+  scaleY:
+    type: number
+    exclusiveMinimum: 0
+    description: Vertical scale baked into rect geometry
   alpha:
     type: number
     description: Opacity/transparency of the rectangle (0-1)
@@ -170,10 +183,12 @@ properties:
     description: Optional fill of the rectangle. Supports solid colors and structured gradient fills. When omitted, the rect renders transparent.
   border:
     type: object
+    additionalProperties: false
     description: Border properties
     properties:
       width:
         type: number
+        minimum: 0
         description: Border width in pixels
         default: 0
       color:
@@ -186,14 +201,57 @@ properties:
         minimum: 0
         maximum: 1
         default: 1
+  cornerRadius:
+    description: Uniform radius or independent corner radii in pixels
+    oneOf:
+      - type: number
+        minimum: 0
+      - type: object
+        additionalProperties: false
+        properties:
+          topLeft:
+            type: number
+            minimum: 0
+          topRight:
+            type: number
+            minimum: 0
+          bottomRight:
+            type: number
+            minimum: 0
+          bottomLeft:
+            type: number
+            minimum: 0
   rotation:
     type: number
     description: Rotation in degrees
     default: 0
   filters:
     $ref: "../shader-config.yaml#/definitions/elementFilters"
+  blur:
+    type: object
+    additionalProperties: false
+    required: [x, y]
+    properties:
+      x:
+        type: number
+        minimum: 0
+      y:
+        type: number
+        minimum: 0
+      quality:
+        type: number
+        minimum: 1
+        default: 4
+      kernelSize:
+        type: number
+        enum: [5, 7, 9, 11, 13, 15]
+        default: 5
+      repeatEdgePixels:
+        type: boolean
+        default: false
   hover:
     type: object
+    additionalProperties: false
     properties:
       soundSrc:
         type: string
@@ -212,6 +270,7 @@ properties:
         description: Payload for hover action event
   click:
     type: object
+    additionalProperties: false
     properties:
       soundSrc:
         type: string
@@ -227,36 +286,55 @@ properties:
         description: Payload for click action event
   drag:
     type: object
+    additionalProperties: false
+    minProperties: 1
     properties:
       start:
-        payload:
-          type: object
-          description: Payload for click action event
+        type: object
+        additionalProperties: false
+        properties:
+          payload:
+            type: object
+            description: Payload for drag start event
       end:
-        payload:
-          type: object
-          description: Payload for click action event
+        type: object
+        additionalProperties: false
+        properties:
+          payload:
+            type: object
+            description: Payload for drag end event
       move:
-        payload:
-          type: object
-          description: Payload for click action event
+        type: object
+        additionalProperties: false
+        properties:
+          payload:
+            type: object
+            description: Payload for drag move event
   rightClick:
     type: object
+    additionalProperties: false
     properties:
       soundSrc:
         type: string
         description: source of sound to be played when the rect is right-clicked
+      soundVolume:
+        type: number
+        minimum: 0
+        maximum: 100
+        default: 100
       payload:
         type: object
         description: Payload for right-click action event
   scrollUp:
     type: object
+    additionalProperties: false
     properties:
       payload:
         type: object
         description: Payload for scroll up action event
   scrollDown:
     type: object
+    additionalProperties: false
     properties:
       payload:
         type: object

--- a/src/types.js
+++ b/src/types.js
@@ -97,6 +97,7 @@
 /**
  * @typedef {Object} HoverProps
  * @property {string} soundSrc
+ * @property {number} [soundVolume]
  * @property {string} cursor
  * @property {Object} payload
  */
@@ -104,6 +105,7 @@
 /**
  * @typedef {Object} ClickProps
  * @property {string} soundSrc
+ * @property {number} [soundVolume]
  * @property {Object} payload
  */
 
@@ -471,8 +473,8 @@
  * @property {RectFillPoint} [end]
  * @property {RectFillStop[]} stops
  * @property {'local' | 'global'} [coordinateSpace]
- * @property {number} [textureSize]
- * @property {'clamp-to-edge' | 'repeat'} [wrapMode]
+ * @property {number} [resolution]
+ * @property {'pad' | 'repeat'} [spread]
  */
 
 /**
@@ -484,8 +486,8 @@
  * @property {number} [outerRadius]
  * @property {RectFillStop[]} stops
  * @property {'local' | 'global'} [coordinateSpace]
- * @property {number} [textureSize]
- * @property {'clamp-to-edge' | 'repeat'} [wrapMode]
+ * @property {number} [resolution]
+ * @property {'pad' | 'repeat'} [spread]
  * @property {number} [scale]
  * @property {number} [rotation]
  */
@@ -502,6 +504,8 @@
  * @property {number} border.width
  * @property {string} border.color
  * @property {number} border.alpha
+ * @property {{topLeft: number, topRight: number, bottomRight: number, bottomLeft: number}} [cornerRadius]
+ * @property {BlurConfig} [blur]
  * @property {string} cursor - Cursor style (e.g., "pointer")
  * @property {string} pointerDown - Event name for pointer down
  * @property {string} pointerUp - Event name for pointer up
@@ -803,6 +807,17 @@ export const WhiteListAnimationProps = {
   blurY: "blurY",
   uProgress: "uProgress",
 };
+
+const RECT_STYLE_ANIMATION_PROPERTY_PATTERN =
+  /^rect\.(?:width|height|fill\.(?:color|(?:start|end|innerCenter|outerCenter)\.(?:x|y)|(?:innerRadius|outerRadius|scale|rotation)|stops\.\d+\.(?:offset|color))|border\.(?:width|color|alpha)|cornerRadius\.(?:topLeft|topRight|bottomRight|bottomLeft))$/;
+
+export const isRectStyleAnimationProperty = (property) =>
+  typeof property === "string" &&
+  RECT_STYLE_ANIMATION_PROPERTY_PATTERN.test(property);
+
+export const isSupportedAnimationProperty = (property) =>
+  Boolean(WhiteListAnimationProps[property]) ||
+  isRectStyleAnimationProperty(property);
 
 export const WhiteListTransitionProps = WhiteListAnimationProps;
 

--- a/src/util/normalizeAnimations.js
+++ b/src/util/normalizeAnimations.js
@@ -1,5 +1,6 @@
 import { SUPPORTED_EASING_NAMES } from "./animationTimeline.js";
 import { normalizeShaderCompositor } from "../plugins/elements/util/shaderConfig.js";
+import { Color } from "pixi.js";
 
 const ANIMATION_TYPES = new Set(["update", "transition"]);
 const CONTINUITY_MODES = new Set(["render", "persistent"]);
@@ -33,6 +34,13 @@ const MASK_CHANNELS = new Set(["red", "green", "blue", "alpha"]);
 const MASK_SEQUENCE_SAMPLE_MODES = new Set(["hold", "linear"]);
 const SUPPORTED_EASINGS = new Set(SUPPORTED_EASING_NAMES);
 const SHADER_PARAMETER_PATTERN = /^[a-z][A-Za-z0-9]*$/;
+const RECT_STYLE_TWEEN_FIELDS = new Set([
+  "width",
+  "height",
+  "fill",
+  "border",
+  "cornerRadius",
+]);
 
 const assertPlainObject = (value, path) => {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -43,6 +51,14 @@ const assertPlainObject = (value, path) => {
 const assertString = (value, path) => {
   if (typeof value !== "string" || value.length === 0) {
     throw new Error(`${path} must be a non-empty string.`);
+  }
+};
+
+const assertKnownFields = (value, fields, path) => {
+  for (const key of Object.keys(value)) {
+    if (!fields.has(key)) {
+      throw new Error(`${path}.${key} is not supported.`);
+    }
   }
 };
 
@@ -142,6 +158,7 @@ const normalizeKeyframes = (
   propertyConfig,
   path,
   assertValue = assertNumber,
+  normalizeValue = (value) => (Array.isArray(value) ? [...value] : value),
 ) => {
   assertPlainObject(propertyConfig, path);
 
@@ -149,9 +166,7 @@ const normalizeKeyframes = (
 
   if (propertyConfig.initialValue !== undefined) {
     assertValue(propertyConfig.initialValue, `${path}.initialValue`);
-    normalized.initialValue = Array.isArray(propertyConfig.initialValue)
-      ? [...propertyConfig.initialValue]
-      : propertyConfig.initialValue;
+    normalized.initialValue = normalizeValue(propertyConfig.initialValue);
   }
 
   if (
@@ -188,9 +203,7 @@ const normalizeKeyframes = (
     }
 
     return {
-      value: Array.isArray(keyframe.value)
-        ? [...keyframe.value]
-        : keyframe.value,
+      value: normalizeValue(keyframe.value),
       duration: keyframe.duration,
       easing: keyframe.easing ?? "linear",
       ...(keyframe.relative !== undefined
@@ -273,6 +286,258 @@ const normalizeUpdatePropertyConfig = (propertyConfig, path) => {
   return normalizeKeyframes(propertyConfig, path);
 };
 
+const normalizeColorValue = (value, path) => {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${path} must be a non-empty color string.`);
+  }
+
+  try {
+    return new Color(value).toArray();
+  } catch {
+    throw new Error(`${path} must be a valid color.`);
+  }
+};
+
+const normalizeColorPropertyConfig = (propertyConfig, path) => {
+  assertPlainObject(propertyConfig, path);
+
+  if (propertyConfig.auto !== undefined) {
+    return normalizeUpdatePropertyConfig(propertyConfig, path);
+  }
+
+  for (const [index, keyframe] of (propertyConfig.keyframes ?? []).entries()) {
+    if (keyframe?.relative === true) {
+      throw new Error(
+        `${path}.keyframes[${index}].relative is not supported for colors.`,
+      );
+    }
+  }
+
+  return normalizeKeyframes(
+    propertyConfig,
+    path,
+    (value, valuePath) => {
+      normalizeColorValue(value, valuePath);
+    },
+    normalizeColorValue,
+  );
+};
+
+const normalizeRectPointTween = (point, path, prefix) => {
+  assertPlainObject(point, path);
+  assertKnownFields(point, new Set(["x", "y"]), path);
+  const entries = Object.entries(point);
+  if (entries.length === 0) {
+    throw new Error(`${path} must define x or y.`);
+  }
+  return Object.fromEntries(
+    entries.map(([axis, config]) => [
+      `${prefix}.${axis}`,
+      normalizeUpdatePropertyConfig(config, `${path}.${axis}`),
+    ]),
+  );
+};
+
+const normalizeRectFillStopsTween = (stops, path) => {
+  if (!Array.isArray(stops) || stops.length === 0) {
+    throw new Error(`${path} must be a non-empty array.`);
+  }
+
+  const indices = new Set();
+  return Object.assign(
+    {},
+    ...stops.map((stop, itemIndex) => {
+      const itemPath = `${path}[${itemIndex}]`;
+      assertPlainObject(stop, itemPath);
+      assertKnownFields(stop, new Set(["index", "offset", "color"]), itemPath);
+      if (!Number.isInteger(stop.index) || stop.index < 0) {
+        throw new Error(`${itemPath}.index must be a non-negative integer.`);
+      }
+      if (indices.has(stop.index)) {
+        throw new Error(`${path} cannot target stop ${stop.index} twice.`);
+      }
+      indices.add(stop.index);
+      if (stop.offset === undefined && stop.color === undefined) {
+        throw new Error(`${itemPath} must define offset or color.`);
+      }
+
+      return {
+        ...(stop.offset === undefined
+          ? {}
+          : {
+              [`rect.fill.stops.${stop.index}.offset`]:
+                normalizeUpdatePropertyConfig(
+                  stop.offset,
+                  `${itemPath}.offset`,
+                ),
+            }),
+        ...(stop.color === undefined
+          ? {}
+          : {
+              [`rect.fill.stops.${stop.index}.color`]:
+                normalizeColorPropertyConfig(stop.color, `${itemPath}.color`),
+            }),
+      };
+    }),
+  );
+};
+
+const normalizeRectFillTween = (fill, path) => {
+  assertPlainObject(fill, path);
+  assertKnownFields(
+    fill,
+    new Set([
+      "color",
+      "start",
+      "end",
+      "innerCenter",
+      "innerRadius",
+      "outerCenter",
+      "outerRadius",
+      "stops",
+      "scale",
+      "rotation",
+    ]),
+    path,
+  );
+  if (Object.keys(fill).length === 0) {
+    throw new Error(`${path} must define at least one property.`);
+  }
+
+  return {
+    ...(fill.color === undefined
+      ? {}
+      : {
+          "rect.fill.color": normalizeColorPropertyConfig(
+            fill.color,
+            `${path}.color`,
+          ),
+        }),
+    ...(fill.start === undefined
+      ? {}
+      : normalizeRectPointTween(
+          fill.start,
+          `${path}.start`,
+          "rect.fill.start",
+        )),
+    ...(fill.end === undefined
+      ? {}
+      : normalizeRectPointTween(fill.end, `${path}.end`, "rect.fill.end")),
+    ...(fill.innerCenter === undefined
+      ? {}
+      : normalizeRectPointTween(
+          fill.innerCenter,
+          `${path}.innerCenter`,
+          "rect.fill.innerCenter",
+        )),
+    ...(fill.outerCenter === undefined
+      ? {}
+      : normalizeRectPointTween(
+          fill.outerCenter,
+          `${path}.outerCenter`,
+          "rect.fill.outerCenter",
+        )),
+    ...Object.fromEntries(
+      ["innerRadius", "outerRadius", "scale", "rotation"]
+        .filter((property) => fill[property] !== undefined)
+        .map((property) => [
+          `rect.fill.${property}`,
+          normalizeUpdatePropertyConfig(fill[property], `${path}.${property}`),
+        ]),
+    ),
+    ...(fill.stops === undefined
+      ? {}
+      : normalizeRectFillStopsTween(fill.stops, `${path}.stops`)),
+  };
+};
+
+const normalizeRectBorderTween = (border, path) => {
+  assertPlainObject(border, path);
+  assertKnownFields(border, new Set(["width", "color", "alpha"]), path);
+  const entries = Object.entries(border);
+  if (entries.length === 0) {
+    throw new Error(`${path} must define width, color, or alpha.`);
+  }
+
+  return Object.fromEntries(
+    entries.map(([property, config]) => [
+      `rect.border.${property}`,
+      property === "color"
+        ? normalizeColorPropertyConfig(config, `${path}.${property}`)
+        : normalizeUpdatePropertyConfig(config, `${path}.${property}`),
+    ]),
+  );
+};
+
+const normalizeRectCornerRadiusTween = (cornerRadius, path) => {
+  assertPlainObject(cornerRadius, path);
+  const isUniformTimeline =
+    cornerRadius.keyframes !== undefined || cornerRadius.auto !== undefined;
+  const cornerNames = ["topLeft", "topRight", "bottomRight", "bottomLeft"];
+
+  if (isUniformTimeline) {
+    assertKnownFields(
+      cornerRadius,
+      new Set(["initialValue", "keyframes", "auto"]),
+      path,
+    );
+    const normalized = normalizeUpdatePropertyConfig(cornerRadius, path);
+    return Object.fromEntries(
+      cornerNames.map((corner) => [`rect.cornerRadius.${corner}`, normalized]),
+    );
+  }
+
+  assertKnownFields(cornerRadius, new Set(cornerNames), path);
+  const entries = Object.entries(cornerRadius);
+  if (entries.length === 0) {
+    throw new Error(`${path} must define at least one corner.`);
+  }
+  return Object.fromEntries(
+    entries.map(([corner, config]) => [
+      `rect.cornerRadius.${corner}`,
+      normalizeUpdatePropertyConfig(config, `${path}.${corner}`),
+    ]),
+  );
+};
+
+const normalizeRectStyleTween = (rectTween, path) => {
+  const normalized = {};
+  if (rectTween.width !== undefined) {
+    normalized["rect.width"] = normalizeUpdatePropertyConfig(
+      rectTween.width,
+      `${path}.width`,
+    );
+  }
+  if (rectTween.height !== undefined) {
+    normalized["rect.height"] = normalizeUpdatePropertyConfig(
+      rectTween.height,
+      `${path}.height`,
+    );
+  }
+  if (rectTween.fill !== undefined) {
+    Object.assign(
+      normalized,
+      normalizeRectFillTween(rectTween.fill, `${path}.fill`),
+    );
+  }
+  if (rectTween.border !== undefined) {
+    Object.assign(
+      normalized,
+      normalizeRectBorderTween(rectTween.border, `${path}.border`),
+    );
+  }
+  if (rectTween.cornerRadius !== undefined) {
+    Object.assign(
+      normalized,
+      normalizeRectCornerRadiusTween(
+        rectTween.cornerRadius,
+        `${path}.cornerRadius`,
+      ),
+    );
+  }
+  return normalized;
+};
+
 const normalizeTweenMap = (
   tween,
   path,
@@ -324,7 +589,17 @@ const normalizeFilterTweens = (filters, path) => {
 const normalizeUpdateTween = (tween, path) => {
   assertPlainObject(tween, path);
 
-  const { filters, ...elementTween } = tween;
+  const { filters, ...nonFilterTween } = tween;
+  const rectTween = Object.fromEntries(
+    Object.entries(nonFilterTween).filter(([property]) =>
+      RECT_STYLE_TWEEN_FIELDS.has(property),
+    ),
+  );
+  const elementTween = Object.fromEntries(
+    Object.entries(nonFilterTween).filter(
+      ([property]) => !RECT_STYLE_TWEEN_FIELDS.has(property),
+    ),
+  );
   const normalized = {};
 
   if (Object.keys(elementTween).length > 0) {
@@ -334,6 +609,12 @@ const normalizeUpdateTween = (tween, path) => {
       UPDATE_TWEEN_PROPERTIES,
       normalizeUpdatePropertyConfig,
     );
+  }
+  if (Object.keys(rectTween).length > 0) {
+    normalized.tween = {
+      ...normalized.tween,
+      ...normalizeRectStyleTween(rectTween, path),
+    };
   }
 
   if (filters !== undefined) {

--- a/src/util/normalizeAnimations.test.js
+++ b/src/util/normalizeAnimations.test.js
@@ -731,3 +731,233 @@ describe("normalizeAnimations shader support", () => {
     ).toThrow(/keyframes must be a non-empty array/);
   });
 });
+
+describe("normalizeAnimations rect style support", () => {
+  it("flattens complete rect style timelines into internal animation paths", () => {
+    const [animation] = normalizeAnimations([
+      {
+        id: "reshape",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          width: { auto: { duration: 300 } },
+          height: {
+            initialValue: 80,
+            keyframes: [{ duration: 300, value: 120 }],
+          },
+          fill: {
+            start: {
+              x: { auto: { duration: 300 } },
+            },
+            stops: [
+              {
+                index: 1,
+                offset: { auto: { duration: 300 } },
+                color: {
+                  initialValue: "#ff0000",
+                  keyframes: [{ duration: 300, value: "#0000ff" }],
+                },
+              },
+            ],
+          },
+          border: {
+            width: { auto: { duration: 300 } },
+            color: { auto: { duration: 300 } },
+            alpha: { auto: { duration: 300 } },
+          },
+          cornerRadius: {
+            topLeft: { auto: { duration: 300 } },
+            bottomRight: { auto: { duration: 300 } },
+          },
+        },
+      },
+    ]);
+
+    expect(Object.keys(animation.tween)).toEqual([
+      "rect.width",
+      "rect.height",
+      "rect.fill.start.x",
+      "rect.fill.stops.1.offset",
+      "rect.fill.stops.1.color",
+      "rect.border.width",
+      "rect.border.color",
+      "rect.border.alpha",
+      "rect.cornerRadius.topLeft",
+      "rect.cornerRadius.bottomRight",
+    ]);
+    expect(animation.tween["rect.fill.stops.1.color"].initialValue).toEqual([
+      1, 0, 0, 1,
+    ]);
+    expect(
+      animation.tween["rect.fill.stops.1.color"].keyframes[0].value,
+    ).toEqual([0, 0, 1, 1]);
+  });
+
+  it("expands a uniform corner radius timeline to every corner", () => {
+    const [animation] = normalizeAnimations([
+      {
+        id: "round",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          cornerRadius: {
+            auto: { duration: 200, easing: "easeOutQuad" },
+          },
+        },
+      },
+    ]);
+
+    expect(Object.keys(animation.tween)).toEqual([
+      "rect.cornerRadius.topLeft",
+      "rect.cornerRadius.topRight",
+      "rect.cornerRadius.bottomRight",
+      "rect.cornerRadius.bottomLeft",
+    ]);
+    expect(animation.tween["rect.cornerRadius.bottomLeft"].auto).toEqual({
+      duration: 200,
+      easing: "easeOutQuad",
+    });
+  });
+
+  it.each([
+    [
+      "unknown fill field",
+      { fill: { opacity: { auto: { duration: 100 } } } },
+      "animations[0].tween.fill.opacity is not supported",
+    ],
+    ["empty fill", { fill: {} }, "animations[0].tween.fill must define"],
+    [
+      "empty gradient point",
+      { fill: { start: {} } },
+      "animations[0].tween.fill.start must define x or y",
+    ],
+    [
+      "unknown gradient point field",
+      {
+        fill: {
+          start: {
+            z: { auto: { duration: 100 } },
+          },
+        },
+      },
+      "animations[0].tween.fill.start.z is not supported",
+    ],
+    [
+      "empty stops",
+      { fill: { stops: [] } },
+      "animations[0].tween.fill.stops must be a non-empty array",
+    ],
+    ["empty border", { border: {} }, "animations[0].tween.border must define"],
+    [
+      "unknown border field",
+      { border: { placement: { auto: { duration: 100 } } } },
+      "animations[0].tween.border.placement is not supported",
+    ],
+    [
+      "invalid stop index",
+      {
+        fill: {
+          stops: [
+            {
+              index: -1,
+              color: { auto: { duration: 100 } },
+            },
+          ],
+        },
+      },
+      "index must be a non-negative integer",
+    ],
+    [
+      "non-integer stop index",
+      {
+        fill: {
+          stops: [
+            {
+              index: 0.5,
+              color: { auto: { duration: 100 } },
+            },
+          ],
+        },
+      },
+      "index must be a non-negative integer",
+    ],
+    [
+      "stop without an animated channel",
+      {
+        fill: {
+          stops: [{ index: 0 }],
+        },
+      },
+      "must define offset or color",
+    ],
+    [
+      "duplicate stop index",
+      {
+        fill: {
+          stops: [
+            { index: 0, offset: { auto: { duration: 100 } } },
+            { index: 0, color: { auto: { duration: 100 } } },
+          ],
+        },
+      },
+      "cannot target stop 0 twice",
+    ],
+    [
+      "invalid color",
+      {
+        fill: {
+          color: {
+            keyframes: [{ duration: 100, value: "invalid()" }],
+          },
+        },
+      },
+      "must be a valid color",
+    ],
+    [
+      "relative color",
+      {
+        border: {
+          color: {
+            keyframes: [{ duration: 100, value: "#ffffff", relative: true }],
+          },
+        },
+      },
+      "relative is not supported for colors",
+    ],
+    [
+      "empty per-corner map",
+      { cornerRadius: {} },
+      "animations[0].tween.cornerRadius must define at least one corner",
+    ],
+    [
+      "unknown corner",
+      {
+        cornerRadius: {
+          upperLeft: { auto: { duration: 100 } },
+        },
+      },
+      "animations[0].tween.cornerRadius.upperLeft is not supported",
+    ],
+    [
+      "mixed uniform and per-corner timelines",
+      {
+        cornerRadius: {
+          auto: { duration: 100 },
+          topLeft: { auto: { duration: 100 } },
+        },
+      },
+      "animations[0].tween.cornerRadius.topLeft is not supported",
+    ],
+  ])("rejects %s", (_name, tween, message) => {
+    expect(() =>
+      normalizeAnimations([
+        {
+          id: "invalid-rect",
+          targetId: "panel",
+          type: "update",
+          tween,
+        },
+      ]),
+    ).toThrow(message);
+  });
+});

--- a/vt/reference/rect/rounded-corners-01.webp
+++ b/vt/reference/rect/rounded-corners-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72fce2f0170e651f84553100d3142a11a9d579c1bac85b356890855c3849ec41
+size 5674

--- a/vt/reference/recttransition/rect-update-style-01.webp
+++ b/vt/reference/recttransition/rect-update-style-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a7e964e9a229f38134a6265a47327ddc992a06ae0199c363110287be28069d3
+size 2332

--- a/vt/reference/recttransition/rect-update-style-02.webp
+++ b/vt/reference/recttransition/rect-update-style-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:971cfc6c9aa7dfec0ebecf67f3c69705fa7e60e9b517c195b7b6c4bdb7df5f45
+size 3348

--- a/vt/reference/recttransition/rect-update-style-03.webp
+++ b/vt/reference/recttransition/rect-update-style-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33dcbee6dc6bd4ead4ab2890441fd95e4da17ba44e4a872f7bc9d8647e7a80f2
+size 4292

--- a/vt/reference/shaderfilters/rect-shader-filter-stack-01.webp
+++ b/vt/reference/shaderfilters/rect-shader-filter-stack-01.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f2820b7ab4d8a1edab0be42741f09b0c2c9b36d3b0d2a3a15dc195fba93931ca
-size 6254
+oid sha256:9df8aab4516fabe90fb9585404e3a2a5a8a3aaea6be6d4371ab2c099d3df6968
+size 7130

--- a/vt/specs/rect/delete-rect.yaml
+++ b/vt/specs/rect/delete-rect.yaml
@@ -20,7 +20,6 @@ states:
         width: 100
         height: 80
         fill: "#FFFFFF"
-        zIndex: 1
       - id: rect-2
         type: rect
         x: 200
@@ -28,7 +27,6 @@ states:
         width: 120
         height: 90
         fill: "#FFFFFF"
-        zIndex: 1
       - id: rect-3
         type: rect
         x: 350
@@ -36,7 +34,6 @@ states:
         width: 80
         height: 100
         fill: "#FFFFFF"
-        zIndex: 1
   - elements:
       - id: rect-2
         type: rect
@@ -45,4 +42,3 @@ states:
         width: 120
         height: 90
         fill: "#FFFFFF"
-        zIndex: 1

--- a/vt/specs/rect/gradient-fills.yaml
+++ b/vt/specs/rect/gradient-fills.yaml
@@ -112,7 +112,7 @@ states:
           type: linear-gradient
           start: { x: 0, y: 0 }
           end: { x: 0.25, y: 0 }
-          wrapMode: repeat
+          spread: repeat
           stops:
             - offset: 0
               color: "#ffffff"

--- a/vt/specs/rect/rounded-corners.yaml
+++ b/vt/specs/rect/rounded-corners.yaml
@@ -1,0 +1,54 @@
+---
+title: Rect Independent Corner Radii
+description: Rects support uniform and independent corner radii with oversized radii normalized safely
+specs:
+  - the first rect should have four equal rounded corners
+  - the second rect should have four visibly different corners
+  - the third rect should reduce oversized radii without overlap
+---
+states:
+  - elements:
+      - id: uniform-rounded
+        type: rect
+        x: 80
+        "y": 100
+        width: 280
+        height: 180
+        fill: "#2563eb"
+        border:
+          width: 6
+          color: "#ffffff"
+          alpha: 0.9
+        cornerRadius: 36
+      - id: independent-rounded
+        type: rect
+        x: 500
+        "y": 100
+        width: 280
+        height: 180
+        fill:
+          type: linear-gradient
+          start: { x: 0, y: 0 }
+          end: { x: 1, y: 1 }
+          stops:
+            - offset: 0
+              color: "#7c3aed"
+            - offset: 1
+              color: "#ec4899"
+        cornerRadius:
+          topLeft: 64
+          topRight: 8
+          bottomRight: 48
+          bottomLeft: 20
+      - id: normalized-rounded
+        type: rect
+        x: 920
+        "y": 100
+        width: 220
+        height: 180
+        fill: "#059669"
+        cornerRadius:
+          topLeft: 180
+          topRight: 180
+          bottomRight: 40
+          bottomLeft: 40

--- a/vt/specs/rect/update-rect.yaml
+++ b/vt/specs/rect/update-rect.yaml
@@ -20,7 +20,6 @@ states:
         width: 100
         height: 80
         fill: "#FFFFFF"
-        zIndex: 1
   - elements:
       - id: rect-1
         type: rect
@@ -29,4 +28,3 @@ states:
         width: 150
         height: 120
         fill: "#FFFFFF"
-        zIndex: 1

--- a/vt/specs/rectevent/drag-events.yaml
+++ b/vt/specs/rectevent/drag-events.yaml
@@ -66,7 +66,8 @@ states:
         width: 200
         height: 100
         fill: "#A6A6A6"
-        cursor: pointer
+        hover:
+          cursor: pointer
         drag:
           start:
             payload:

--- a/vt/specs/recttransition/rect-update-style.yaml
+++ b/vt/specs/recttransition/rect-update-style.yaml
@@ -1,0 +1,80 @@
+---
+title: Rect Style Update Animation
+description: Rect dimensions, fill, border, and independent corners animate together
+specs:
+  - dimensions should interpolate without using display-object scale
+  - solid fill and border colors should interpolate by RGBA channel
+  - each corner radius should interpolate independently
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - elements:
+      - id: style-panel
+        type: rect
+        x: 180
+        "y": 180
+        width: 260
+        height: 160
+        fill: "#ef4444"
+        border:
+          width: 4
+          color: "#ffffff"
+          alpha: 1
+        cornerRadius: 8
+  - elements:
+      - id: style-panel
+        type: rect
+        x: 180
+        "y": 180
+        width: 620
+        height: 340
+        fill: "#2563eb"
+        border:
+          width: 18
+          color: "#22c55e"
+          alpha: 0.5
+        cornerRadius:
+          topLeft: 72
+          topRight: 12
+          bottomRight: 96
+          bottomLeft: 36
+    animations:
+      - id: animate-style
+        targetId: style-panel
+        type: update
+        tween:
+          width:
+            auto: { duration: 1000, easing: linear }
+          height:
+            auto: { duration: 1000, easing: linear }
+          fill:
+            color:
+              auto: { duration: 1000, easing: linear }
+          border:
+            width:
+              auto: { duration: 1000, easing: linear }
+            color:
+              auto: { duration: 1000, easing: linear }
+            alpha:
+              auto: { duration: 1000, easing: linear }
+          cornerRadius:
+            topLeft:
+              auto: { duration: 1000, easing: linear }
+            topRight:
+              auto: { duration: 1000, easing: linear }
+            bottomRight:
+              auto: { duration: 1000, easing: linear }
+            bottomLeft:
+              auto: { duration: 1000, easing: linear }

--- a/vt/specs/video/add-rotation.yaml
+++ b/vt/specs/video/add-rotation.yaml
@@ -11,8 +11,10 @@ steps:
     detail:
       elementId: rotated-video
       time: 1
-  - action: wait
-    ms: 1500
+  - action: waitFor
+    selector: 'html[data-vt-video-frame-ready="rotated-video"]'
+    state: attached
+    timeoutMs: 10000
   - action: customEvent
     name: "primeVtScreenshot"
   - action: wait

--- a/vt/specs/video/video-update-rotation.yaml
+++ b/vt/specs/video/video-update-rotation.yaml
@@ -14,8 +14,10 @@ steps:
     detail:
       elementId: rotating-video
       time: 1
-  - action: wait
-    ms: 1500
+  - action: waitFor
+    selector: 'html[data-vt-video-frame-ready="rotating-video"]'
+    state: attached
+    timeoutMs: 10000
   - action: customEvent
     name: "primeVtScreenshot"
   - action: wait

--- a/vt/templates/default.html
+++ b/vt/templates/default.html
@@ -990,6 +990,7 @@
         });
 
         window.addEventListener("snapShotVideoFrame", (event) => {
+          delete document.documentElement.dataset.vtVideoFrameReady;
           const videoElement = app.findElementByLabel(event.detail?.elementId);
           const source = videoElement?.texture?.source;
           const video = source?.resource;
@@ -998,13 +999,33 @@
           }
 
           video.pause();
-          const commitVideoFrame = () => {
+          let hasCommittedVideoFrame = false;
+          const commitVideoFrame = async () => {
+            if (hasCommittedVideoFrame) {
+              return;
+            }
+
+            if (
+              video.readyState < HTMLMediaElement.HAVE_CURRENT_DATA ||
+              video.videoWidth <= 0 ||
+              video.videoHeight <= 0
+            ) {
+              requestAnimationFrame(commitVideoFrame);
+              return;
+            }
+
+            hasCommittedVideoFrame = true;
             video.pause();
             source.__routeGraphicsVideoTextureRuntime?.requestUpdate?.({
               force: true,
             });
             source.update?.();
-            void app.extractBase64();
+            try {
+              await app.extractBase64();
+            } finally {
+              document.documentElement.dataset.vtVideoFrameReady =
+                event.detail?.elementId ?? "ready";
+            }
           };
           const playUntilVideoFrame = () => {
             const requestedTime = Number(event.detail?.time ?? 0);
@@ -1018,9 +1039,10 @@
             const waitForPresentedVideoFrame = () => {
               if (typeof video.requestVideoFrameCallback === "function") {
                 video.requestVideoFrameCallback(commitVideoFrame);
-              } else {
-                requestAnimationFrame(commitVideoFrame);
               }
+              requestAnimationFrame(() => {
+                requestAnimationFrame(commitVideoFrame);
+              });
             };
             const seekableEnd =
               video.seekable.length > 0


### PR DESCRIPTION
## Summary

- complete the renderer-neutral rect contract with independent corner radii, strict nested validation, gradient sampling controls, blur preservation, and consistent interactions
- add rect style update tweens for dimensions, solid and gradient fills, borders, gradient stops and geometry, and uniform or per-corner radii through private internal animation channels
- batch animated redraws, validate incompatible style targets before playback, and preserve existing transform and shader-filter tween behavior
- update schemas and documentation, add visual fixtures and references, and bump the feature version to 1.35.0

## Testing

- `bun run test` — 99 files, 1,158 tests passed
- `bun run lint`
- `bun run build`
- `bunx oxlint src spec` — 0 errors
- parsed 551 documents across 292 YAML schema and fixture files
- `bun run vt:generate` — 259 pages generated
- `bun run vt:screenshot` — 224/224 specs captured successfully
- visually inspected independent-corner and rect-style animation frames