### PR TITLE
feat(animations): add keyframe delays

### DIFF
--- a/docs/animation-implementation-plan.md
+++ b/docs/animation-implementation-plan.md
@@ -1,6 +1,6 @@
 # Animation Implementation Plan
 
-Last updated: 2026-07-30
+Last updated: 2026-07-31
 
 ## Purpose
 
@@ -25,6 +25,7 @@ The runtime and schema currently support:
 - `playback.continuity: render | persistent`
 - positive playback speed
 - non-blocking loops for updates
+- non-negative per-segment delays for manual and automatic tweens
 - manual deterministic sampling
 
 The old `operation`, `properties`, `subjects`, `live`, and `replace` public

--- a/docs/animation-model.md
+++ b/docs/animation-model.md
@@ -1,6 +1,6 @@
 # Animation Model
 
-Last updated: 2026-07-30
+Last updated: 2026-07-31
 
 See also:
 
@@ -28,6 +28,7 @@ The runtime now exposes:
 - optional `playback.continuity: render | persistent` on `update` and `transition`
 - optional positive `playback.speed` on `update` and `transition`
 - optional infinite `playback.loop` on `update`
+- optional non-negative per-segment `delay`
 - independently targeted shader parameter timelines
 - inline single-pass and multi-pass transition compositors
 - composable mask plus compositor transitions
@@ -177,7 +178,8 @@ x:
     - duration: 450
       value: 180
       easing: "easeOutQuad"
-    - duration: 150
+    - delay: 300
+      duration: 150
       value: 220
       easing: "easeInQuad"
 ```
@@ -194,6 +196,14 @@ from the previous value. The first authored keyframe controls the segment from
 `initialValue` or the current live value to that keyframe. `auto.easing` follows
 the same rule for the single segment from the current live value to the next
 state value.
+
+Each keyframe may define a finite, non-negative `delay` in milliseconds. The
+runtime holds the previous value for that delay and then interpolates for the
+keyframe's `duration`. A first-keyframe delay holds `initialValue` or the
+current live value; a later delay creates a gap between segments. Total track
+duration is the sum of every `delay + duration`. Delays scale with
+`playback.speed` and repeat with the rest of a loop. Omitting `delay`, or
+setting it to `0`, starts the segment immediately.
 
 The same payload is reused in two places:
 
@@ -217,9 +227,12 @@ its current live value to the next state's value" case:
 ```yaml
 x:
   auto:
+    delay: 200
     duration: 450
     easing: "easeOutQuad"
 ```
+
+`auto.delay` holds the current live value before its generated segment starts.
 
 `keyframes` and `auto` are mutually exclusive on the same property.
 

--- a/docs/shader-interface.md
+++ b/docs/shader-interface.md
@@ -298,7 +298,8 @@ animations:
               - duration: 400
                 value: 1
                 easing: easeInOutSine
-              - duration: 400
+              - delay: 200
+                duration: 400
                 value: 0.2
                 easing: easeInOutSine
           tint:
@@ -312,6 +313,11 @@ Ordinary element properties and any number of filter ids may coexist in one
 `tween`. A missing `initialValue` is read from the current filter parameter.
 Scalar, vector, and matrix values interpolate component by component. Relative
 keyframes require matching shapes.
+
+Shader tracks use the same delay contract as ordinary tweens. An optional
+finite, non-negative `delay` holds the preceding scalar, vector, or matrix
+value before interpolation. It contributes to total duration and repeats in a
+loop.
 
 Only one active animation may write the same
 `targetId + filterId + parameter` channel in one state.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/pages/docs/guides/shaders.md
+++ b/playground/pages/docs/guides/shaders.md
@@ -252,7 +252,8 @@ animations:
               - duration: 500
                 value: 1
                 easing: easeInOutSine
-              - duration: 500
+              - delay: 250
+                duration: 500
                 value: 0.2
                 easing: easeInOutSine
           tint:
@@ -266,6 +267,10 @@ An update animation may combine ordinary properties and any number of filter
 ids in one `tween`. Arrays interpolate component by component. Missing initial
 values come from the filter's current parameters. Only one active animation
 may write a particular target/filter/parameter channel.
+
+Shader parameter keyframes accept the same optional `delay` as ordinary
+tweens. It must be a finite number greater than or equal to zero and holds the
+previous scalar, vector, or matrix value before that segment starts.
 
 Use `progress` to animate one filter's built-in `uProgress`:
 

--- a/playground/pages/docs/nodes/tween.md
+++ b/playground/pages/docs/nodes/tween.md
@@ -141,17 +141,18 @@ deterministic clock and cannot be tweened.
 
 Each update property accepts:
 
-| Field          | Type   | Required | Default                | Notes                                   |
-| -------------- | ------ | -------- | ---------------------- | --------------------------------------- |
-| `initialValue` | number | No       | current property value | Value sampled before the first segment. |
-| `keyframes`    | array  | Yes      | -                      | Ordered animation segments.             |
+| Field          | Type  | Required | Default                | Notes                                   |
+| -------------- | ----- | -------- | ---------------------- | --------------------------------------- |
+| `initialValue` | value | No       | current property value | Value sampled before the first segment. |
+| `keyframes`    | array | Yes      | -                      | Ordered animation segments.             |
 
 Each keyframe accepts:
 
 | Field      | Type    | Required | Default  | Notes                                              |
 | ---------- | ------- | -------- | -------- | -------------------------------------------------- |
-| `value`    | number  | Yes      | -        | Target value for this segment.                     |
-| `duration` | number  | Yes      | -        | Milliseconds used to reach this value.             |
+| `value`    | value   | Yes      | -        | Target value compatible with the animated channel. |
+| `delay`    | number  | No       | `0`      | Milliseconds to hold the previous value first.     |
+| `duration` | number  | Yes      | -        | Milliseconds used to reach this value after delay. |
 | `easing`   | string  | No       | `linear` | Easing used by the segment reaching this keyframe. |
 | `relative` | boolean | No       | `false`  | Treat `value` as a delta from the preceding value. |
 
@@ -174,6 +175,40 @@ animations:
             easing: linear
 ```
 
+### Delay And Holds
+
+Set `delay` on a keyframe to hold the preceding value before that keyframe's
+interpolation starts. A delay on the first keyframe holds `initialValue`, or
+the current live value when `initialValue` is omitted. A delay on a later
+keyframe creates an empty space between the two movements:
+
+```yaml
+tween:
+  x:
+    initialValue: 100
+    keyframes:
+      - delay: 300
+        duration: 400
+        value: 500
+        easing: easeOutQuad
+      - delay: 800
+        duration: 400
+        value: 900
+        easing: easeInQuad
+```
+
+This track holds `100` for 300 ms, moves to `500` over 400 ms, holds `500`
+for 800 ms, then moves to `900` over 400 ms. Its total duration is 1900 ms.
+
+`delay` is measured in milliseconds and must be a finite number greater than
+or equal to zero. It contributes to completion time, scales with
+`playback.speed`, and repeats as part of a loop. `delay: 0` is equivalent to
+omitting it. `duration` describes only the interpolation after the hold.
+
+The same delay behavior applies to ordinary properties, rect style and
+geometry tracks, shader filter parameters, transition `prev`/`next` surfaces,
+mask progress, and compositor progress or parameters.
+
 ## Automatic End Value
 
 Update properties also support `auto`, which generates one segment from the
@@ -187,6 +222,7 @@ animations:
     tween:
       x:
         auto:
+          delay: 200
           duration: 450
           easing: easeOutQuad
       y:
@@ -197,11 +233,13 @@ animations:
 
 | Field      | Type   | Required | Default  |
 | ---------- | ------ | -------- | -------- |
+| `delay`    | number | No       | `0`      |
 | `duration` | number | Yes      | -        |
 | `easing`   | string | No       | `linear` |
 
 `auto` and `keyframes` are mutually exclusive for one property. `auto` is not
-supported on `prev.tween` or `next.tween`.
+supported on `prev.tween` or `next.tween`. `auto.delay` holds the current live
+value before moving toward the next render state's value.
 
 ## Easing
 

--- a/spec/animations/animationBus.spec.js
+++ b/spec/animations/animationBus.spec.js
@@ -3,6 +3,138 @@ import { createAnimationBus } from "../../src/plugins/animations/animationBus.js
 import { applyElementTransform } from "../../src/plugins/elements/util/transform.js";
 
 describe("animationBus auto tween shorthand", () => {
+  it("holds auto tween values for the configured delay before interpolation", () => {
+    const animationBus = createAnimationBus();
+    const onComplete = vi.fn();
+    const element = {
+      x: 20,
+      scale: { x: 1, y: 1 },
+    };
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "delayed-auto-x",
+        element,
+        properties: {
+          x: {
+            auto: {
+              delay: 200,
+              duration: 400,
+              easing: "linear",
+            },
+          },
+        },
+        targetState: { x: 120 },
+        onComplete,
+      },
+    });
+
+    animationBus.flush();
+    expect(animationBus.getState().animations[0].duration).toBe(600);
+
+    animationBus.tick(200);
+    expect(element.x).toBe(20);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    animationBus.tick(200);
+    expect(element.x).toBeCloseTo(70);
+
+    animationBus.tick(200);
+    expect(element.x).toBeCloseTo(120);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies playback speed to both auto delay and interpolation", () => {
+    const animationBus = createAnimationBus();
+    const onComplete = vi.fn();
+    const element = {
+      x: 20,
+      scale: { x: 1, y: 1 },
+    };
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "fast-delayed-auto-x",
+        playbackSpeed: 2,
+        element,
+        properties: {
+          x: {
+            auto: {
+              delay: 200,
+              duration: 400,
+              easing: "linear",
+            },
+          },
+        },
+        targetState: { x: 120 },
+        onComplete,
+      },
+    });
+
+    animationBus.flush();
+    animationBus.tick(99);
+    expect(element.x).toBe(20);
+
+    animationBus.tick(101);
+    expect(element.x).toBeCloseTo(70);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    animationBus.tick(100);
+    expect(element.x).toBe(120);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds a manual timeline between two keyframe segments", () => {
+    const animationBus = createAnimationBus();
+    const onComplete = vi.fn();
+    const element = {
+      x: 0,
+      scale: { x: 1, y: 1 },
+    };
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "delayed-manual-x",
+        element,
+        properties: {
+          x: {
+            initialValue: 0,
+            keyframes: [
+              { duration: 100, value: 100, easing: "linear" },
+              {
+                delay: 200,
+                duration: 100,
+                value: 200,
+                easing: "linear",
+              },
+            ],
+          },
+        },
+        onComplete,
+      },
+    });
+
+    animationBus.flush();
+    expect(animationBus.getState().animations[0].duration).toBe(400);
+
+    animationBus.tick(100);
+    expect(element.x).toBe(100);
+
+    animationBus.tick(199);
+    expect(element.x).toBe(100);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    animationBus.tick(51);
+    expect(element.x).toBeCloseTo(150);
+
+    animationBus.tick(50);
+    expect(element.x).toBe(200);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
   it("animates to the targetState value for auto tween properties", () => {
     const animationBus = createAnimationBus();
     const onComplete = vi.fn();
@@ -372,6 +504,45 @@ describe("animationBus auto tween shorthand", () => {
     expect(onComplete).not.toHaveBeenCalled();
   });
 
+  it("repeats delayed holds on every loop", () => {
+    const animationBus = createAnimationBus();
+    const element = {
+      x: 0,
+      scale: { x: 1, y: 1 },
+    };
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "looping-delayed-x",
+        loop: true,
+        element,
+        properties: {
+          x: {
+            initialValue: 0,
+            keyframes: [
+              { delay: 100, duration: 100, value: 100, easing: "linear" },
+            ],
+          },
+        },
+      },
+    });
+
+    animationBus.setTime(50);
+    expect(element.x).toBe(0);
+
+    animationBus.setTime(150);
+    expect(element.x).toBeCloseTo(50);
+
+    animationBus.setTime(250);
+    expect(element.x).toBe(0);
+    expect(animationBus.getState().animations[0]).toMatchObject({
+      duration: 200,
+      currentTime: 50,
+      progress: 0.25,
+    });
+  });
+
   it("rejects looping animations without a positive finite duration", () => {
     const animationBus = createAnimationBus();
 
@@ -464,6 +635,43 @@ describe("animationBus auto tween shorthand", () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(onComplete).not.toHaveBeenCalled();
     expect(onBusComplete).not.toHaveBeenCalled();
+  });
+
+  it("settles the target state when cancelled during a delay", () => {
+    const animationBus = createAnimationBus();
+    const onCancel = vi.fn();
+    const element = {
+      x: 10,
+      alpha: 0.25,
+      scale: { x: 1, y: 1 },
+    };
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "cancelled-delayed-update",
+        element,
+        properties: {
+          x: {
+            keyframes: [
+              { delay: 500, duration: 500, value: 110, easing: "linear" },
+            ],
+          },
+        },
+        targetState: { x: 110, alpha: 0.8 },
+        onCancel,
+      },
+    });
+
+    animationBus.flush();
+    animationBus.tick(250);
+    expect(element.x).toBe(10);
+
+    animationBus.dispatch({ type: "CANCEL", id: "cancelled-delayed-update" });
+    animationBus.flush();
+
+    expect(element).toMatchObject({ x: 110, alpha: 0.8 });
+    expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
   it("applies property path mapping for auto scale tweens", () => {
@@ -915,6 +1123,45 @@ describe("animationBus auto tween shorthand", () => {
     expect(element.x).toBeCloseTo(50);
     expect(onCancel).not.toHaveBeenCalled();
     expect(animationBus.isAnimating("persistent-update")).toBe(true);
+  });
+
+  it("preserves progress while a persistent animation is inside its delay", () => {
+    const animationBus = createAnimationBus();
+    const element = {
+      x: 10,
+      scale: { x: 1, y: 1 },
+    };
+
+    animationBus.dispatch({
+      type: "START",
+      payload: {
+        id: "persistent-delayed-update",
+        animationType: "update",
+        targetId: "bg",
+        continuity: "persistent",
+        signature: '{"type":"update","delay":500}',
+        element,
+        properties: {
+          x: {
+            keyframes: [
+              { delay: 500, duration: 500, value: 110, easing: "linear" },
+            ],
+          },
+        },
+      },
+    });
+
+    animationBus.flush();
+    animationBus.tick(300);
+    animationBus.cancelAllExcept(new Set(["persistent-delayed-update"]));
+    animationBus.tick(250);
+
+    expect(element.x).toBeCloseTo(20);
+    expect(animationBus.getState().animations[0]).toMatchObject({
+      currentTime: 550,
+      duration: 1000,
+      progress: 0.55,
+    });
   });
 
   it("exposes pending persistent contexts for continuity planning and cancels unkept ones", () => {

--- a/spec/animations/runReplaceAnimation.spec.js
+++ b/spec/animations/runReplaceAnimation.spec.js
@@ -349,7 +349,9 @@ describe("runReplaceAnimation", () => {
           tween: {
             alpha: {
               initialValue: 0,
-              keyframes: [{ duration: 300, value: 1, easing: "linear" }],
+              keyframes: [
+                { delay: 100, duration: 300, value: 1, easing: "linear" },
+              ],
             },
           },
         },
@@ -377,6 +379,16 @@ describe("runReplaceAnimation", () => {
 
     const dispatched = animationBus.dispatch.mock.calls[0][0];
     expect(dispatched.payload.deferCompletionUntilNextFrame).toBe(false);
+    expect(dispatched.payload.duration).toBe(400);
+
+    const overlay = parent.children.find(
+      (child) => child !== nextDisplayObject,
+    );
+    dispatched.payload.applyFrame(99);
+    expect(overlay.children[0].alpha).toBe(0);
+    dispatched.payload.applyFrame(250);
+    expect(overlay.children[0].alpha).toBeCloseTo(0.5);
+
     dispatched.payload.onComplete();
 
     expect(parent.children).toEqual([nextDisplayObject]);
@@ -853,12 +865,15 @@ describe("runReplaceAnimation", () => {
       tween: {
         ...passthroughCompositor.tween,
         amount: {
-          keyframes: [{ duration: 600, value: 0.8, easing: "linear" }],
+          keyframes: [
+            { delay: 100, duration: 500, value: 0.8, easing: "linear" },
+          ],
         },
         tint: {
           keyframes: [
             {
-              duration: 300,
+              delay: 100,
+              duration: 200,
               value: [0.8, 0.6, 0.4],
               easing: "linear",
             },
@@ -908,7 +923,7 @@ describe("runReplaceAnimation", () => {
     );
 
     const dispatched = animationBus.dispatch.mock.calls[0][0];
-    dispatched.payload.applyFrame(150);
+    dispatched.payload.applyFrame(50);
 
     expect(snapshotCalls).toEqual([
       { x: 0, y: 0, scaleX: 1, scaleY: 1, alpha: 1 },
@@ -953,14 +968,14 @@ describe("runReplaceAnimation", () => {
       width: compositorSprite.texture.width,
       height: compositorSprite.texture.height,
     });
-    expect(shaderUniforms.uniforms.uProgress).toBeCloseTo(0.5);
+    expect(shaderUniforms.uniforms.uProgress).toBeCloseTo(1 / 6);
     expect(shaderUniforms.uniforms.uTime).toBeCloseTo(7.5);
-    expect(shaderUniforms.uniforms.uAmount).toBeCloseTo(0.35);
+    expect(shaderUniforms.uniforms.uAmount).toBeCloseTo(0.2);
     expect(Array.from(shaderUniforms.uniforms.uTint)).toEqual(
       expect.arrayContaining([
-        expect.closeTo(0.5),
-        expect.closeTo(0.5),
-        expect.closeTo(0.5),
+        expect.closeTo(0.2),
+        expect.closeTo(0.4),
+        expect.closeTo(0.6),
       ]),
     );
     expect(filterManager.calculateSpriteMatrix).toHaveBeenCalledWith(
@@ -975,6 +990,18 @@ describe("runReplaceAnimation", () => {
       Texture.EMPTY,
       Texture.EMPTY,
       true,
+    );
+
+    dispatched.payload.applyFrame(150);
+    compositorFilter.apply(filterManager, Texture.EMPTY, Texture.EMPTY, true);
+    expect(shaderUniforms.uniforms.uProgress).toBeCloseTo(0.5);
+    expect(shaderUniforms.uniforms.uAmount).toBeCloseTo(0.26);
+    expect(Array.from(shaderUniforms.uniforms.uTint)).toEqual(
+      expect.arrayContaining([
+        expect.closeTo(0.35),
+        expect.closeTo(0.45),
+        expect.closeTo(0.55),
+      ]),
     );
 
     shaderClock = 9.25;
@@ -2415,7 +2442,9 @@ describe("runReplaceAnimation", () => {
           channel: "red",
           progress: {
             initialValue: 0,
-            keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+            keyframes: [
+              { delay: 200, duration: 800, value: 1, easing: "linear" },
+            ],
           },
         },
       },
@@ -2436,7 +2465,8 @@ describe("runReplaceAnimation", () => {
     const dispatched = animationBus.dispatch.mock.calls[0][0];
 
     expect(app.renderer.extract.pixels).not.toHaveBeenCalled();
-    dispatched.payload.applyFrame(500);
+    expect(dispatched.payload.duration).toBe(1000);
+    dispatched.payload.applyFrame(199);
 
     expect(app.renderer.extract.pixels).not.toHaveBeenCalled();
     const overlay = parent.children.find(
@@ -2447,6 +2477,12 @@ describe("runReplaceAnimation", () => {
     expect(
       maskFilter.resources.replaceMaskUniforms.uniforms.uMaskDirectReveal,
     ).toBe(0);
+    expect(maskFilter.resources.replaceMaskUniforms.uniforms.uProgress).toBe(0);
+
+    dispatched.payload.applyFrame(600);
+    expect(
+      maskFilter.resources.replaceMaskUniforms.uniforms.uProgress,
+    ).toBeCloseTo(0.5);
   });
 
   it("routes single alpha masks through the alpha preprocessing filter", () => {

--- a/spec/elements/rectStyleAnimation.spec.js
+++ b/spec/elements/rectStyleAnimation.spec.js
@@ -49,6 +49,56 @@ const mountRect = (parent, element, animationBus, animations = []) => {
 };
 
 describe("rect style animation", () => {
+  it("holds rect style values during delayed auto and color segments", () => {
+    const parent = new Container();
+    const animationBus = createAnimationBus();
+    const prevElement = createRect({ width: 200, fill: "#ff0000" });
+    const nextElement = createRect({ width: 300, fill: "#0000ff" });
+    const rect = mountRect(parent, prevElement, animationBus);
+    const animations = normalizeAnimations([
+      {
+        id: "delayed-style",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          width: { auto: { delay: 300, duration: 700 } },
+          fill: {
+            color: {
+              initialValue: "#ff0000",
+              keyframes: [{ delay: 300, duration: 700, value: "#0000ff" }],
+            },
+          },
+        },
+      },
+    ]);
+
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations,
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+    animationBus.flush();
+    animationBus.tick(299);
+
+    expect(getRectStyleAnimationValue(rect, "rect.width")).toBe(200);
+    expect(getRectStyleAnimationValue(rect, "rect.fill.color")).toEqual([
+      1, 0, 0, 1,
+    ]);
+
+    animationBus.tick(351);
+
+    expect(getRectStyleAnimationValue(rect, "rect.width")).toBe(250);
+    expect(getRectStyleAnimationValue(rect, "rect.fill.color")).toEqual([
+      0.5, 0, 0.5, 1,
+    ]);
+  });
+
   it("animates dimensions, solid colors, border, and independent corners", () => {
     const parent = new Container();
     const animationBus = createAnimationBus();

--- a/spec/parser/normalizeRenderState.test.yaml
+++ b/spec/parser/normalizeRenderState.test.yaml
@@ -56,6 +56,81 @@ out:
       src: sfx-1
   audioEffects: []
 ---
+case: Normalize keyframe and auto tween delays
+in:
+  - id: state-delayed-animation
+    elements:
+      - id: panel
+        type: rect
+    animations:
+      - id: delayed-panel
+        targetId: panel
+        type: update
+        tween:
+          x:
+            initialValue: 0
+            keyframes:
+              - delay: 250
+                duration: 300
+                value: 100
+          alpha:
+            auto:
+              delay: 400
+              duration: 500
+out:
+  id: state-delayed-animation
+  elements:
+    - id: panel
+      type: rect
+  animations:
+    - id: delayed-panel
+      targetId: panel
+      type: update
+      tween:
+        x:
+          initialValue: 0
+          keyframes:
+            - delay: 250
+              duration: 300
+              value: 100
+              easing: linear
+        alpha:
+          auto:
+            delay: 400
+            duration: 500
+            easing: linear
+  audio: []
+  audioEffects: []
+---
+case: Throw when a keyframe delay is negative
+in:
+  - id: state-invalid-keyframe-delay
+    animations:
+      - id: invalid-delay
+        targetId: panel
+        type: update
+        tween:
+          x:
+            keyframes:
+              - delay: -1
+                duration: 100
+                value: 20
+throws: animations[0].tween.x.keyframes[0].delay must be a finite number greater than or equal to 0.
+---
+case: Throw when an auto tween delay is negative
+in:
+  - id: state-invalid-auto-delay
+    animations:
+      - id: invalid-auto-delay
+        targetId: panel
+        type: update
+        tween:
+          x:
+            auto:
+              delay: -1
+              duration: 100
+throws: animations[0].tween.x.auto.delay must be a finite number greater than or equal to 0.
+---
 case: Normalize transition animation with mask defaults
 in:
   - id: state-2-replace

--- a/spec/util/animationTimeline.spec.js
+++ b/spec/util/animationTimeline.spec.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   SUPPORTED_EASING_NAMES,
   buildTimeline,
+  calculateMaxDuration,
   getEasingFunction,
   getValueAtTime,
 } from "../../src/util/animationTimeline.js";
@@ -55,5 +56,78 @@ describe("animationTimeline easings", () => {
 
     expect(getValueAtTime(timeline, 500)).toBeCloseTo(25);
     expect(getValueAtTime(timeline, 1500)).toBeCloseTo(175);
+  });
+
+  it("holds the previous value during first and subsequent keyframe delays", () => {
+    const timeline = buildTimeline([
+      { value: 0 },
+      {
+        delay: 200,
+        duration: 400,
+        value: 100,
+        easing: "linear",
+      },
+      {
+        delay: 300,
+        duration: 100,
+        value: 200,
+        easing: "linear",
+      },
+    ]);
+
+    expect(timeline).toEqual([
+      { time: 0, value: 0, easing: "linear" },
+      { time: 200, value: 0, easing: "linear" },
+      { time: 600, value: 100, easing: "linear" },
+      { time: 900, value: 100, easing: "linear" },
+      { time: 1000, value: 200, easing: "linear" },
+    ]);
+    expect(getValueAtTime(timeline, 100)).toBe(0);
+    expect(getValueAtTime(timeline, 400)).toBeCloseTo(50);
+    expect(getValueAtTime(timeline, 750)).toBe(100);
+    expect(getValueAtTime(timeline, 950)).toBeCloseTo(150);
+    expect(calculateMaxDuration([{ timeline }])).toBe(1000);
+  });
+
+  it("does not add a hold point for an omitted or zero delay", () => {
+    const timeline = buildTimeline([
+      { value: 0 },
+      { delay: 0, duration: 100, value: 1 },
+      { duration: 100, value: 2 },
+    ]);
+
+    expect(timeline.map(({ time, value }) => ({ time, value }))).toEqual([
+      { time: 0, value: 0 },
+      { time: 100, value: 1 },
+      { time: 200, value: 2 },
+    ]);
+  });
+
+  it("starts easing only after the delay boundary", () => {
+    const timeline = buildTimeline([
+      { value: 10 },
+      {
+        delay: 200,
+        duration: 400,
+        value: 110,
+        easing: "easeInQuad",
+      },
+    ]);
+
+    expect(getValueAtTime(timeline, 199.999)).toBe(10);
+    expect(getValueAtTime(timeline, 200)).toBe(10);
+    expect(getValueAtTime(timeline, 300)).toBeCloseTo(16.25);
+    expect(getValueAtTime(timeline, 600)).toBe(110);
+  });
+
+  it("supports a pure delayed step with zero interpolation duration", () => {
+    const timeline = buildTimeline([
+      { value: 0 },
+      { delay: 250, duration: 0, value: 1 },
+    ]);
+
+    expect(calculateMaxDuration([{ timeline }])).toBe(250);
+    expect(getValueAtTime(timeline, 249.999)).toBe(0);
+    expect(getValueAtTime(timeline, 250)).toBe(1);
   });
 });

--- a/spec/util/animationTimeline.spec.js
+++ b/spec/util/animationTimeline.spec.js
@@ -120,14 +120,40 @@ describe("animationTimeline easings", () => {
     expect(getValueAtTime(timeline, 600)).toBe(110);
   });
 
-  it("supports a pure delayed step with zero interpolation duration", () => {
+  it("resolves a delayed zero-duration step at its boundary", () => {
     const timeline = buildTimeline([
       { value: 0 },
       { delay: 250, duration: 0, value: 1 },
+      { duration: 250, value: 2, easing: "linear" },
     ]);
 
-    expect(calculateMaxDuration([{ timeline }])).toBe(250);
+    expect(calculateMaxDuration([{ timeline }])).toBe(500);
     expect(getValueAtTime(timeline, 249.999)).toBe(0);
     expect(getValueAtTime(timeline, 250)).toBe(1);
+    expect(getValueAtTime(timeline, 375)).toBeCloseTo(1.5);
+  });
+
+  it("resolves consecutive zero-duration steps to the last value at a timestamp", () => {
+    const timeline = buildTimeline([
+      { value: 0 },
+      { delay: 250, duration: 0, value: 1 },
+      { duration: 0, value: 2 },
+      { duration: 250, value: 3, easing: "linear" },
+    ]);
+
+    expect(getValueAtTime(timeline, 249.999)).toBe(0);
+    expect(getValueAtTime(timeline, 250)).toBe(2);
+    expect(getValueAtTime(timeline, 375)).toBeCloseTo(2.5);
+  });
+
+  it("resolves zero-duration steps at the initial timestamp", () => {
+    const timeline = buildTimeline([
+      { value: 0 },
+      { duration: 0, value: 1 },
+      { duration: 100, value: 2, easing: "linear" },
+    ]);
+
+    expect(getValueAtTime(timeline, 0)).toBe(1);
+    expect(getValueAtTime(timeline, 50)).toBeCloseTo(1.5);
   });
 });

--- a/src/plugins/animations/animationBus.js
+++ b/src/plugins/animations/animationBus.js
@@ -97,6 +97,7 @@ const buildPropertyTimelines = (
         const timeline = buildTimeline([
           { value: currentValue },
           {
+            delay: config.auto.delay,
             duration: config.auto.duration,
             value: targetValue,
             easing: config.auto.easing,

--- a/src/plugins/animations/planAnimations.test.js
+++ b/src/plugins/animations/planAnimations.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { normalizeAnimations } from "../../util/normalizeAnimations.js";
 import { getAnimationContinuitySignature } from "./planAnimations.js";
 
 describe("getAnimationContinuitySignature", () => {
@@ -98,6 +99,90 @@ describe("getAnimationContinuitySignature", () => {
           loop: true,
         },
       }),
+    );
+  });
+
+  it("includes keyframe and auto delays in persistent signatures", () => {
+    const manual = {
+      id: "delayed-move",
+      targetId: "portrait",
+      type: "update",
+      playback: {
+        continuity: "persistent",
+      },
+      tween: {
+        x: {
+          keyframes: [
+            { delay: 100, duration: 1000, value: 400, easing: "linear" },
+          ],
+        },
+      },
+    };
+    const automatic = {
+      ...manual,
+      tween: {
+        x: {
+          auto: { delay: 100, duration: 1000, easing: "linear" },
+        },
+      },
+    };
+
+    expect(getAnimationContinuitySignature(manual)).not.toBe(
+      getAnimationContinuitySignature({
+        ...manual,
+        tween: {
+          x: {
+            keyframes: [
+              { delay: 200, duration: 1000, value: 400, easing: "linear" },
+            ],
+          },
+        },
+      }),
+    );
+    expect(getAnimationContinuitySignature(automatic)).not.toBe(
+      getAnimationContinuitySignature({
+        ...automatic,
+        tween: {
+          x: {
+            auto: { delay: 200, duration: 1000, easing: "linear" },
+          },
+        },
+      }),
+    );
+  });
+
+  it("treats an explicit zero delay like an omitted delay", () => {
+    const [withZero] = normalizeAnimations([
+      {
+        id: "zero-delay",
+        targetId: "portrait",
+        type: "update",
+        playback: { continuity: "persistent" },
+        tween: {
+          x: {
+            keyframes: [
+              { delay: 0, duration: 1000, value: 400, easing: "linear" },
+            ],
+          },
+        },
+      },
+    ]);
+    const [withoutDelay] = normalizeAnimations([
+      {
+        id: "zero-delay",
+        targetId: "portrait",
+        type: "update",
+        playback: { continuity: "persistent" },
+        tween: {
+          x: {
+            keyframes: [{ duration: 1000, value: 400, easing: "linear" }],
+          },
+        },
+      },
+    ]);
+
+    expect(getAnimationContinuitySignature(withZero)).toBe(
+      getAnimationContinuitySignature(withoutDelay),
     );
   });
 });

--- a/src/plugins/elements/util/shaderFilterEffect.test.js
+++ b/src/plugins/elements/util/shaderFilterEffect.test.js
@@ -818,6 +818,83 @@ describe("shader filter resources", () => {
     displayObject.destroy();
   });
 
+  it("holds element and filter parameters during delayed segments", () => {
+    const displayObject = {
+      label: "shader-target",
+      width: 32,
+      height: 32,
+      alpha: 0.2,
+      scale: { x: 1, y: 1 },
+      destroy() {},
+    };
+    const filters = normalizeElementShaderFilters([
+      {
+        id: "grade",
+        type: "shader",
+        parameters: { amount: 0.2 },
+        source: shaderSource,
+      },
+    ]);
+    syncShaderFilters(displayObject, filters, { width: 32, height: 32 });
+
+    const completionTracker = {
+      getVersion: () => 7,
+      track: vi.fn(),
+      complete: vi.fn(),
+    };
+    const animationBus = createAnimationBus();
+    dispatchUpdateAnimationsNow({
+      animations: [
+        {
+          id: "delayed-filter",
+          targetId: "shader-target",
+          type: "update",
+          tween: {
+            alpha: {
+              keyframes: [
+                { delay: 100, duration: 100, value: 1, easing: "linear" },
+              ],
+            },
+          },
+          filterTweens: {
+            grade: {
+              amount: {
+                keyframes: [
+                  { delay: 100, duration: 100, value: 1, easing: "linear" },
+                ],
+              },
+            },
+          },
+        },
+      ],
+      animationBus,
+      completionTracker,
+      element: displayObject,
+      targetState: { alpha: 1 },
+    });
+
+    animationBus.flush();
+    animationBus.tick(99);
+
+    expect(displayObject.alpha).toBeCloseTo(0.2);
+    expect(
+      displayObject.filters[0].resources.shaderUniforms.uniforms.uAmount,
+    ).toBeCloseTo(0.2);
+    expect(completionTracker.complete).not.toHaveBeenCalled();
+
+    animationBus.tick(51);
+
+    expect(displayObject.alpha).toBeCloseTo(0.6);
+    expect(
+      displayObject.filters[0].resources.shaderUniforms.uniforms.uAmount,
+    ).toBeCloseTo(0.6);
+
+    animationBus.tick(50);
+    expect(completionTracker.complete).toHaveBeenCalledWith(7);
+
+    displayObject.destroy();
+  });
+
   it("animates progress only on the explicitly targeted filter", () => {
     const displayObject = {
       label: "shader-target",

--- a/src/schemas/animations/animation.yaml
+++ b/src/schemas/animations/animation.yaml
@@ -19,6 +19,11 @@ $defs:
       duration:
         type: number
         description: Duration to reach this value in milliseconds.
+      delay:
+        type: number
+        minimum: 0
+        default: 0
+        description: Time in milliseconds to hold the previous value before starting this keyframe segment.
       easing:
         type: string
         description: Easing function to use.
@@ -74,6 +79,11 @@ $defs:
         description: Target color value.
       duration:
         type: number
+      delay:
+        type: number
+        minimum: 0
+        default: 0
+        description: Time in milliseconds to hold the previous color before starting this keyframe segment.
       easing:
         type: string
         enum:
@@ -146,6 +156,11 @@ $defs:
       duration:
         type: number
         description: Duration in milliseconds for the generated tween.
+      delay:
+        type: number
+        minimum: 0
+        default: 0
+        description: Time in milliseconds to hold the current value before starting the generated tween.
       easing:
         type: string
         description: Easing function to use.

--- a/src/schemas/shader-config.yaml
+++ b/src/schemas/shader-config.yaml
@@ -141,6 +141,11 @@ definitions:
           - $ref: "#/definitions/numericArray"
       duration:
         type: number
+      delay:
+        type: number
+        minimum: 0
+        default: 0
+        description: Time in milliseconds to hold the previous value before starting this keyframe segment.
       easing:
         $ref: "#/definitions/easing"
       relative:

--- a/src/util/animationTimeline.js
+++ b/src/util/animationTimeline.js
@@ -166,7 +166,7 @@ export const buildTimeline = (keyframesInput) => {
   let latestValue;
 
   keyframesInput.forEach(
-    ({ value, duration, easing = "linear", relative }, index) => {
+    ({ value, delay = 0, duration, easing = "linear", relative }, index) => {
       if (index === 0) {
         latestValue = value;
         timeline.push({ time: accumulatedTime, value, easing: "linear" });
@@ -175,6 +175,15 @@ export const buildTimeline = (keyframesInput) => {
 
       if (duration === undefined) {
         return;
+      }
+
+      if (delay > 0) {
+        accumulatedTime += delay;
+        timeline.push({
+          time: accumulatedTime,
+          value: latestValue,
+          easing: "linear",
+        });
       }
 
       accumulatedTime += duration;

--- a/src/util/animationTimeline.js
+++ b/src/util/animationTimeline.js
@@ -210,7 +210,7 @@ export const calculateMaxDuration = (timelines) => {
 
 export const getValueAtTime = (timeline, currentTime) => {
   if (timeline.length === 0) return 0;
-  if (currentTime <= timeline[0].time) return timeline[0].value;
+  if (currentTime < timeline[0].time) return timeline[0].value;
   if (currentTime >= timeline[timeline.length - 1].time) {
     return timeline[timeline.length - 1].value;
   }
@@ -219,7 +219,7 @@ export const getValueAtTime = (timeline, currentTime) => {
     const { time: startTime, value: startValue } = timeline[i];
     const { time: endTime, value: endValue, easing } = timeline[i + 1];
 
-    if (currentTime >= startTime && currentTime <= endTime) {
+    if (currentTime >= startTime && currentTime < endTime) {
       const t = (currentTime - startTime) / (endTime - startTime);
       return interpolateTweenValues(
         startValue,

--- a/src/util/animationTimeline.test.js
+++ b/src/util/animationTimeline.test.js
@@ -24,4 +24,21 @@ describe("animationTimeline numeric arrays", () => {
 
     expect(getValueAtTime(timeline, 100)).toEqual([3, 1]);
   });
+
+  it("holds vector values before applying a delayed relative keyframe", () => {
+    const timeline = buildTimeline([
+      { value: [1, 2] },
+      {
+        value: [2, -1],
+        delay: 50,
+        duration: 100,
+        easing: "linear",
+        relative: true,
+      },
+    ]);
+
+    expect(getValueAtTime(timeline, 25)).toEqual([1, 2]);
+    expect(getValueAtTime(timeline, 100)).toEqual([2, 1.5]);
+    expect(getValueAtTime(timeline, 150)).toEqual([3, 1]);
+  });
 });

--- a/src/util/normalizeAnimations.js
+++ b/src/util/normalizeAnimations.js
@@ -98,6 +98,14 @@ const assertPositiveFiniteNumber = (value, path) => {
   }
 };
 
+const assertNonNegativeFiniteNumber = (value, path) => {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(
+      `${path} must be a finite number greater than or equal to 0.`,
+    );
+  }
+};
+
 const normalizePlayback = (playback, path) => {
   assertPlainObject(playback, path);
 
@@ -132,6 +140,10 @@ const normalizeAutoTween = (autoConfig, path) => {
   assertPlainObject(autoConfig, path);
   assertNumber(autoConfig.duration, `${path}.duration`);
 
+  if (autoConfig.delay !== undefined) {
+    assertNonNegativeFiniteNumber(autoConfig.delay, `${path}.delay`);
+  }
+
   if (
     autoConfig.easing !== undefined &&
     typeof autoConfig.easing !== "string"
@@ -151,6 +163,7 @@ const normalizeAutoTween = (autoConfig, path) => {
   return {
     duration: autoConfig.duration,
     easing: autoConfig.easing ?? "linear",
+    ...(autoConfig.delay > 0 ? { delay: autoConfig.delay } : {}),
   };
 };
 
@@ -182,6 +195,10 @@ const normalizeKeyframes = (
     assertValue(keyframe.value, `${keyframePath}.value`);
     assertNumber(keyframe.duration, `${keyframePath}.duration`);
 
+    if (keyframe.delay !== undefined) {
+      assertNonNegativeFiniteNumber(keyframe.delay, `${keyframePath}.delay`);
+    }
+
     if (keyframe.easing !== undefined && typeof keyframe.easing !== "string") {
       throw new Error(`${keyframePath}.easing must be a string.`);
     }
@@ -206,6 +223,7 @@ const normalizeKeyframes = (
       value: normalizeValue(keyframe.value),
       duration: keyframe.duration,
       easing: keyframe.easing ?? "linear",
+      ...(keyframe.delay > 0 ? { delay: keyframe.delay } : {}),
       ...(keyframe.relative !== undefined
         ? { relative: keyframe.relative }
         : {}),

--- a/src/util/normalizeAnimations.test.js
+++ b/src/util/normalizeAnimations.test.js
@@ -45,6 +45,179 @@ const createCompositor = (overrides = {}) => ({
 });
 
 describe("normalizeAnimations shader support", () => {
+  it("normalizes delays for manual, auto, filter, mask, and compositor tracks", () => {
+    const [updateAnimation, transitionAnimation] = normalizeAnimations([
+      {
+        id: "delayed-update",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          x: {
+            initialValue: 0,
+            keyframes: [{ delay: 100, duration: 200, value: 50 }],
+          },
+          alpha: {
+            auto: { delay: 150, duration: 250 },
+          },
+          y: {
+            auto: { delay: 0, duration: 250 },
+          },
+          filters: {
+            grade: {
+              tint: {
+                keyframes: [
+                  { delay: 300, duration: 400, value: [0.2, 0.4, 0.6] },
+                ],
+              },
+            },
+          },
+        },
+      },
+      {
+        id: "delayed-transition",
+        targetId: "scene",
+        type: "transition",
+        mask: {
+          kind: "single",
+          texture: "wipe",
+          progress: {
+            keyframes: [{ delay: 500, duration: 600, value: 1 }],
+          },
+        },
+        compositor: createCompositor({
+          parameters: { edgeWidth: 0.04 },
+          tween: {
+            progress: {
+              keyframes: [{ delay: 700, duration: 800, value: 1 }],
+            },
+            edgeWidth: {
+              keyframes: [{ delay: 900, duration: 1000, value: 0.12 }],
+            },
+          },
+        }),
+      },
+    ]);
+
+    expect(updateAnimation.tween.x.keyframes[0]).toMatchObject({
+      delay: 100,
+      duration: 200,
+      value: 50,
+    });
+    expect(updateAnimation.tween.alpha.auto).toEqual({
+      delay: 150,
+      duration: 250,
+      easing: "linear",
+    });
+    expect(updateAnimation.tween.y.auto).toEqual({
+      duration: 250,
+      easing: "linear",
+    });
+    expect(updateAnimation.filterTweens.grade.tint.keyframes[0]).toMatchObject({
+      delay: 300,
+      duration: 400,
+      value: [0.2, 0.4, 0.6],
+    });
+    expect(transitionAnimation.mask.progress.keyframes[0].delay).toBe(500);
+    expect(
+      transitionAnimation.compositor.tween.uProgress.keyframes[0].delay,
+    ).toBe(700);
+    expect(
+      transitionAnimation.compositor.tween.edgeWidth.keyframes[0].delay,
+    ).toBe(900);
+  });
+
+  it.each([
+    ["manual", { keyframes: [{ delay: -1, duration: 100, value: 1 }] }],
+    ["auto", { auto: { delay: -1, duration: 100 } }],
+    [
+      "fractional negative",
+      { keyframes: [{ delay: -0.001, duration: 100, value: 1 }] },
+    ],
+    [
+      "non-finite manual",
+      {
+        keyframes: [
+          { delay: Number.POSITIVE_INFINITY, duration: 100, value: 1 },
+        ],
+      },
+    ],
+    ["non-finite auto", { auto: { delay: Number.NaN, duration: 100 } }],
+    [
+      "negative infinite auto",
+      { auto: { delay: Number.NEGATIVE_INFINITY, duration: 100 } },
+    ],
+    ["string manual", { keyframes: [{ delay: "0", duration: 100, value: 1 }] }],
+    ["null auto", { auto: { delay: null, duration: 100 } }],
+  ])("rejects invalid %s delays", (_name, x) => {
+    expect(() =>
+      normalizeAnimations([
+        {
+          id: "invalid-delay",
+          targetId: "panel",
+          type: "update",
+          tween: { x },
+        },
+      ]),
+    ).toThrow(/delay must be a finite number greater than or equal to 0/);
+  });
+
+  it.each([
+    [
+      "filter parameter",
+      {
+        id: "invalid-filter-delay",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          filters: {
+            grade: {
+              amount: {
+                keyframes: [{ delay: -1, duration: 100, value: 1 }],
+              },
+            },
+          },
+        },
+      },
+      "animations[0].tween.filters.grade.amount.keyframes[0].delay",
+    ],
+    [
+      "mask progress",
+      {
+        id: "invalid-mask-delay",
+        targetId: "scene",
+        type: "transition",
+        mask: {
+          kind: "single",
+          texture: "wipe",
+          progress: {
+            keyframes: [{ delay: -1, duration: 100, value: 1 }],
+          },
+        },
+      },
+      "animations[0].mask.progress.keyframes[0].delay",
+    ],
+    [
+      "compositor progress",
+      {
+        id: "invalid-compositor-delay",
+        targetId: "scene",
+        type: "transition",
+        compositor: createCompositor({
+          tween: {
+            progress: {
+              keyframes: [{ delay: -1, duration: 100, value: 1 }],
+            },
+          },
+        }),
+      },
+      "animations[0].compositor.tween.progress.keyframes[0].delay",
+    ],
+  ])("reports the exact invalid %s delay path", (_name, animation, path) => {
+    expect(() => normalizeAnimations([animation])).toThrow(
+      `${path} must be a finite number greater than or equal to 0.`,
+    );
+  });
+
   it("keeps ordinary update tweens unchanged", () => {
     const [animation] = normalizeAnimations([
       {
@@ -743,7 +916,7 @@ describe("normalizeAnimations rect style support", () => {
           width: { auto: { duration: 300 } },
           height: {
             initialValue: 80,
-            keyframes: [{ duration: 300, value: 120 }],
+            keyframes: [{ delay: 50, duration: 300, value: 120 }],
           },
           fill: {
             start: {
@@ -785,6 +958,7 @@ describe("normalizeAnimations rect style support", () => {
       "rect.cornerRadius.topLeft",
       "rect.cornerRadius.bottomRight",
     ]);
+    expect(animation.tween["rect.height"].keyframes[0].delay).toBe(50);
     expect(animation.tween["rect.fill.stops.1.color"].initialValue).toEqual([
       1, 0, 0, 1,
     ]);

--- a/vt/reference/recttransition/rect-update-keyframe-delay-01.webp
+++ b/vt/reference/recttransition/rect-update-keyframe-delay-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70892f2618a23add1d03513e285dc00f6e343be47ef45e64338a4feac0353768
+size 1794

--- a/vt/reference/recttransition/rect-update-keyframe-delay-02.webp
+++ b/vt/reference/recttransition/rect-update-keyframe-delay-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70892f2618a23add1d03513e285dc00f6e343be47ef45e64338a4feac0353768
+size 1794

--- a/vt/reference/recttransition/rect-update-keyframe-delay-03.webp
+++ b/vt/reference/recttransition/rect-update-keyframe-delay-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f1624cc8de3e5bf0a3dbeccb7a301388c13ffe497c11a127aaa351e22fd5b50
+size 1828

--- a/vt/reference/recttransition/rect-update-keyframe-delay-04.webp
+++ b/vt/reference/recttransition/rect-update-keyframe-delay-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2862a7a5299201a60afecaea087ffcfcba96bbd07ec2e06b3c8d69c12160277
+size 1804

--- a/vt/reference/recttransition/rect-update-keyframe-delay-05.webp
+++ b/vt/reference/recttransition/rect-update-keyframe-delay-05.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:005bb2740514e412019736c5b197ad147709a22e638e082fbde21142195778dd
+size 1790

--- a/vt/specs/recttransition/rect-update-keyframe-delay.yaml
+++ b/vt/specs/recttransition/rect-update-keyframe-delay.yaml
@@ -1,0 +1,90 @@
+---
+title: Rect Update Keyframe Delay
+description: Manual keyframes and auto tweens honor their initial and inter-keyframe delays
+specs:
+  - both rects should remain at their initial positions during the first 300ms delay
+  - the white rect should interpolate during its first keyframe while the gray rect follows its delayed auto tween
+  - the white rect should hold at its first keyframe value during the 400ms gap before its second keyframe
+  - both rects should finish at the authored destination after 1500ms
+steps:
+  - action: keypress
+    key: "n"
+  - action: wait
+    ms: 300
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 200
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 300
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 400
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 600
+  - action: screenshot
+---
+states:
+  - elements:
+      - id: manual-delay
+        type: rect
+        x: 120
+        "y": 160
+        width: 140
+        height: 120
+        fill: "#FFFFFF"
+      - id: auto-delay
+        type: rect
+        x: 120
+        "y": 420
+        width: 140
+        height: 120
+        fill: "#A6A6A6"
+  - elements:
+      - id: manual-delay
+        type: rect
+        x: 980
+        "y": 160
+        width: 140
+        height: 120
+        fill: "#FFFFFF"
+      - id: auto-delay
+        type: rect
+        x: 980
+        "y": 420
+        width: 140
+        height: 120
+        fill: "#A6A6A6"
+    animations:
+      - id: manual-keyframe-delay
+        targetId: manual-delay
+        type: update
+        tween:
+          x:
+            initialValue: 120
+            keyframes:
+              - delay: 300
+                duration: 400
+                value: 500
+                easing: linear
+              - delay: 400
+                duration: 400
+                value: 980
+                easing: linear
+      - id: auto-tween-delay
+        targetId: auto-delay
+        type: update
+        tween:
+          x:
+            auto:
+              delay: 300
+              duration: 1200
+              easing: linear


### PR DESCRIPTION
## Summary

- add non-negative per-keyframe and auto tween delays through the shared animation timeline
- support delays across ordinary, rect, filter, transition surface, mask, and compositor tracks
- document hold semantics, speed/loop behavior, validation, and zero-delay canonicalization
- bump the feature version to 1.36.0

## Validation

- 1,195 tests passed across 99 files
- source lint passed
- production build passed
- documentation site build passed
- pre-push checks passed