### PR TITLE
feat(audio): implement inline transitions

### DIFF
--- a/docs/inline-audio-transitions.md
+++ b/docs/inline-audio-transitions.md
@@ -1,17 +1,14 @@
 # Inline Audio Transition Interface
 
-Status: proposed; design-only; not implemented
+Status: implemented
 
 Last updated: 2026-08-02
 
 ## Purpose
 
-This document proposes replacing separately authored `audio-transition`
-records with one inline transition interface on `sound` and `audio-channel`
-nodes.
-
-The proposal is intentionally documentation-only. The current runtime and
-schemas continue to use the `audioEffects` interface documented in
+This document defines the canonical inline transition interface on `sound` and
+`audio-channel` nodes. Separately authored `audio-transition` records remain
+accepted as a legacy compatibility interface documented in
 [`audio-effects.md`](./audio-effects.md).
 
 ## Goals
@@ -30,8 +27,8 @@ schemas continue to use the `audioEffects` interface documented in
 - no second shorthand interface for simple fades
 - no named `fade`, `crossfade`, `hold`, or `offset` operations
 - no transition of boolean switches or source-identity fields
-- no shared multi-target audio timeline in this proposal
-- no implementation or compatibility removal in this pull request
+- no shared multi-target audio timeline in this interface
+- no removal of the legacy compatibility interface in this change
 
 ## Canonical Shape
 
@@ -76,7 +73,7 @@ additional keyframes express advanced behavior through the same interface.
 
 ### Structural Definition
 
-The proposed public structure, expressed as TypeScript-like documentation, is:
+The public structure, expressed as TypeScript-like documentation, is:
 
 ```ts
 type InlineAudioTransition = {
@@ -508,12 +505,12 @@ until the applicable exit tracks and any completable, already-authorized
 `loopEnd` tail have completed. Non-progressing zero-rate tails use the finite
 fallback defined under Exit.
 
-A future audio-specific transition-complete event or explicitly blocking audio
-timeline is outside this proposal.
+An audio-specific transition-complete event or explicitly blocking audio
+timeline is outside this interface.
 
 ## Validation
 
-The future implementation should reject:
+The runtime rejects:
 
 - `transition` that is not a non-empty object
 - unsupported lifecycle phase names
@@ -531,36 +528,11 @@ The future implementation should reject:
 
 ## Compatibility And Migration
 
-When implemented:
-
-1. inline `transition` becomes the canonical public authoring interface
+1. inline `transition` is the canonical public authoring interface
 2. existing `audioEffects` / `audio-transition` input remains accepted for a
    compatibility period
 3. both forms normalize to the same internal property timelines
 4. defining both forms for one target in one state is a validation error
-5. current fixtures migrate to inline syntax while dedicated compatibility
-   tests retain the legacy form
+5. manual fixtures use inline syntax while dedicated compatibility tests retain
+   the legacy form
 6. removal of `audioEffects` requires a separate breaking release
-
-This proposal does not add inline fields to schemas or types yet. Those changes
-belong in the implementation pull request so published validation never claims
-support before the runtime provides it.
-
-## Implementation Requirements For A Later Pull Request
-
-The later implementation must include:
-
-- schema and JSDoc types for inline lifecycle tracks
-- normalization into one internal target-to-transition map
-- shared enter/exit scheduling time for ready replacement instances
-- pending-decode enter scheduling that does not delay outgoing teardown
-- per-property cancellation of pending enter tracks superseded by updates
-- keyframe-delay support in audio parameter automation
-- current-value hold on interruption
-- cleanup after both the longest exit track and any completable `loopEnd` tail
-- full-timeline boundary calculation and finite fallback for zero-rate tails
-- conflict validation against legacy `audioEffects`
-- unit tests for normalization and timing
-- audio-stage tests for enter, deferred-enter updates, exit, interruption,
-  replacement, and zero-rate loop-end resumption
-- manual audio fixtures for immediate, delayed, and full-volume overlap

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -35,6 +35,7 @@ const createAudioParam = (
 const createAudioContextMock = ({
   decodedBuffer = { duration: 1 },
   reflectScheduledAudioParamValue = true,
+  startImpl,
   supportCancelAndHold = true,
   supportStereoPanner = true,
 } = {}) => {
@@ -81,7 +82,7 @@ const createAudioContextMock = ({
         playbackRate: createAudioParam(1, audioParamOptions),
         connect: vi.fn(),
         disconnect: vi.fn(),
-        start: vi.fn(),
+        start: vi.fn(startImpl),
         stop: vi.fn(),
       };
       context.sources.push(node);
@@ -2492,6 +2493,165 @@ describe("AudioStage graph rendering", () => {
     expect(source.stop).toHaveBeenCalledWith(11.25);
   });
 
+  it("composes inline channel and sound enter tracks on independent gain nodes", async () => {
+    const { stage, context } = await setupAudioStage();
+
+    stage.renderGraph({
+      nextAudio: [
+        {
+          id: "music",
+          type: "audio-channel",
+          volume: 50,
+          transition: {
+            enter: {
+              volume: {
+                initialValue: 0,
+                keyframes: [{ value: 50, duration: 1000 }],
+              },
+            },
+          },
+          children: [
+            {
+              id: "bgm",
+              type: "sound",
+              src: "theme",
+              volume: 80,
+              transition: {
+                enter: {
+                  volume: {
+                    initialValue: 0,
+                    keyframes: [{ value: 80, duration: 500 }],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const channel = stage._inspect().channels.get("music");
+    const sound = findCurrentSound(stage, "bgm");
+    expect(channel.gainNode).not.toBe(sound.gainNode);
+    expect(channel.gainNode.gain.setValueAtTime).toHaveBeenLastCalledWith(
+      0,
+      10,
+    );
+    expect(channel.gainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      0.5,
+      11,
+    );
+    expect(sound.gainNode.gain.setValueAtTime).toHaveBeenLastCalledWith(0, 10);
+    expect(sound.gainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      0.8,
+      10.5,
+    );
+    expect(context.sources[0].start).toHaveBeenCalledWith(10, 0);
+  });
+
+  it("does not restart automation when only an inline transition declaration changes", async () => {
+    const { stage, context } = await setupAudioStage();
+    const firstAudio = [
+      {
+        id: "bgm",
+        type: "sound",
+        src: "theme",
+        volume: 80,
+        transition: {
+          enter: {
+            volume: {
+              initialValue: 0,
+              keyframes: [{ value: 80, duration: 1000 }],
+            },
+          },
+        },
+      },
+    ];
+    const secondAudio = [
+      {
+        id: "bgm",
+        type: "sound",
+        src: "theme",
+        volume: 80,
+        transition: {
+          update: {
+            volume: {
+              keyframes: [{ value: 80, duration: 250 }],
+            },
+          },
+        },
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: firstAudio });
+    const sound = findCurrentSound(stage, "bgm");
+    const gain = sound.gainNode.gain;
+    const cancelCount = gain.cancelScheduledValues.mock.calls.length;
+    const holdCount = gain.cancelAndHoldAtTime.mock.calls.length;
+    const setCount = gain.setValueAtTime.mock.calls.length;
+    const rampCount = gain.linearRampToValueAtTime.mock.calls.length;
+
+    context.currentTime = 10.25;
+    stage.renderGraph({ prevAudio: firstAudio, nextAudio: secondAudio });
+
+    expect(context.sources).toHaveLength(1);
+    expect(gain.cancelScheduledValues).toHaveBeenCalledTimes(cancelCount);
+    expect(gain.cancelAndHoldAtTime).toHaveBeenCalledTimes(holdCount);
+    expect(gain.setValueAtTime).toHaveBeenCalledTimes(setCount);
+    expect(gain.linearRampToValueAtTime).toHaveBeenCalledTimes(rampCount);
+    expect(gain.linearRampToValueAtTime).toHaveBeenLastCalledWith(0.8, 11);
+  });
+
+  it("waits for the longest delayed inline exit track before cleanup", async () => {
+    const { stage, context } = await setupAudioStage();
+    const audio = [
+      {
+        id: "bgm",
+        type: "sound",
+        src: "theme",
+        volume: 100,
+        pan: 0,
+        playbackRate: 1,
+        transition: {
+          exit: {
+            volume: {
+              keyframes: [{ delay: 200, value: 0, duration: 300 }],
+            },
+            pan: {
+              keyframes: [{ delay: 100, value: 1, duration: 800 }],
+            },
+            playbackRate: {
+              keyframes: [{ delay: 300, value: 0.5, duration: 400 }],
+            },
+          },
+        },
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: audio });
+    const sound = findCurrentSound(stage, "bgm");
+    const source = context.sources[0];
+    stage.renderGraph({ prevAudio: audio, nextAudio: [] });
+
+    expect(sound.gainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      0,
+      10.5,
+    );
+    expect(sound.pannerNode.pan.linearRampToValueAtTime).toHaveBeenCalledWith(
+      1,
+      10.9,
+    );
+    expect(source.playbackRate.linearRampToValueAtTime).toHaveBeenCalledWith(
+      0.5,
+      10.7,
+    );
+    expect(source.stop).toHaveBeenCalledWith(10.9);
+    vi.advanceTimersByTime(899);
+    expect(findSound(stage, "bgm")).toBe(sound);
+    vi.advanceTimersByTime(1);
+    expect(findSound(stage, "bgm")).toBeUndefined();
+  });
+
   it("crossfades replacement instances with independent inline enter and exit delays", async () => {
     const { stage, context } = await setupAudioStage({
       assetMap: new Map([
@@ -2614,6 +2774,55 @@ describe("AudioStage graph rendering", () => {
       1,
       12,
     );
+  });
+
+  it("does not apply inline enter tracks when declarative source start fails", async () => {
+    const { stage, context } = await setupAudioStage({
+      contextOptions: {
+        startImpl: () => {
+          throw new Error("browser start failure");
+        },
+      },
+    });
+
+    expect(() =>
+      stage.renderGraph({
+        nextAudio: [
+          {
+            id: "bgm",
+            type: "sound",
+            src: "theme",
+            volume: 80,
+            pan: 0.5,
+            playbackRate: 2,
+            transition: {
+              enter: {
+                volume: {
+                  initialValue: 0,
+                  keyframes: [{ value: 80, duration: 500 }],
+                },
+                pan: {
+                  initialValue: -1,
+                  keyframes: [{ value: 0.5, duration: 500 }],
+                },
+                playbackRate: {
+                  initialValue: 0.5,
+                  keyframes: [{ value: 2, duration: 500 }],
+                },
+              },
+            },
+          },
+        ],
+      }),
+    ).toThrow("browser start failure");
+
+    const sound = findCurrentSound(stage, "bgm");
+    expect(sound.pendingEnterTransitions).not.toBeNull();
+    expect(sound.gainNode.gain.linearRampToValueAtTime).not.toHaveBeenCalled();
+    expect(sound.pannerNode.pan.linearRampToValueAtTime).not.toHaveBeenCalled();
+    expect(
+      context.sources[0].playbackRate.linearRampToValueAtTime,
+    ).not.toHaveBeenCalled();
   });
 
   it("supersedes only changed pending enter properties before delayed playback", async () => {

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -214,9 +214,13 @@ describe("AudioStage graph rendering", () => {
     );
     expect(context.sources[0].connect).toHaveBeenCalledWith(bgm.gainNode);
     expect(bgm.gainNode.connect).toHaveBeenCalledWith(bgm.pannerNode);
-    expect(bgm.pannerNode.connect).toHaveBeenCalledWith(music.gainNode);
+    expect(bgm.pannerNode.connect).toHaveBeenCalledWith(bgm.muteGainNode);
+    expect(bgm.muteGainNode.connect).toHaveBeenCalledWith(music.gainNode);
     expect(music.gainNode.connect).toHaveBeenCalledWith(music.pannerNode);
-    expect(music.pannerNode.connect).toHaveBeenCalledWith(context.destination);
+    expect(music.pannerNode.connect).toHaveBeenCalledWith(music.muteGainNode);
+    expect(music.muteGainNode.connect).toHaveBeenCalledWith(
+      context.destination,
+    );
   });
 
   it("restarts a looping channel only after its complete delayed schedule finishes", async () => {
@@ -429,6 +433,10 @@ describe("AudioStage graph rendering", () => {
     expect(source.loop).toBe(false);
 
     source.onended();
+    expect(findSound(stage, "outgoing")).toBeDefined();
+    vi.advanceTimersByTime(499);
+    expect(findSound(stage, "outgoing")).toBeDefined();
+    vi.advanceTimersByTime(1);
     expect(findSound(stage, "outgoing")).toBeUndefined();
   });
 
@@ -532,7 +540,7 @@ describe("AudioStage graph rendering", () => {
     expect(incomingChannel.pannerNode.pan.value).toBe(0.5);
     expect(outgoingChannel.gainNode.gain.value).toBe(1);
     expect(outgoingChannel.pannerNode.pan.value).toBe(0);
-    expect(incomingSound.pannerNode.connect).toHaveBeenCalledWith(
+    expect(incomingSound.muteGainNode.connect).toHaveBeenCalledWith(
       incomingChannel.gainNode,
     );
 
@@ -1791,12 +1799,16 @@ describe("AudioStage graph rendering", () => {
     const firstChannel = stage._inspect().channels.get("music-a");
     const secondChannel = stage._inspect().channels.get("music-b");
 
-    expect(bgm.pannerNode.connect).toHaveBeenCalledWith(firstChannel.gainNode);
+    expect(bgm.muteGainNode.connect).toHaveBeenCalledWith(
+      firstChannel.gainNode,
+    );
 
     stage.renderGraph({ prevAudio: firstAudio, nextAudio: secondAudio });
 
-    expect(bgm.pannerNode.disconnect).toHaveBeenCalled();
-    expect(bgm.pannerNode.connect).toHaveBeenCalledWith(secondChannel.gainNode);
+    expect(bgm.muteGainNode.disconnect).toHaveBeenCalled();
+    expect(bgm.muteGainNode.connect).toHaveBeenCalledWith(
+      secondChannel.gainNode,
+    );
     expect(findCurrentSound(stage, "bgm")).toBe(bgm);
   });
 
@@ -2411,5 +2423,419 @@ describe("AudioStage graph rendering", () => {
         ],
       }),
     ).toThrow('targetId "missing" does not resolve');
+  });
+
+  it("applies inline channel enter, update, and exit tracks", async () => {
+    const { stage, context } = await setupAudioStage();
+    const firstAudio = [
+      {
+        id: "music",
+        type: "audio-channel",
+        volume: 80,
+        transition: {
+          enter: {
+            volume: {
+              initialValue: 0,
+              keyframes: [{ value: 80, duration: 500 }],
+            },
+          },
+        },
+        children: [{ id: "bgm", type: "sound", src: "theme", loop: true }],
+      },
+    ];
+    const secondAudio = [
+      {
+        id: "music",
+        type: "audio-channel",
+        volume: 40,
+        transition: {
+          update: {
+            volume: {
+              keyframes: [{ delay: 100, value: 40, duration: 400 }],
+            },
+          },
+          exit: {
+            volume: {
+              keyframes: [{ value: 0, duration: 750 }],
+            },
+          },
+        },
+        children: [{ id: "bgm", type: "sound", src: "theme", loop: true }],
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: firstAudio });
+    const music = stage._inspect().channels.get("music");
+    expect(music.gainNode.gain.setValueAtTime).toHaveBeenLastCalledWith(0, 10);
+    expect(music.gainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      0.8,
+      10.5,
+    );
+
+    context.currentTime = 10.5;
+    stage.renderGraph({ prevAudio: firstAudio, nextAudio: secondAudio });
+    expect(music.gainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      0.8,
+      10.6,
+    );
+    expect(music.gainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      0.4,
+      11,
+    );
+
+    const source = context.sources[0];
+    stage.renderGraph({ prevAudio: secondAudio, nextAudio: [] });
+    expect(music.gainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      0,
+      11.25,
+    );
+    expect(source.stop).toHaveBeenCalledWith(11.25);
+  });
+
+  it("crossfades replacement instances with independent inline enter and exit delays", async () => {
+    const { stage, context } = await setupAudioStage({
+      assetMap: new Map([
+        ["first", { duration: 20 }],
+        ["second", { duration: 20 }],
+      ]),
+    });
+    const outgoingAudio = [
+      {
+        id: "bgm",
+        type: "sound",
+        src: "first",
+        loop: true,
+        volume: 80,
+        transition: {
+          exit: {
+            volume: {
+              keyframes: [{ delay: 1000, value: 0, duration: 2000 }],
+            },
+          },
+        },
+      },
+    ];
+    const incomingAudio = [
+      {
+        id: "bgm",
+        type: "sound",
+        src: "second",
+        loop: true,
+        volume: 80,
+        transition: {
+          enter: {
+            volume: {
+              initialValue: 0,
+              keyframes: [{ delay: 500, value: 80, duration: 1500 }],
+            },
+          },
+        },
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: outgoingAudio });
+    const outgoing = findCurrentSound(stage, "bgm");
+    const outgoingSource = context.sources[0];
+
+    stage.renderGraph({
+      prevAudio: outgoingAudio,
+      nextAudio: incomingAudio,
+    });
+
+    const incoming = findCurrentSound(stage, "bgm");
+    const incomingSource = context.sources[1];
+    expect(incoming).not.toBe(outgoing);
+    expect(outgoingSource.stop).toHaveBeenCalledWith(13);
+    expect(
+      outgoing.gainNode.gain.linearRampToValueAtTime,
+    ).toHaveBeenNthCalledWith(1, 0.8, 11);
+    expect(
+      outgoing.gainNode.gain.linearRampToValueAtTime,
+    ).toHaveBeenNthCalledWith(2, 0, 13);
+    expect(incomingSource.start).toHaveBeenCalledWith(10, 0);
+    expect(incoming.gainNode.gain.setValueAtTime).toHaveBeenLastCalledWith(
+      0,
+      10,
+    );
+    expect(
+      incoming.gainNode.gain.linearRampToValueAtTime,
+    ).toHaveBeenNthCalledWith(1, 0, 10.5);
+    expect(
+      incoming.gainNode.gain.linearRampToValueAtTime,
+    ).toHaveBeenNthCalledWith(2, 0.8, 12);
+    expect(stage._inspect().sounds.get(outgoing.internalId)).toBe(outgoing);
+
+    vi.advanceTimersByTime(2999);
+    expect(stage._inspect().sounds.get(outgoing.internalId)).toBe(outgoing);
+    vi.advanceTimersByTime(1);
+    expect(stage._inspect().sounds.has(outgoing.internalId)).toBe(false);
+    expect(findCurrentSound(stage, "bgm")).toBe(incoming);
+  });
+
+  it("starts a delayed sound's inline enter tracks when playback actually starts", async () => {
+    const { stage, context, getAsset } = await setupAudioStage();
+    stage.renderGraph({
+      nextAudio: [
+        {
+          id: "delayed",
+          type: "sound",
+          src: "theme",
+          startDelayMs: 1000,
+          volume: 100,
+          transition: {
+            enter: {
+              volume: {
+                initialValue: 0,
+                keyframes: [{ value: 100, duration: 1000 }],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const delayed = findCurrentSound(stage, "delayed");
+    expect(getAsset).not.toHaveBeenCalled();
+    expect(
+      delayed.gainNode.gain.linearRampToValueAtTime,
+    ).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(999);
+    expect(context.sources).toHaveLength(0);
+
+    context.currentTime = 11;
+    vi.advanceTimersByTime(1);
+
+    expect(context.sources).toHaveLength(1);
+    expect(delayed.gainNode.gain.setValueAtTime).toHaveBeenLastCalledWith(
+      0,
+      11,
+    );
+    expect(delayed.gainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      1,
+      12,
+    );
+  });
+
+  it("supersedes only changed pending enter properties before delayed playback", async () => {
+    const { stage, context } = await setupAudioStage();
+    const firstAudio = [
+      {
+        id: "delayed",
+        type: "sound",
+        src: "theme",
+        startDelayMs: 100,
+        volume: 80,
+        pan: 1,
+        playbackRate: 2,
+        transition: {
+          enter: {
+            volume: {
+              initialValue: 0,
+              keyframes: [{ value: 80, duration: 100 }],
+            },
+            pan: {
+              initialValue: -1,
+              keyframes: [{ value: 1, duration: 100 }],
+            },
+            playbackRate: {
+              initialValue: 0,
+              keyframes: [{ value: 2, duration: 100 }],
+            },
+          },
+        },
+      },
+    ];
+    const updatedAudio = [
+      {
+        id: "delayed",
+        type: "sound",
+        src: "theme",
+        startDelayMs: 100,
+        volume: 40,
+        pan: 1,
+        playbackRate: 1,
+        transition: {
+          update: {
+            volume: { keyframes: [{ value: 40, duration: 100 }] },
+            playbackRate: { keyframes: [{ value: 1, duration: 200 }] },
+          },
+        },
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: firstAudio });
+    const delayed = findCurrentSound(stage, "delayed");
+    context.currentTime = 10.05;
+    vi.advanceTimersByTime(50);
+    stage.renderGraph({ prevAudio: firstAudio, nextAudio: updatedAudio });
+
+    expect(delayed.gainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      0.4,
+      10.15,
+    );
+    context.currentTime = 10.1;
+    vi.advanceTimersByTime(50);
+
+    const source = context.sources[0];
+    expect(delayed.gainNode.gain.setValueAtTime).not.toHaveBeenCalledWith(
+      0,
+      10.1,
+    );
+    expect(delayed.pannerNode.pan.setValueAtTime).toHaveBeenLastCalledWith(
+      -1,
+      10.1,
+    );
+    expect(delayed.pannerNode.pan.linearRampToValueAtTime).toHaveBeenCalledWith(
+      1,
+      10.2,
+    );
+    expect(source.playbackRate.setValueAtTime.mock.calls.at(-1)[0]).toBeCloseTo(
+      1.75,
+    );
+    expect(source.playbackRate.setValueAtTime.mock.calls.at(-1)[1]).toBe(10.1);
+    expect(source.playbackRate.linearRampToValueAtTime).toHaveBeenCalledWith(
+      1,
+      10.25,
+    );
+  });
+
+  it("keeps mute gating independent from active inline volume automation", async () => {
+    const { stage } = await setupAudioStage();
+    const mutedAudio = [
+      {
+        id: "bgm",
+        type: "sound",
+        src: "theme",
+        volume: 100,
+        muted: true,
+        transition: {
+          enter: {
+            volume: {
+              initialValue: 0,
+              keyframes: [{ value: 100, duration: 1000 }],
+            },
+          },
+        },
+      },
+    ];
+    const audibleAudio = [
+      {
+        id: "bgm",
+        type: "sound",
+        src: "theme",
+        volume: 100,
+        muted: false,
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: mutedAudio });
+    const bgm = findCurrentSound(stage, "bgm");
+    const volumeCancelCount =
+      bgm.gainNode.gain.cancelScheduledValues.mock.calls.length;
+    const volumeHoldCount =
+      bgm.gainNode.gain.cancelAndHoldAtTime.mock.calls.length;
+    expect(bgm.muteGainNode.gain.value).toBe(0);
+    expect(bgm.gainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      1,
+      11,
+    );
+
+    stage.renderGraph({ prevAudio: mutedAudio, nextAudio: audibleAudio });
+
+    expect(bgm.muteGainNode.gain.value).toBe(1);
+    expect(bgm.gainNode.gain.cancelScheduledValues).toHaveBeenCalledTimes(
+      volumeCancelCount,
+    );
+    expect(bgm.gainNode.gain.cancelAndHoldAtTime).toHaveBeenCalledTimes(
+      volumeHoldCount,
+    );
+    expect(bgm.gainNode.gain.linearRampToValueAtTime).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a zero-rate loop-end tail resume through its complete exit timeline", async () => {
+    const { stage, context } = await setupAudioStage({
+      assetMap: new Map([["paused", { duration: 4 }]]),
+    });
+    const audio = [
+      {
+        id: "music",
+        type: "audio-channel",
+        interruption: "loopEnd",
+        children: [
+          {
+            id: "paused",
+            type: "sound",
+            src: "paused",
+            loop: true,
+            playbackRate: 0,
+            transition: {
+              exit: {
+                playbackRate: {
+                  keyframes: [{ value: 1, duration: 1000 }],
+                },
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: audio });
+    const source = context.sources[0];
+    stage.renderGraph({ prevAudio: audio, nextAudio: [] });
+
+    expect(source.playbackRate.linearRampToValueAtTime).toHaveBeenCalledWith(
+      1,
+      11,
+    );
+    expect(source.stop.mock.calls[0][0]).toBeCloseTo(14.5, 3);
+    vi.advanceTimersByTime(1000);
+    expect(findSound(stage, "paused")).toBeDefined();
+
+    context.currentTime = 14.5;
+    source.onended();
+    expect(findSound(stage, "paused")).toBeUndefined();
+    expect(stage._inspect().channels.has("music")).toBe(false);
+  });
+
+  it("uses the finite exit fallback when a rate timeline cannot reach loop end", async () => {
+    const { stage, context } = await setupAudioStage({
+      assetMap: new Map([["slowing", { duration: 4 }]]),
+    });
+    const audio = [
+      {
+        id: "music",
+        type: "audio-channel",
+        interruption: "loopEnd",
+        children: [
+          {
+            id: "slowing",
+            type: "sound",
+            src: "slowing",
+            loop: true,
+            playbackRate: 1,
+            transition: {
+              exit: {
+                playbackRate: {
+                  keyframes: [{ value: 0, duration: 1000 }],
+                },
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    stage.renderGraph({ nextAudio: audio });
+    const source = context.sources[0];
+    stage.renderGraph({ prevAudio: audio, nextAudio: [] });
+
+    expect(source.stop).toHaveBeenCalledWith(11);
+    expect(findSound(stage, "slowing")).toBeDefined();
+    vi.advanceTimersByTime(999);
+    expect(findSound(stage, "slowing")).toBeDefined();
+    vi.advanceTimersByTime(1);
+    expect(findSound(stage, "slowing")).toBeUndefined();
+    expect(stage._inspect().channels.has("music")).toBe(false);
   });
 });

--- a/spec/audio/controlledPlayback.spec.js
+++ b/spec/audio/controlledPlayback.spec.js
@@ -1201,6 +1201,90 @@ describe("command-controlled sound playback", () => {
     expect(restartedRate.linearRampToValueAtTime).toHaveBeenCalledWith(2, 11);
   });
 
+  it("preserves pending enter tracks when source start fails and retries them on a later play", async () => {
+    let startAttempts = 0;
+    const { context, eventHandler, render, stage } = await setupControlledStage(
+      {
+        contextOptions: {
+          startImpl: () => {
+            startAttempts += 1;
+            if (startAttempts === 1) {
+              throw new Error("browser start failure");
+            }
+          },
+        },
+      },
+    );
+    const transition = {
+      enter: {
+        volume: {
+          initialValue: 0,
+          keyframes: [{ value: 80, duration: 500 }],
+        },
+        pan: {
+          initialValue: -1,
+          keyframes: [{ value: 0.5, duration: 500 }],
+        },
+        playbackRate: {
+          initialValue: 0.5,
+          keyframes: [{ value: 2, duration: 500 }],
+        },
+      },
+    };
+    const sound = (commandId) =>
+      playbackSound({
+        commandId,
+        operation: "play",
+        positionMs: 0,
+        volume: 80,
+        pan: 0.5,
+        playbackRate: 2,
+        transition,
+      });
+
+    render([sound(1)]);
+    await flushMicrotasks();
+
+    const currentKey = stage._inspect().currentSoundKeyById.get("player");
+    const instance = stage._inspect().sounds.get(currentKey);
+    expect(eventsByName(eventHandler, "soundError").at(-1)).toEqual({
+      _event: {
+        id: "player",
+        commandId: 1,
+        errorCode: "playback-failed",
+      },
+    });
+    expect(instance.pendingEnterTransitions).not.toBeNull();
+
+    context.currentTime = 11;
+    render([sound(2)]);
+    await flushMicrotasks();
+
+    expect(startAttempts).toBe(2);
+    expect(context.sources).toHaveLength(2);
+    expect(instance.pendingEnterTransitions).toBeNull();
+    expect(instance.gainNode.gain.setValueAtTime).toHaveBeenLastCalledWith(
+      0,
+      11,
+    );
+    expect(
+      instance.gainNode.gain.linearRampToValueAtTime,
+    ).toHaveBeenLastCalledWith(0.8, 11.5);
+    expect(instance.pannerNode.pan.setValueAtTime).toHaveBeenLastCalledWith(
+      -1,
+      11,
+    );
+    expect(
+      instance.pannerNode.pan.linearRampToValueAtTime,
+    ).toHaveBeenLastCalledWith(0.5, 11.5);
+    expect(
+      context.sources[1].playbackRate.setValueAtTime,
+    ).toHaveBeenLastCalledWith(0.5, 11);
+    expect(
+      context.sources[1].playbackRate.linearRampToValueAtTime,
+    ).toHaveBeenLastCalledWith(2, 11.5);
+  });
+
   it("starts a replacement enter after pending decode without delaying outgoing exit", async () => {
     let resolveDecode;
     const decodePromise = new Promise((resolve) => {

--- a/spec/audio/controlledPlayback.spec.js
+++ b/spec/audio/controlledPlayback.spec.js
@@ -1383,6 +1383,109 @@ describe("command-controlled sound playback", () => {
     ).toHaveBeenLastCalledWith(1, 10.75);
   });
 
+  it("supersedes only changed enter tracks after a failed source start", async () => {
+    let startAttempts = 0;
+    const { context, render, stage } = await setupControlledStage({
+      contextOptions: {
+        startImpl: () => {
+          startAttempts += 1;
+          if (startAttempts === 1) {
+            throw new Error("browser start failure");
+          }
+        },
+      },
+    });
+    const initial = playbackSound({
+      commandId: 1,
+      operation: "play",
+      positionMs: 0,
+      volume: 80,
+      pan: 0.5,
+      playbackRate: 2,
+      transition: {
+        enter: {
+          volume: {
+            initialValue: 0,
+            keyframes: [{ value: 80, duration: 500 }],
+          },
+          pan: {
+            initialValue: -1,
+            keyframes: [{ value: 0.5, duration: 500 }],
+          },
+          playbackRate: {
+            initialValue: 0.5,
+            keyframes: [{ value: 2, duration: 500 }],
+          },
+        },
+      },
+    });
+    const updated = (commandId) =>
+      playbackSound({
+        commandId,
+        operation: "play",
+        positionMs: 0,
+        volume: 40,
+        pan: 0.5,
+        playbackRate: 2,
+        transition: {
+          update: {
+            volume: { keyframes: [{ value: 40, duration: 500 }] },
+          },
+        },
+      });
+
+    render([initial]);
+    await flushMicrotasks();
+    const currentKey = stage._inspect().currentSoundKeyById.get("player");
+    const instance = stage._inspect().sounds.get(currentKey);
+
+    context.currentTime = 10.25;
+    render([updated(1)]);
+
+    expect(instance.pendingEnterTransitions).toEqual({
+      volume: null,
+      pan: initial.transition.enter.pan,
+      playbackRate: initial.transition.enter.playbackRate,
+    });
+    expect(instance.gainNode.gain.setValueAtTime).toHaveBeenLastCalledWith(
+      0.8,
+      10.25,
+    );
+    expect(
+      instance.gainNode.gain.linearRampToValueAtTime,
+    ).toHaveBeenLastCalledWith(0.4, 10.75);
+    const volumeSetCount =
+      instance.gainNode.gain.setValueAtTime.mock.calls.length;
+    const volumeRampCount =
+      instance.gainNode.gain.linearRampToValueAtTime.mock.calls.length;
+
+    context.currentTime = 10.5;
+    render([updated(2)]);
+    await flushMicrotasks();
+
+    expect(startAttempts).toBe(2);
+    expect(instance.pendingEnterTransitions).toBeNull();
+    expect(instance.gainNode.gain.setValueAtTime).toHaveBeenCalledTimes(
+      volumeSetCount,
+    );
+    expect(
+      instance.gainNode.gain.linearRampToValueAtTime,
+    ).toHaveBeenCalledTimes(volumeRampCount);
+    expect(instance.pannerNode.pan.setValueAtTime).toHaveBeenLastCalledWith(
+      -1,
+      10.5,
+    );
+    expect(
+      instance.pannerNode.pan.linearRampToValueAtTime,
+    ).toHaveBeenLastCalledWith(0.5, 11);
+    expect(
+      context.sources[1].playbackRate.setValueAtTime,
+    ).toHaveBeenLastCalledWith(0.5, 10.5);
+    expect(
+      context.sources[1].playbackRate.linearRampToValueAtTime,
+    ).toHaveBeenLastCalledWith(2, 11);
+  });
+
   it("starts a replacement enter after pending decode without delaying outgoing exit", async () => {
     let resolveDecode;
     const decodePromise = new Promise((resolve) => {

--- a/spec/audio/controlledPlayback.spec.js
+++ b/spec/audio/controlledPlayback.spec.js
@@ -1084,4 +1084,193 @@ describe("command-controlled sound playback", () => {
 
     expect(eventsByName(eventHandler, "soundComplete")).toEqual([]);
   });
+
+  it("runs inline enter once for same-source transport plays and again for replacement", async () => {
+    const { context, render, stage } = await setupControlledStage({
+      assets: new Map([
+        ["track", { duration: 10 }],
+        ["next", { duration: 10 }],
+      ]),
+    });
+    const enter = {
+      enter: {
+        volume: {
+          initialValue: 0,
+          keyframes: [{ value: 80, duration: 500 }],
+        },
+      },
+    };
+
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+        volume: 80,
+        transition: enter,
+      }),
+    ]);
+    await flushMicrotasks();
+    const firstKey = stage._inspect().currentSoundKeyById.get("player");
+    const firstInstance = stage._inspect().sounds.get(firstKey);
+    expect(
+      firstInstance.gainNode.gain.linearRampToValueAtTime,
+    ).toHaveBeenCalledTimes(1);
+
+    render([
+      playbackSound({
+        commandId: 2,
+        operation: "play",
+        positionMs: 1000,
+        volume: 80,
+        transition: enter,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(2);
+    expect(stage._inspect().currentSoundKeyById.get("player")).toBe(firstKey);
+    expect(
+      firstInstance.gainNode.gain.linearRampToValueAtTime,
+    ).toHaveBeenCalledTimes(1);
+
+    render([
+      playbackSound({
+        commandId: 3,
+        operation: "play",
+        positionMs: 0,
+        src: "next",
+        volume: 80,
+        transition: enter,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    const replacementKey = stage._inspect().currentSoundKeyById.get("player");
+    const replacement = stage._inspect().sounds.get(replacementKey);
+    expect(replacementKey).not.toBe(firstKey);
+    expect(context.sources).toHaveLength(3);
+    expect(replacement.gainNode.gain.setValueAtTime).toHaveBeenLastCalledWith(
+      0,
+      10,
+    );
+    expect(
+      replacement.gainNode.gain.linearRampToValueAtTime,
+    ).toHaveBeenCalledWith(0.8, 10.5);
+  });
+
+  it("carries active playback-rate automation across a same-source transport restart", async () => {
+    const { context, render } = await setupControlledStage();
+    const transition = {
+      enter: {
+        playbackRate: {
+          initialValue: 0.5,
+          keyframes: [{ value: 2, duration: 1000 }],
+        },
+      },
+    };
+
+    render([
+      playbackSound({
+        commandId: 1,
+        operation: "play",
+        positionMs: 0,
+        playbackRate: 2,
+        transition,
+      }),
+    ]);
+    await flushMicrotasks();
+    context.currentTime = 10.25;
+
+    render([
+      playbackSound({
+        commandId: 2,
+        operation: "play",
+        positionMs: 1000,
+        playbackRate: 2,
+        transition,
+      }),
+    ]);
+    await flushMicrotasks();
+
+    const restartedRate = context.sources[1].playbackRate;
+    expect(restartedRate.setValueAtTime.mock.calls.at(-1)[0]).toBeCloseTo(
+      0.875,
+    );
+    expect(restartedRate.setValueAtTime.mock.calls.at(-1)[1]).toBe(10.25);
+    expect(restartedRate.linearRampToValueAtTime).toHaveBeenCalledWith(2, 11);
+  });
+
+  it("starts a replacement enter after pending decode without delaying outgoing exit", async () => {
+    let resolveDecode;
+    const decodePromise = new Promise((resolve) => {
+      resolveDecode = resolve;
+    });
+    const { context, render, stage } = await setupControlledStage({
+      assets: new Map([["track", { duration: 10 }]]),
+      pendingAssets: new Map([["next", decodePromise]]),
+    });
+    const outgoing = playbackSound({
+      commandId: 1,
+      operation: "play",
+      positionMs: 0,
+      volume: 80,
+      transition: {
+        exit: {
+          volume: {
+            keyframes: [{ value: 0, duration: 1000 }],
+          },
+        },
+      },
+    });
+
+    render([outgoing]);
+    await flushMicrotasks();
+    const outgoingKey = stage._inspect().currentSoundKeyById.get("player");
+    const outgoingInstance = stage._inspect().sounds.get(outgoingKey);
+    const outgoingSource = context.sources[0];
+
+    render([
+      playbackSound({
+        commandId: 2,
+        operation: "play",
+        positionMs: 0,
+        src: "next",
+        volume: 80,
+        transition: {
+          enter: {
+            volume: {
+              initialValue: 0,
+              keyframes: [{ value: 80, duration: 500 }],
+            },
+          },
+        },
+      }),
+    ]);
+
+    const incomingKey = stage._inspect().currentSoundKeyById.get("player");
+    const incomingInstance = stage._inspect().sounds.get(incomingKey);
+    expect(incomingKey).not.toBe(outgoingKey);
+    expect(outgoingSource.stop).toHaveBeenCalledWith(11);
+    expect(
+      outgoingInstance.gainNode.gain.linearRampToValueAtTime,
+    ).toHaveBeenCalledWith(0, 11);
+    expect(context.sources).toHaveLength(1);
+    expect(
+      incomingInstance.gainNode.gain.linearRampToValueAtTime,
+    ).not.toHaveBeenCalled();
+
+    context.currentTime = 11.5;
+    vi.advanceTimersByTime(1000);
+    resolveDecode({ duration: 10 });
+    await flushMicrotasks();
+
+    expect(context.sources).toHaveLength(2);
+    expect(
+      incomingInstance.gainNode.gain.setValueAtTime,
+    ).toHaveBeenLastCalledWith(0, 11.5);
+    expect(
+      incomingInstance.gainNode.gain.linearRampToValueAtTime,
+    ).toHaveBeenCalledWith(0.8, 12);
+  });
 });

--- a/spec/audio/controlledPlayback.spec.js
+++ b/spec/audio/controlledPlayback.spec.js
@@ -1085,6 +1085,53 @@ describe("command-controlled sound playback", () => {
     expect(eventsByName(eventHandler, "soundComplete")).toEqual([]);
   });
 
+  it("preserves non-looping rate history when finishing at loopEnd", async () => {
+    const { context, render, stage } = await setupControlledStage();
+    const channel = (children) => ({
+      id: "music",
+      type: "audio-channel",
+      interruption: "loopEnd",
+      children,
+    });
+    const initial = playbackSound({
+      commandId: 1,
+      operation: "play",
+      positionMs: 0,
+      playbackRate: 0.5,
+    });
+    const faster = playbackSound({
+      commandId: 1,
+      operation: "play",
+      positionMs: 0,
+      playbackRate: 2,
+    });
+
+    render([channel([initial])]);
+    await flushMicrotasks();
+    const source = context.sources[0];
+
+    context.currentTime = 12;
+    render([channel([faster])]);
+
+    const currentKey = stage._inspect().currentSoundKeyById.get("player");
+    const instance = stage._inspect().sounds.get(currentKey);
+    expect(instance.control.sourceCursorMs).toBeCloseTo(1000);
+    expect(instance.sourceStartOffset).toBeCloseTo(1);
+    expect(instance.sourceStartedAt).toBe(12);
+
+    context.currentTime = 13;
+    render([channel([])]);
+
+    expect(source.loop).toBe(false);
+    expect(source.stop).toHaveBeenCalledTimes(1);
+    expect(source.stop).toHaveBeenCalledWith(16.5);
+    expect(stage._inspect().sounds.get(currentKey)).toBe(instance);
+
+    context.currentTime = 16.5;
+    source.onended();
+    expect(stage._inspect().sounds.has(currentKey)).toBe(false);
+  });
+
   it("runs inline enter once for same-source transport plays and again for replacement", async () => {
     const { context, render, stage } = await setupControlledStage({
       assets: new Map([

--- a/spec/audio/controlledPlayback.spec.js
+++ b/spec/audio/controlledPlayback.spec.js
@@ -1255,6 +1255,15 @@ describe("command-controlled sound playback", () => {
       },
     });
     expect(instance.pendingEnterTransitions).not.toBeNull();
+    expect(
+      instance.gainNode.gain.linearRampToValueAtTime,
+    ).not.toHaveBeenCalled();
+    expect(
+      instance.pannerNode.pan.linearRampToValueAtTime,
+    ).not.toHaveBeenCalled();
+    expect(
+      context.sources[0].playbackRate.linearRampToValueAtTime,
+    ).not.toHaveBeenCalled();
 
     context.currentTime = 11;
     render([sound(2)]);
@@ -1283,6 +1292,95 @@ describe("command-controlled sound playback", () => {
     expect(
       context.sources[1].playbackRate.linearRampToValueAtTime,
     ).toHaveBeenLastCalledWith(2, 11.5);
+  });
+
+  it("does not let a failed enter attempt influence an intervening property update", async () => {
+    let startAttempts = 0;
+    const { context, render, stage } = await setupControlledStage({
+      contextOptions: {
+        startImpl: () => {
+          startAttempts += 1;
+          if (startAttempts === 1) {
+            throw new Error("browser start failure");
+          }
+        },
+      },
+    });
+    const initial = playbackSound({
+      commandId: 1,
+      operation: "play",
+      positionMs: 0,
+      volume: 80,
+      pan: 0.5,
+      playbackRate: 2,
+      transition: {
+        enter: {
+          volume: {
+            initialValue: 0,
+            keyframes: [{ value: 80, duration: 500 }],
+          },
+          pan: {
+            initialValue: -1,
+            keyframes: [{ value: 0.5, duration: 500 }],
+          },
+          playbackRate: {
+            initialValue: 0.5,
+            keyframes: [{ value: 2, duration: 500 }],
+          },
+        },
+      },
+    });
+    const updated = (commandId) =>
+      playbackSound({
+        commandId,
+        operation: "play",
+        positionMs: 0,
+        volume: 40,
+        pan: 0,
+        playbackRate: 1,
+        transition: {
+          update: {
+            volume: { keyframes: [{ value: 40, duration: 500 }] },
+            pan: { keyframes: [{ value: 0, duration: 500 }] },
+            playbackRate: { keyframes: [{ value: 1, duration: 500 }] },
+          },
+        },
+      });
+
+    render([initial]);
+    await flushMicrotasks();
+    const currentKey = stage._inspect().currentSoundKeyById.get("player");
+    const instance = stage._inspect().sounds.get(currentKey);
+
+    context.currentTime = 10.25;
+    render([updated(1)]);
+
+    expect(instance.gainNode.gain.setValueAtTime).toHaveBeenLastCalledWith(
+      0.8,
+      10.25,
+    );
+    expect(instance.pannerNode.pan.setValueAtTime).toHaveBeenLastCalledWith(
+      0.5,
+      10.25,
+    );
+    expect(instance.pendingEnterTransitions).toEqual({
+      volume: null,
+      pan: null,
+      playbackRate: null,
+    });
+
+    context.currentTime = 10.5;
+    render([updated(2)]);
+    await flushMicrotasks();
+
+    expect(startAttempts).toBe(2);
+    expect(instance.pendingEnterTransitions).toBeNull();
+    expect(
+      context.sources[1].playbackRate.setValueAtTime,
+    ).toHaveBeenLastCalledWith(1.5, 10.5);
+    expect(
+      context.sources[1].playbackRate.linearRampToValueAtTime,
+    ).toHaveBeenLastCalledWith(1, 10.75);
   });
 
   it("starts a replacement enter after pending decode without delaying outgoing exit", async () => {

--- a/spec/audio/normalizeAudio.spec.js
+++ b/spec/audio/normalizeAudio.spec.js
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAudioRenderState } from "../../src/util/normalizeAudio.js";
+
+const track = (value, overrides = {}) => ({
+  keyframes: [{ value, duration: 100, ...overrides }],
+});
+
+const soundWithTransition = (transition, overrides = {}) => ({
+  id: "bgm",
+  type: "sound",
+  src: "theme",
+  volume: 80,
+  pan: 0.25,
+  playbackRate: 1.5,
+  transition,
+  ...overrides,
+});
+
+describe("inline audio transition normalization", () => {
+  it("normalizes lifecycle-first channel and sound tracks into the shared internal map", () => {
+    const channelEnter = track(60, { delay: 25 });
+    const soundUpdate = track(0.25);
+    const soundExit = track(0);
+
+    const normalized = normalizeAudioRenderState({
+      audio: [
+        {
+          id: "music",
+          type: "audio-channel",
+          volume: 60,
+          transition: { enter: { volume: channelEnter } },
+          children: [
+            soundWithTransition({
+              update: { pan: soundUpdate },
+              exit: { playbackRate: soundExit },
+            }),
+          ],
+        },
+      ],
+    });
+
+    expect(normalized.transitions).toEqual(
+      new Map([
+        ["music", { volume: { enter: channelEnter } }],
+        [
+          "bgm",
+          {
+            pan: { update: soundUpdate },
+            playbackRate: { exit: soundExit },
+          },
+        ],
+      ]),
+    );
+    expect(normalized.channels[0]).not.toHaveProperty("transition");
+    expect(normalized.sounds[0]).not.toHaveProperty("transition");
+  });
+
+  it("keeps legacy transitions normalized through the same map", () => {
+    const enter = track(80);
+    const normalized = normalizeAudioRenderState({
+      audio: [soundWithTransition(undefined)],
+      audioEffects: [
+        {
+          id: "legacy-fade",
+          type: "audio-transition",
+          targetId: "bgm",
+          properties: { volume: { enter } },
+        },
+      ],
+    });
+
+    expect(normalized.transitions.get("bgm")).toEqual({
+      volume: { enter },
+    });
+  });
+
+  it("accepts signed relative deltas and delay on every lifecycle", () => {
+    const normalized = normalizeAudioRenderState({
+      audio: [
+        soundWithTransition({
+          enter: {
+            volume: {
+              initialValue: 0,
+              keyframes: [
+                { value: 120, duration: 25, relative: true, delay: 10 },
+                { value: 80, duration: 25 },
+              ],
+            },
+          },
+          update: {
+            pan: {
+              keyframes: [
+                { value: -10, duration: 10, relative: true },
+                { value: 0.25, duration: 10 },
+              ],
+            },
+          },
+          exit: {
+            playbackRate: {
+              keyframes: [
+                { value: -100, duration: 50, relative: true, delay: 20 },
+              ],
+            },
+          },
+        }),
+      ],
+    });
+
+    expect(normalized.transitions.get("bgm")).toBeDefined();
+  });
+
+  it("allows exit tracks to end away from the node's declared value", () => {
+    expect(() =>
+      normalizeAudioRenderState({
+        audio: [
+          soundWithTransition({
+            exit: { volume: track(0) },
+          }),
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts inline and legacy transitions when they target different nodes", () => {
+    const normalized = normalizeAudioRenderState({
+      audio: [
+        soundWithTransition({ enter: { volume: track(80) } }),
+        { id: "sfx", type: "sound", src: "click" },
+      ],
+      audioEffects: [
+        {
+          id: "legacy-sfx",
+          type: "audio-transition",
+          targetId: "sfx",
+          properties: { volume: { exit: track(0) } },
+        },
+      ],
+    });
+
+    expect([...normalized.transitions.keys()]).toEqual(["sfx", "bgm"]);
+  });
+
+  it("rejects inline and legacy transitions targeting the same node", () => {
+    expect(() =>
+      normalizeAudioRenderState({
+        audio: [soundWithTransition({ enter: { volume: track(80) } })],
+        audioEffects: [
+          {
+            id: "legacy-bgm",
+            type: "audio-transition",
+            targetId: "bgm",
+            properties: { volume: { exit: track(0) } },
+          },
+        ],
+      }),
+    ).toThrow("cannot define both inline transition and legacy");
+  });
+
+  it.each([
+    ["an empty transition", {}, "must be a non-empty object"],
+    [
+      "an unknown lifecycle",
+      { pause: { volume: track(80) } },
+      'unsupported inline audio transition phase "pause"',
+    ],
+    ["an empty lifecycle", { enter: {} }, "must be a non-empty object"],
+    [
+      "an unknown property",
+      { enter: { pitch: track(80) } },
+      'unsupported inline audio transition property "pitch"',
+    ],
+    [
+      "an empty keyframe list",
+      { enter: { volume: { keyframes: [] } } },
+      "keyframes must be a non-empty array",
+    ],
+    [
+      "an unknown track field",
+      {
+        enter: { volume: { keyframes: [{ value: 80, duration: 1 }], hold: 2 } },
+      },
+      'unsupported audio transition field "hold"',
+    ],
+    [
+      "an unknown keyframe field",
+      { enter: { volume: track(80, { offset: 1 }) } },
+      'unsupported audio transition keyframe field "offset"',
+    ],
+    [
+      "a missing keyframe value",
+      { enter: { volume: { keyframes: [{ duration: 1 }] } } },
+      "value is required",
+    ],
+    [
+      "a missing keyframe duration",
+      { enter: { volume: { keyframes: [{ value: 80 }] } } },
+      "duration is required",
+    ],
+    [
+      "a negative delay",
+      { enter: { volume: track(80, { delay: -1 }) } },
+      "must be greater than or equal to 0",
+    ],
+    [
+      "a non-finite delay",
+      { enter: { volume: track(80, { delay: Number.POSITIVE_INFINITY }) } },
+      "must be a finite number",
+    ],
+    [
+      "a non-finite duration",
+      { enter: { volume: track(80, { duration: Number.NaN }) } },
+      "must be a number",
+    ],
+    [
+      "a non-finite value",
+      { enter: { volume: track(Number.NEGATIVE_INFINITY) } },
+      "must be a finite number",
+    ],
+    [
+      "an unsupported easing",
+      { enter: { volume: track(80, { easing: "smooth" }) } },
+      'easing "smooth" is not supported',
+    ],
+    [
+      "a non-boolean relative flag",
+      { enter: { volume: track(80, { relative: 1 }) } },
+      "relative must be a boolean",
+    ],
+    [
+      "an out-of-range absolute volume",
+      { enter: { volume: track(101) } },
+      "must be less than or equal to 100",
+    ],
+    [
+      "a relative final enter keyframe",
+      { enter: { volume: track(80, { relative: true }) } },
+      "must end with an absolute value",
+    ],
+    [
+      "an enter endpoint that differs from the node value",
+      { enter: { volume: track(40) } },
+      "must end at the node's declared volume value 80",
+    ],
+    [
+      "an update endpoint that differs from the node value",
+      { update: { playbackRate: track(1) } },
+      "must end at the node's declared playbackRate value 1.5",
+    ],
+  ])("rejects %s", (_name, transition, message) => {
+    expect(() =>
+      normalizeAudioRenderState({
+        audio: [soundWithTransition(transition)],
+      }),
+    ).toThrow(message);
+  });
+
+  it("rejects playback-rate automation on channels", () => {
+    expect(() =>
+      normalizeAudioRenderState({
+        audio: [
+          {
+            id: "music",
+            type: "audio-channel",
+            transition: { exit: { playbackRate: track(0) } },
+          },
+        ],
+      }),
+    ).toThrow('is not supported for node type "audio-channel"');
+  });
+});

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -871,11 +871,6 @@ const createSourceForSound = (sound, startOffset = sound.startAt ?? 0) => {
   source.buffer = audioBuffer;
   source.loop = sound.loop ?? false;
 
-  const pendingEnterTransitions = applyPendingSoundEnterTransitions(
-    sound,
-    source,
-  );
-
   connect(source, sound.gainNode);
 
   sound.sourceEnded = false;
@@ -906,6 +901,10 @@ const createSourceForSound = (sound, startOffset = sound.startAt ?? 0) => {
   } else {
     source.start(startTime, offset);
   }
+  const pendingEnterTransitions = applyPendingSoundEnterTransitions(
+    sound,
+    source,
+  );
   consumePendingSoundEnterTransitions(sound, pendingEnterTransitions);
   debugAudio("source started", {
     id: sound.id,
@@ -1468,11 +1467,6 @@ export const createAudioStage = () => {
     const source = context.createBufferSource();
     source.buffer = control.decodedBuffer;
     configureControlledLoop(instance, source);
-
-    const pendingEnterTransitions = applyPendingSoundEnterTransitions(
-      instance,
-      source,
-    );
     connect(source, instance.gainNode);
 
     const sourceToken = control.sourceToken + 1;
@@ -1544,6 +1538,10 @@ export const createAudioStage = () => {
       disconnect(source);
       throw error;
     }
+    const pendingEnterTransitions = applyPendingSoundEnterTransitions(
+      instance,
+      source,
+    );
     consumePendingSoundEnterTransitions(instance, pendingEnterTransitions);
 
     return source;

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -736,7 +736,13 @@ const applyPendingSoundEnterTransitions = (sound, source) => {
       transition: null,
     });
   }
-  sound.pendingEnterTransitions = null;
+  return transitions;
+};
+
+const consumePendingSoundEnterTransitions = (sound, transitions) => {
+  if (sound.pendingEnterTransitions === transitions) {
+    sound.pendingEnterTransitions = null;
+  }
 };
 
 const createChannelInstance = (channel, outputNode) => {
@@ -865,7 +871,10 @@ const createSourceForSound = (sound, startOffset = sound.startAt ?? 0) => {
   source.buffer = audioBuffer;
   source.loop = sound.loop ?? false;
 
-  applyPendingSoundEnterTransitions(sound, source);
+  const pendingEnterTransitions = applyPendingSoundEnterTransitions(
+    sound,
+    source,
+  );
 
   connect(source, sound.gainNode);
 
@@ -897,6 +906,7 @@ const createSourceForSound = (sound, startOffset = sound.startAt ?? 0) => {
   } else {
     source.start(startTime, offset);
   }
+  consumePendingSoundEnterTransitions(sound, pendingEnterTransitions);
   debugAudio("source started", {
     id: sound.id,
     src: sound.src,
@@ -1459,7 +1469,10 @@ export const createAudioStage = () => {
     source.buffer = control.decodedBuffer;
     configureControlledLoop(instance, source);
 
-    applyPendingSoundEnterTransitions(instance, source);
+    const pendingEnterTransitions = applyPendingSoundEnterTransitions(
+      instance,
+      source,
+    );
     connect(source, instance.gainNode);
 
     const sourceToken = control.sourceToken + 1;
@@ -1531,6 +1544,7 @@ export const createAudioStage = () => {
       disconnect(source);
       throw error;
     }
+    consumePendingSoundEnterTransitions(instance, pendingEnterTransitions);
 
     return source;
   };

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -1202,9 +1202,14 @@ export const createAudioStage = () => {
     const control = instance.control;
     if (!control) return 0;
 
+    const context = getAudioContext();
     control.cursorMs = getControlledPositionMs(instance);
     control.sourceCursorMs = control.cursorMs;
-    control.sourceStartedAt = getAudioContext().currentTime;
+    control.sourceStartedAt = context.currentTime;
+    instance.sourceStartOffset =
+      Math.max(0, toFiniteParamValue(instance.startAt, 0)) +
+      control.cursorMs / 1000;
+    instance.sourceStartedAt = context.currentTime;
     return control.cursorMs;
   };
 

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -191,6 +191,15 @@ const buildAudioTimeline = ({
   ];
 
   for (const keyframe of transition.keyframes) {
+    const delayMs = Math.max(0, toFiniteParamValue(keyframe.delay, 0));
+    if (delayMs > 0) {
+      elapsedMs += delayMs;
+      timeline.push({
+        time: elapsedMs,
+        value: timeline[timeline.length - 1].value,
+        easing: "linear",
+      });
+    }
     elapsedMs += Math.max(0, toFiniteParamValue(keyframe.duration, 0));
     const nextAuthoredValue = keyframe.relative
       ? authoredValue + keyframe.value
@@ -296,6 +305,69 @@ const rampParam = ({
   return timeline[timeline.length - 1].time;
 };
 
+const applyDeferredTimeline = ({
+  param,
+  automation,
+  normalizeParamValue,
+  context = getAudioContext(),
+}) => {
+  if (!param || !automation) return 0;
+
+  const now = context.currentTime;
+  const elapsedMs = Math.max(0, (now - automation.startTime) * 1000);
+  const { timeline } = automation;
+  const currentValue = normalizeParamValue(
+    getTimelineValueAtTime(timeline, elapsedMs),
+  );
+
+  if (typeof param.cancelScheduledValues === "function") {
+    param.cancelScheduledValues(now);
+  }
+  setParamAtTime(param, currentValue, now);
+
+  for (let index = 1; index < timeline.length; index++) {
+    const start = timeline[index - 1];
+    const end = timeline[index];
+    if (end.time <= elapsedMs) continue;
+
+    const durationMs = end.time - start.time;
+    const endTime = automation.startTime + end.time / 1000;
+    if (
+      durationMs <= 0 ||
+      typeof param.linearRampToValueAtTime !== "function"
+    ) {
+      setParamAtTime(param, end.value, endTime);
+      continue;
+    }
+
+    if (end.easing === "linear") {
+      param.linearRampToValueAtTime(end.value, endTime);
+      continue;
+    }
+
+    const easing = getEasingFunction(end.easing);
+    const sampleCount = Math.min(
+      AUDIO_AUTOMATION_MAX_SAMPLES,
+      Math.max(1, Math.ceil(durationMs / AUDIO_AUTOMATION_SAMPLE_INTERVAL_MS)),
+    );
+    for (let sample = 1; sample <= sampleCount; sample++) {
+      const progress = sample / sampleCount;
+      const sampleElapsedMs = start.time + durationMs * progress;
+      if (sampleElapsedMs <= elapsedMs) continue;
+      const value = normalizeParamValue(
+        start.value + (end.value - start.value) * easing(progress),
+      );
+      param.linearRampToValueAtTime(
+        value,
+        automation.startTime + sampleElapsedMs / 1000,
+      );
+    }
+  }
+
+  audioParamAutomation.set(param, automation);
+  return Math.max(0, timeline[timeline.length - 1].time - elapsedMs);
+};
+
 const createGainNode = (value = 1) => {
   const context = getAudioContext();
   const node = context.createGain();
@@ -314,8 +386,9 @@ const createPannerNode = (pan = 0) => {
   return node;
 };
 
-const getVolumeValue = ({ volume, muted }) =>
-  muted ? 0 : normalizeVolume(volume, 100);
+const getVolumeValue = ({ volume }) => normalizeVolume(volume, 100);
+
+const getMuteValue = ({ muted }) => (muted ? 0 : 1);
 
 const hasSameSoundSourceIdentity = (previous, next) =>
   previous.src === next.src &&
@@ -339,6 +412,10 @@ const normalizeDirectVolume = (volume, fallback = 1) => {
 };
 
 const getTransitionPhase = (effects = [], targetId, property, phase) => {
+  if (effects instanceof Map) {
+    return effects.get(targetId)?.[property]?.[phase] ?? null;
+  }
+
   const transition = effects.find(
     (effect) =>
       effect.type === "audio-transition" && effect.targetId === targetId,
@@ -347,22 +424,13 @@ const getTransitionPhase = (effects = [], targetId, property, phase) => {
   return transition?.properties?.[property]?.[phase] ?? null;
 };
 
-const getTransitionDuration = (transition) =>
-  transition?.keyframes?.reduce(
-    (duration, keyframe) =>
-      duration + Math.max(0, toFiniteParamValue(keyframe.duration, 0)),
-    0,
-  ) ?? 0;
-
-const getLoopEndDelayMs = (sound, context = getAudioContext()) => {
+const getRemainingIterationMediaSeconds = (
+  sound,
+  context = getAudioContext(),
+) => {
   const source = sound.source;
-  if (!source?.loop) {
+  if (!source) {
     return null;
-  }
-
-  const playbackRate = getCurrentParamValue(source.playbackRate, context);
-  if (playbackRate <= 0) {
-    return Number.POSITIVE_INFINITY;
   }
 
   const configuredLoopEnd =
@@ -381,11 +449,11 @@ const getLoopEndDelayMs = (sound, context = getAudioContext()) => {
     : toFiniteParamValue(source.loopEnd, 0) > loopStart
       ? toFiniteParamValue(source.loopEnd, 0)
       : bufferDuration;
-  const loopDuration = loopEnd - loopStart;
-  if (!Number.isFinite(loopDuration) || loopDuration < 0) {
+  const iterationDuration = loopEnd - loopStart;
+  if (!Number.isFinite(iterationDuration) || iterationDuration < 0) {
     return null;
   }
-  if (loopDuration === 0) {
+  if (iterationDuration === 0) {
     return 0;
   }
 
@@ -393,17 +461,121 @@ const getLoopEndDelayMs = (sound, context = getAudioContext()) => {
     sound.sourceStartedAt,
     context.currentTime,
   );
-  const elapsedSeconds = Math.max(0, context.currentTime - startedAt);
+  const progressedMediaSeconds = integrateAudioParamValue(
+    source.playbackRate,
+    startedAt,
+    context.currentTime,
+  );
   const startOffset = toFiniteParamValue(sound.sourceStartOffset, loopStart);
-  const elapsedInLoop =
-    (Math.max(0, startOffset - loopStart) + elapsedSeconds * playbackRate) %
-    loopDuration;
-  const remainingInLoop =
-    elapsedSeconds > 0 && elapsedInLoop === 0
-      ? 0
-      : loopDuration - elapsedInLoop;
+  const absoluteOffset = startOffset + progressedMediaSeconds;
+  if (!source.loop) {
+    return Math.max(0, loopEnd - Math.min(absoluteOffset, loopEnd));
+  }
 
-  return (remainingInLoop / playbackRate) * 1000;
+  const elapsedInIteration =
+    (((absoluteOffset - loopStart) % iterationDuration) + iterationDuration) %
+    iterationDuration;
+  if (progressedMediaSeconds > 0 && elapsedInIteration === 0) {
+    return 0;
+  }
+  return iterationDuration - elapsedInIteration;
+};
+
+const integrateTimelineRange = (timeline, startMs, endMs, normalizeValue) => {
+  const durationMs = Math.max(0, endMs - startMs);
+  if (durationMs === 0) return 0;
+
+  const sampleCount = Math.min(
+    AUDIO_AUTOMATION_MAX_SAMPLES,
+    Math.max(1, Math.ceil(durationMs / AUDIO_AUTOMATION_SAMPLE_INTERVAL_MS)),
+  );
+  const sampleDurationMs = durationMs / sampleCount;
+  let progressSeconds = 0;
+  for (let sample = 0; sample < sampleCount; sample++) {
+    const sampleTimeMs = startMs + (sample + 0.5) * sampleDurationMs;
+    const rate = normalizeValue(getTimelineValueAtTime(timeline, sampleTimeMs));
+    progressSeconds += Math.max(0, rate) * (sampleDurationMs / 1000);
+  }
+  return progressSeconds;
+};
+
+const getTimeToMediaProgressMs = (
+  param,
+  requiredProgressSeconds,
+  context = getAudioContext(),
+) => {
+  if (requiredProgressSeconds <= 0) return 0;
+
+  const automation = audioParamAutomation.get(param);
+  if (!automation) {
+    const rate = Math.max(0, getParamValue(param, 1));
+    return rate > 0
+      ? (requiredProgressSeconds / rate) * 1000
+      : Number.POSITIVE_INFINITY;
+  }
+
+  const elapsedMs = Math.max(
+    0,
+    (context.currentTime - automation.startTime) * 1000,
+  );
+  const timelineEndMs =
+    automation.timeline[automation.timeline.length - 1].time;
+  const scheduledEndMs = Math.max(elapsedMs, timelineEndMs);
+  const scheduledProgress = integrateTimelineRange(
+    automation.timeline,
+    elapsedMs,
+    scheduledEndMs,
+    automation.normalizeValue,
+  );
+
+  if (scheduledProgress >= requiredProgressSeconds) {
+    let lowMs = elapsedMs;
+    let highMs = scheduledEndMs;
+    for (let iteration = 0; iteration < 48; iteration++) {
+      const midpointMs = (lowMs + highMs) / 2;
+      const progress = integrateTimelineRange(
+        automation.timeline,
+        elapsedMs,
+        midpointMs,
+        automation.normalizeValue,
+      );
+      if (progress >= requiredProgressSeconds) {
+        highMs = midpointMs;
+      } else {
+        lowMs = midpointMs;
+      }
+    }
+    return Math.max(0, highMs - elapsedMs);
+  }
+
+  const finalRate = Math.max(
+    0,
+    automation.normalizeValue(
+      getTimelineValueAtTime(automation.timeline, timelineEndMs),
+    ),
+  );
+  if (finalRate <= 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  return (
+    Math.max(0, timelineEndMs - elapsedMs) +
+    ((requiredProgressSeconds - scheduledProgress) / finalRate) * 1000
+  );
+};
+
+const hasContinuingPlaybackProgress = (param) => {
+  const automation = audioParamAutomation.get(param);
+  if (!automation) {
+    return getParamValue(param, 1) > 0;
+  }
+
+  const timelineEndMs =
+    automation.timeline[automation.timeline.length - 1].time;
+  const finalRate = automation.normalizeValue(
+    getTimelineValueAtTime(automation.timeline, timelineEndMs),
+  );
+  return finalRate > 0;
 };
 
 const applyAudioParam = ({
@@ -452,25 +624,135 @@ const applyPan = ({ pannerNode, targetValue, transition }) =>
       Math.max(-1, Math.min(1, toFiniteParamValue(value, 0))),
   });
 
+const normalizePlaybackRateValue = (value) =>
+  Math.max(0, toFiniteParamValue(value, 1));
+
 const applyPlaybackRate = ({ source, targetValue, transition }) =>
   applyAudioParam({
     param: source?.playbackRate,
     targetValue,
     transition,
-    normalizeTargetValue: (value) => Math.max(0, toFiniteParamValue(value, 1)),
+    normalizeTargetValue: normalizePlaybackRateValue,
   });
+
+const getPlaybackRateAutomationValue = (sound, context = getAudioContext()) => {
+  const automation = sound.playbackRateAutomation;
+  if (!automation) {
+    return normalizePlaybackRateValue(sound.playbackRate);
+  }
+
+  const elapsedMs = Math.max(
+    0,
+    (context.currentTime - automation.startTime) * 1000,
+  );
+  return normalizePlaybackRateValue(
+    getTimelineValueAtTime(automation.timeline, elapsedMs),
+  );
+};
+
+const startPlaybackRateAutomation = ({ sound, transition, currentValue }) => {
+  if (!transition) {
+    sound.playbackRateAutomation = null;
+    return 0;
+  }
+
+  const context = getAudioContext();
+  const timeline = buildAudioTimeline({
+    transition,
+    currentValue,
+    normalizeTransitionValue: normalizePlaybackRateValue,
+    denormalizeParamValue: (value) => value,
+  });
+  sound.playbackRateAutomation = {
+    startTime: context.currentTime,
+    timeline,
+    normalizeValue: normalizePlaybackRateValue,
+  };
+  return timeline[timeline.length - 1].time;
+};
+
+const applySoundPlaybackRateTransition = ({
+  sound,
+  transition,
+  currentValue,
+}) => {
+  if (sound.source) {
+    const duration = applyPlaybackRate({
+      source: sound.source,
+      targetValue: sound.playbackRate,
+      transition,
+    });
+    sound.playbackRateAutomation = transition
+      ? (audioParamAutomation.get(sound.source.playbackRate) ?? null)
+      : null;
+    return duration;
+  }
+
+  return startPlaybackRateAutomation({
+    sound,
+    transition,
+    currentValue:
+      currentValue ?? getPlaybackRateAutomationValue(sound, getAudioContext()),
+  });
+};
+
+const applyPendingSoundEnterTransitions = (sound, source) => {
+  const transitions = sound.pendingEnterTransitions;
+  if (transitions) {
+    if (transitions.volume) {
+      applyVolume({
+        gainNode: sound.gainNode,
+        targetValue: getVolumeValue(sound),
+        transition: transitions.volume,
+      });
+    }
+    if (transitions.pan) {
+      applyPan({
+        pannerNode: sound.pannerNode,
+        targetValue: sound.pan,
+        transition: transitions.pan,
+      });
+    }
+  }
+
+  if (transitions?.playbackRate) {
+    applyPlaybackRate({
+      source,
+      targetValue: sound.playbackRate ?? 1,
+      transition: transitions.playbackRate,
+    });
+    sound.playbackRateAutomation =
+      audioParamAutomation.get(source?.playbackRate) ?? null;
+  } else if (sound.playbackRateAutomation) {
+    applyDeferredTimeline({
+      param: source?.playbackRate,
+      automation: sound.playbackRateAutomation,
+      normalizeParamValue: normalizePlaybackRateValue,
+    });
+  } else {
+    applyPlaybackRate({
+      source,
+      targetValue: sound.playbackRate ?? 1,
+      transition: null,
+    });
+  }
+  sound.pendingEnterTransitions = null;
+};
 
 const createChannelInstance = (channel, outputNode) => {
   const gainNode = createGainNode(getVolumeValue(channel));
   const pannerNode = createPannerNode(channel.pan ?? 0);
+  const muteGainNode = createGainNode(getMuteValue(channel));
 
-  connect(gainNode, pannerNode ?? outputNode);
-  if (pannerNode) connect(pannerNode, outputNode);
+  connect(gainNode, pannerNode ?? muteGainNode);
+  if (pannerNode) connect(pannerNode, muteGainNode);
+  connect(muteGainNode, outputNode);
 
   return {
     id: channel.id,
     gainNode,
     pannerNode,
+    muteGainNode,
     volume: channel.volume ?? 100,
     muted: channel.muted ?? false,
     pan: channel.pan ?? 0,
@@ -492,9 +774,11 @@ const createChannelInstance = (channel, outputNode) => {
 const createSoundInstance = ({ sound, channelNode, internalId }) => {
   const gainNode = createGainNode(getVolumeValue(sound));
   const pannerNode = createPannerNode(sound.pan ?? 0);
+  const muteGainNode = createGainNode(getMuteValue(sound));
 
-  connect(gainNode, pannerNode ?? channelNode);
-  if (pannerNode) connect(pannerNode, channelNode);
+  connect(gainNode, pannerNode ?? muteGainNode);
+  if (pannerNode) connect(pannerNode, muteGainNode);
+  connect(muteGainNode, channelNode);
 
   return {
     internalId,
@@ -513,6 +797,7 @@ const createSoundInstance = ({ sound, channelNode, internalId }) => {
     channelNode,
     gainNode,
     pannerNode,
+    muteGainNode,
     source: null,
     sourceStartedAt: null,
     sourceStartOffset: sound.startAt ?? 0,
@@ -521,7 +806,8 @@ const createSoundInstance = ({ sound, channelNode, internalId }) => {
     onFinishingSourceStarted: null,
     finishing: false,
     finishingCallbacks: new Set(),
-    playbackRateTransition: null,
+    pendingEnterTransitions: null,
+    playbackRateAutomation: null,
     playbackPending: false,
     pendingTimeoutId: null,
     pendingDelayMs: 0,
@@ -579,12 +865,7 @@ const createSourceForSound = (sound, startOffset = sound.startAt ?? 0) => {
   source.buffer = audioBuffer;
   source.loop = sound.loop ?? false;
 
-  applyPlaybackRate({
-    source,
-    targetValue: sound.playbackRate ?? 1,
-    transition: sound.playbackRateTransition,
-  });
-  sound.playbackRateTransition = null;
+  applyPendingSoundEnterTransitions(sound, source);
 
   connect(source, sound.gainNode);
 
@@ -732,6 +1013,8 @@ const stopSource = (sound, delayMs = 0) => {
 
 const cleanupSound = (sound) => {
   sound.onSourceEnded = null;
+  sound.pendingEnterTransitions = null;
+  sound.playbackRateAutomation = null;
 
   if (sound.control) {
     sound.control.decodeRequestId += 1;
@@ -757,6 +1040,7 @@ const cleanupSound = (sound) => {
   disconnect(sound.source);
   disconnect(sound.gainNode);
   disconnect(sound.pannerNode);
+  disconnect(sound.muteGainNode);
 };
 
 const cleanupChannel = (channel) => {
@@ -766,6 +1050,7 @@ const cleanupChannel = (channel) => {
   }
   disconnect(channel.gainNode);
   disconnect(channel.pannerNode);
+  disconnect(channel.muteGainNode);
 };
 
 const schedule = (callback, delayMs) => {
@@ -1174,12 +1459,7 @@ export const createAudioStage = () => {
     source.buffer = control.decodedBuffer;
     configureControlledLoop(instance, source);
 
-    applyPlaybackRate({
-      source,
-      targetValue: instance.playbackRate ?? 1,
-      transition: instance.playbackRateTransition,
-    });
-    instance.playbackRateTransition = null;
+    applyPendingSoundEnterTransitions(instance, source);
     connect(source, instance.gainNode);
 
     const sourceToken = control.sourceToken + 1;
@@ -2059,6 +2339,7 @@ export const createAudioStage = () => {
       const currentVolumeValue = getVolumeValue(existing);
       const nextVolumeValue = getVolumeValue(channel);
       const volumeChanged = currentVolumeValue !== nextVolumeValue;
+      const mutedChanged = existing.muted !== channel.muted;
       const panChanged = existing.pan !== (channel.pan ?? 0);
       const loopInterrupted = existing.loop && !channel.loop;
 
@@ -2095,6 +2376,9 @@ export const createAudioStage = () => {
           targetValue: channel.pan,
           transition: panTransition,
         });
+      }
+      if (mutedChanged) {
+        setParamNow(existing.muteGainNode.gain, getMuteValue(channel));
       }
       return existing;
     }
@@ -2138,8 +2422,12 @@ export const createAudioStage = () => {
   const connectSoundToChannel = (instance, channelNode) => {
     disconnect(instance.gainNode);
     disconnect(instance.pannerNode);
-    connect(instance.gainNode, instance.pannerNode ?? channelNode);
-    if (instance.pannerNode) connect(instance.pannerNode, channelNode);
+    disconnect(instance.muteGainNode);
+    connect(instance.gainNode, instance.pannerNode ?? instance.muteGainNode);
+    if (instance.pannerNode) {
+      connect(instance.pannerNode, instance.muteGainNode);
+    }
+    connect(instance.muteGainNode, channelNode);
     instance.channelNode = channelNode;
   };
 
@@ -2190,29 +2478,16 @@ export const createAudioStage = () => {
     currentSoundKeyById.set(sound.id, internalId);
     bindChannelLoopCompletion(instance);
 
-    const volumeTransition = getTransitionPhase(
-      effects,
-      sound.id,
-      "volume",
-      phase,
-    );
-    const panTransition = getTransitionPhase(effects, sound.id, "pan", phase);
-    applyVolume({
-      gainNode: instance.gainNode,
-      targetValue: getVolumeValue(sound),
-      transition: volumeTransition,
-    });
-    applyPan({
-      pannerNode: instance.pannerNode,
-      targetValue: sound.pan,
-      transition: panTransition,
-    });
-    instance.playbackRateTransition = getTransitionPhase(
-      effects,
-      sound.id,
-      "playbackRate",
-      phase,
-    );
+    instance.pendingEnterTransitions = {
+      volume: getTransitionPhase(effects, sound.id, "volume", phase),
+      pan: getTransitionPhase(effects, sound.id, "pan", phase),
+      playbackRate: getTransitionPhase(
+        effects,
+        sound.id,
+        "playbackRate",
+        phase,
+      ),
+    };
     if (instance.control) {
       acceptControlledCommand(instance, sound.playback);
     } else if (parentChannel.control?.status === "paused") {
@@ -2224,6 +2499,7 @@ export const createAudioStage = () => {
   };
 
   const applySoundExitTransitions = (instance, effects) => {
+    instance.pendingEnterTransitions = null;
     const volumeTransition = getTransitionPhase(
       effects,
       instance.id,
@@ -2258,16 +2534,10 @@ export const createAudioStage = () => {
       : 0;
     let playbackRateDuration = 0;
     if (playbackRateTransition) {
-      if (instance.source) {
-        playbackRateDuration = applyPlaybackRate({
-          source: instance.source,
-          targetValue: instance.playbackRate,
-          transition: playbackRateTransition,
-        });
-      } else {
-        instance.playbackRateTransition = playbackRateTransition;
-        playbackRateDuration = getTransitionDuration(playbackRateTransition);
-      }
+      playbackRateDuration = applySoundPlaybackRateTransition({
+        sound: instance,
+        transition: playbackRateTransition,
+      });
     }
 
     return Math.max(volumeDuration, panDuration, playbackRateDuration);
@@ -2277,6 +2547,7 @@ export const createAudioStage = () => {
     if (!instance) return 0;
 
     instance.finishing = false;
+    instance.pendingEnterTransitions = null;
     instance.finishingCallbacks.clear();
     instance.onSourceEnded = null;
 
@@ -2308,9 +2579,8 @@ export const createAudioStage = () => {
       targetValue: instance.pan,
       transition: panTransition,
     });
-    const playbackRateDuration = applyPlaybackRate({
-      source: instance.source,
-      targetValue: instance.playbackRate,
+    const playbackRateDuration = applySoundPlaybackRateTransition({
+      sound: instance,
       transition: playbackRateTransition,
     });
     const ownDuration = Math.max(
@@ -2346,12 +2616,17 @@ export const createAudioStage = () => {
     }
 
     instance.finishing = true;
-    const loopEndDelayMs = getLoopEndDelayMs(instance);
+    const transitionStartTime = getAudioContext().currentTime;
+    const remainingMediaAtInterruption =
+      getRemainingIterationMediaSeconds(instance);
     const exitDuration = applySoundExitTransitions(instance, effects);
+    const exitDeadlineTime = transitionStartTime + exitDuration / 1000;
     instance.loop = false;
+    let transitionComplete = exitDuration <= 0;
+    let tailComplete = false;
 
     const cleanupFinishedSound = () => {
-      if (!instance.finishing) {
+      if (!instance.finishing || !transitionComplete || !tailComplete) {
         return;
       }
 
@@ -2366,9 +2641,14 @@ export const createAudioStage = () => {
       }
       finishingCallbacks.forEach((callback) => callback());
     };
-    const stopAndCleanupAfterExit = () => {
-      stopSource(instance, exitDuration);
-      instance.cleanupTimeoutId = schedule(cleanupFinishedSound, exitDuration);
+    const completeTailWithoutLoopEnd = () => {
+      const remainingExitMs = Math.max(
+        0,
+        (exitDeadlineTime - getAudioContext().currentTime) * 1000,
+      );
+      stopSource(instance, remainingExitMs);
+      tailComplete = true;
+      cleanupFinishedSound();
     };
     const finishActiveSource = () => {
       instance.onFinishingSourceStarted = null;
@@ -2376,37 +2656,61 @@ export const createAudioStage = () => {
         return;
       }
       if (!instance.source || instance.sourceEnded) {
+        tailComplete = true;
         cleanupFinishedSound();
         return;
       }
 
-      const playbackRate = getCurrentParamValue(
+      const remainingMediaSeconds =
+        remainingMediaAtInterruption ??
+        getRemainingIterationMediaSeconds(instance);
+      if (remainingMediaSeconds === null) {
+        if (!hasContinuingPlaybackProgress(instance.source.playbackRate)) {
+          completeTailWithoutLoopEnd();
+          return;
+        }
+        instance.source.loop = false;
+        return;
+      }
+
+      const loopEndDelayMs = getTimeToMediaProgressMs(
         instance.source.playbackRate,
+        remainingMediaSeconds,
         getAudioContext(),
       );
-      if (playbackRate <= 0 || loopEndDelayMs === Number.POSITIVE_INFINITY) {
-        stopAndCleanupAfterExit();
+      if (!Number.isFinite(loopEndDelayMs)) {
+        completeTailWithoutLoopEnd();
         return;
       }
 
       instance.source.loop = false;
-      if (loopEndDelayMs !== null) {
-        try {
-          instance.source.stop(
-            getAudioContext().currentTime + loopEndDelayMs / 1000,
-          );
-        } catch {
-          cleanupFinishedSound();
-        }
+      try {
+        const stopTime = getAudioContext().currentTime + loopEndDelayMs / 1000;
+        instance.source.stop(Number(stopTime.toFixed(9)));
+      } catch {
+        tailComplete = true;
+        cleanupFinishedSound();
       }
     };
 
+    if (exitDuration > 0) {
+      instance.cleanupTimeoutId = schedule(() => {
+        transitionComplete = true;
+        cleanupFinishedSound();
+      }, exitDuration);
+    }
+
     if (getAudioContext().state !== "running") {
+      transitionComplete = true;
+      tailComplete = true;
       cleanupFinishedSound();
       return;
     }
 
-    instance.onSourceEnded = cleanupFinishedSound;
+    instance.onSourceEnded = () => {
+      tailComplete = true;
+      cleanupFinishedSound();
+    };
     if (
       waitForPendingPlayback &&
       (instance.playbackPending || instance.pendingTimeoutId !== null)
@@ -2415,6 +2719,7 @@ export const createAudioStage = () => {
       return;
     }
     if (!instance.source || instance.sourceEnded) {
+      tailComplete = true;
       cleanupFinishedSound();
       return;
     }
@@ -2426,11 +2731,25 @@ export const createAudioStage = () => {
     const currentVolumeValue = getVolumeValue(instance);
     const nextVolumeValue = getVolumeValue(sound);
     const volumeChanged = currentVolumeValue !== nextVolumeValue;
+    const mutedChanged = instance.muted !== sound.muted;
     const panChanged = instance.pan !== sound.pan;
     const loopChanged = instance.loop !== sound.loop;
     const playbackRateChanged = instance.playbackRate !== sound.playbackRate;
     const startDelayChanged = instance.startDelayMs !== sound.startDelayMs;
     const sourceBeforeUpdate = instance.source;
+    const currentPlaybackRateValue = instance.source
+      ? getCurrentParamValue(instance.source.playbackRate, getAudioContext())
+      : getPlaybackRateAutomationValue(instance, getAudioContext());
+
+    if (volumeChanged && instance.pendingEnterTransitions) {
+      instance.pendingEnterTransitions.volume = null;
+    }
+    if (panChanged && instance.pendingEnterTransitions) {
+      instance.pendingEnterTransitions.pan = null;
+    }
+    if (playbackRateChanged && instance.pendingEnterTransitions) {
+      instance.pendingEnterTransitions.playbackRate = null;
+    }
 
     if (
       instance.control &&
@@ -2497,6 +2816,10 @@ export const createAudioStage = () => {
       });
     }
 
+    if (mutedChanged) {
+      setParamNow(instance.muteGainNode.gain, getMuteValue(sound));
+    }
+
     if (playbackRateChanged) {
       const playbackRateTransition = getTransitionPhase(
         effects,
@@ -2505,15 +2828,22 @@ export const createAudioStage = () => {
         "update",
       );
       if (instance.control && loopChanged && instance.source) {
-        instance.playbackRateTransition = playbackRateTransition;
+        startPlaybackRateAutomation({
+          sound: instance,
+          transition: playbackRateTransition,
+          currentValue: currentPlaybackRateValue,
+        });
       } else if (instance.source) {
-        applyPlaybackRate({
-          source: instance.source,
-          targetValue: sound.playbackRate,
+        applySoundPlaybackRateTransition({
+          sound: instance,
           transition: playbackRateTransition,
         });
       } else {
-        instance.playbackRateTransition = playbackRateTransition;
+        startPlaybackRateAutomation({
+          sound: instance,
+          transition: playbackRateTransition,
+          currentValue: currentPlaybackRateValue,
+        });
       }
     }
 
@@ -2627,6 +2957,8 @@ export const createAudioStage = () => {
     return {
       prev,
       next,
+      prevTransitions: prev.transitions,
+      nextTransitions: next.transitions,
       prevChannelById,
       nextChannelById,
       prevSoundById,
@@ -2643,6 +2975,8 @@ export const createAudioStage = () => {
   } = {}) => {
     const {
       next,
+      prevTransitions,
+      nextTransitions,
       prevChannelById,
       nextChannelById,
       prevSoundById,
@@ -2695,7 +3029,7 @@ export const createAudioStage = () => {
     for (const [id, prevChannel] of prevChannelById) {
       if (!nextChannelById.has(id)) {
         const channel = channels.get(id);
-        const duration = removeChannel(channel, prevAudioEffects);
+        const duration = removeChannel(channel, prevTransitions);
         channelCleanupDurations.set(id, duration);
         if (prevChannel.interruption === "loopEnd" && channel) {
           channel.loop = false;
@@ -2732,7 +3066,7 @@ export const createAudioStage = () => {
     for (const [id, nextChannel] of nextChannelById) {
       ensureChannel(
         nextChannel,
-        nextAudioEffects,
+        nextTransitions,
         prevChannelById.has(id) ? "update" : "enter",
       );
     }
@@ -2752,7 +3086,7 @@ export const createAudioStage = () => {
         if (!finishAtLoopEnd) {
           return removeSoundInstance(
             instance,
-            prevAudioEffects,
+            prevTransitions,
             inheritedDuration,
           );
         }
@@ -2762,11 +3096,11 @@ export const createAudioStage = () => {
           finishSoundForDeferredChannel(
             instance,
             deferredCleanup,
-            prevAudioEffects,
+            prevTransitions,
           );
         } else {
           finishSoundInstance(instance, undefined, {
-            effects: prevAudioEffects,
+            effects: prevTransitions,
             waitForPendingPlayback: true,
           });
         }
@@ -2801,7 +3135,7 @@ export const createAudioStage = () => {
         }
         addSoundInstance({
           sound: nextSound,
-          effects: nextAudioEffects,
+          effects: nextTransitions,
           phase: "enter",
           internalId: `render:${id}:${++soundGeneration}`,
         });
@@ -2812,7 +3146,7 @@ export const createAudioStage = () => {
       if (!prevSoundById.has(id)) {
         addSoundInstance({
           sound: nextSound,
-          effects: nextAudioEffects,
+          effects: nextTransitions,
           phase: "enter",
           internalId: `render:${id}:${++soundGeneration}`,
         });
@@ -2830,7 +3164,7 @@ export const createAudioStage = () => {
         updateSoundInstance({
           instance,
           sound: nextSound,
-          effects: nextAudioEffects,
+          effects: nextTransitions,
         });
       }
     }

--- a/src/schemas/audio/audio-channel.yaml
+++ b/src/schemas/audio/audio-channel.yaml
@@ -37,6 +37,9 @@ properties:
     enum: [immediate, loopEnd]
     description: How active channel playback stops when the channel is interrupted.
     default: immediate
+  transition:
+    $ref: "audio-transition.yaml#/definitions/channelInlineTransition"
+    description: Inline lifecycle automation for channel properties
   playback:
     type: object
     description: Optional cursor-preserving channel transport instruction

--- a/src/schemas/audio/audio-transition.yaml
+++ b/src/schemas/audio/audio-transition.yaml
@@ -77,6 +77,11 @@ definitions:
         type: number
         minimum: 0
         description: Duration to reach this value in milliseconds
+      delay:
+        type: number
+        minimum: 0
+        default: 0
+        description: Time to hold the preceding value before this ramp
       easing:
         $ref: "#/definitions/easing"
       relative:
@@ -161,6 +166,48 @@ definitions:
         minItems: 1
         items:
           $ref: "#/definitions/playbackRateKeyframe"
+    additionalProperties: false
+  soundInlinePhase:
+    type: object
+    minProperties: 1
+    properties:
+      volume:
+        $ref: "#/definitions/volumePhase"
+      pan:
+        $ref: "#/definitions/panPhase"
+      playbackRate:
+        $ref: "#/definitions/playbackRatePhase"
+    additionalProperties: false
+  channelInlinePhase:
+    type: object
+    minProperties: 1
+    properties:
+      volume:
+        $ref: "#/definitions/volumePhase"
+      pan:
+        $ref: "#/definitions/panPhase"
+    additionalProperties: false
+  soundInlineTransition:
+    type: object
+    minProperties: 1
+    properties:
+      enter:
+        $ref: "#/definitions/soundInlinePhase"
+      update:
+        $ref: "#/definitions/soundInlinePhase"
+      exit:
+        $ref: "#/definitions/soundInlinePhase"
+    additionalProperties: false
+  channelInlineTransition:
+    type: object
+    minProperties: 1
+    properties:
+      enter:
+        $ref: "#/definitions/channelInlinePhase"
+      update:
+        $ref: "#/definitions/channelInlinePhase"
+      exit:
+        $ref: "#/definitions/channelInlinePhase"
     additionalProperties: false
   volumeLifecycle:
     type: object

--- a/src/schemas/audio/sound.yaml
+++ b/src/schemas/audio/sound.yaml
@@ -46,6 +46,9 @@ properties:
     description: Playback speed multiplier
     default: 1
     minimum: 0
+  transition:
+    $ref: "audio-transition.yaml#/definitions/soundInlineTransition"
+    description: Inline lifecycle automation for sound properties
   startAt:
     type: number
     description: Start offset in seconds

--- a/src/types.js
+++ b/src/types.js
@@ -733,6 +733,7 @@
  * @property {number} [startAt=0] - Start offset in seconds
  * @property {number|null} [endAt=null] - Optional end time in seconds
  * @property {SoundPlaybackCommand} [playback] - Optional command-controlled playback instruction
+ * @property {InlineAudioTransition} [transition] - Inline lifecycle property automation
  */
 
 /**
@@ -752,12 +753,43 @@
  * @property {'immediate' | 'loopEnd'} [interruption='immediate'] - Whether interruption stops immediately or finishes the active schedule iteration
  * @property {AudioChannelPlaybackCommand} [playback] - Optional cursor-preserving channel transport instruction
  * @property {SoundElement[]} [children=[]] - Sound nodes owned by the channel
+ * @property {InlineAudioTransition} [transition] - Inline lifecycle property automation
+ */
+
+/**
+ * @typedef {Object} InlineAudioTransitionKeyframe
+ * @property {number} value - Absolute target value, or delta when relative is true
+ * @property {number} duration - Ramp duration in milliseconds
+ * @property {number} [delay=0] - Time to hold the preceding value before the ramp
+ * @property {string} [easing="linear"] - Animation easing name
+ * @property {boolean} [relative=false] - Whether value is relative to the previous value
+ */
+
+/**
+ * @typedef {Object} InlineAudioTransitionTrack
+ * @property {number} [initialValue] - Optional starting value before the first keyframe
+ * @property {InlineAudioTransitionKeyframe[]} keyframes - Ordered property keyframes
+ */
+
+/**
+ * @typedef {Object} InlineAudioTransitionPhase
+ * @property {InlineAudioTransitionTrack} [volume] - Volume automation
+ * @property {InlineAudioTransitionTrack} [pan] - Stereo-pan automation
+ * @property {InlineAudioTransitionTrack} [playbackRate] - Playback-rate automation for sounds
+ */
+
+/**
+ * @typedef {Object} InlineAudioTransition
+ * @property {InlineAudioTransitionPhase} [enter] - Automation for creation or incoming replacement
+ * @property {InlineAudioTransitionPhase} [update] - Automation for changed properties
+ * @property {InlineAudioTransitionPhase} [exit] - Automation for removal or outgoing replacement
  */
 
 /**
  * @typedef {Object} AudioTransitionKeyframe
  * @property {number} value - Absolute target value, or delta when relative is true
  * @property {number} duration - Duration to reach this value in milliseconds
+ * @property {number} [delay=0] - Time to hold the preceding value before the ramp
  * @property {string} [easing="linear"] - Animation easing name
  * @property {boolean} [relative=false] - Whether value is relative to the previous value
  */

--- a/src/util/normalizeAudio.js
+++ b/src/util/normalizeAudio.js
@@ -31,6 +31,7 @@ const AUDIO_TRANSITION_PHASE_KEYS = new Set(["initialValue", "keyframes"]);
 const AUDIO_TRANSITION_KEYFRAME_KEYS = new Set([
   "value",
   "duration",
+  "delay",
   "easing",
   "relative",
 ]);
@@ -73,6 +74,14 @@ const assertNumber = (value, path, { min, max } = {}) => {
       `Input error: ${path} must be less than or equal to ${max}.`,
     );
   }
+};
+
+const assertFiniteNumber = (value, path, range) => {
+  assertNumber(value, path);
+  if (!Number.isFinite(value)) {
+    throw new Error(`Input error: ${path} must be a finite number.`);
+  }
+  assertNumber(value, path, range);
 };
 
 const assertOptionalBoolean = (value, path) => {
@@ -160,7 +169,14 @@ const normalizePlaybackCommand = (
   };
 };
 
-const validateSound = (node, path, ids, flattenedSounds, channelId = null) => {
+const validateSound = (
+  node,
+  path,
+  ids,
+  flattenedSounds,
+  inlineTransitions,
+  channelId = null,
+) => {
   assertNonEmptyString(node.id, `${path}.id`);
   assertUniqueId(ids, node.id, `${path}.id`);
   assertNonEmptyString(node.src, `${path}.src`);
@@ -196,6 +212,20 @@ const validateSound = (node, path, ids, flattenedSounds, channelId = null) => {
       ? undefined
       : normalizePlaybackCommand(node.playback, `${path}.playback`);
 
+  if (node.transition !== undefined) {
+    inlineTransitions.set(
+      node.id,
+      validateInlineAudioTransition(node.transition, `${path}.transition`, {
+        nodeType: "sound",
+        propertyValues: {
+          volume,
+          pan: node.pan ?? 0,
+          playbackRate: node.playbackRate ?? 1,
+        },
+      }),
+    );
+  }
+
   flattenedSounds.push({
     id: node.id,
     type: "sound",
@@ -219,6 +249,7 @@ const validateChannel = (
   ids,
   flattenedChannels,
   flattenedSounds,
+  inlineTransitions,
 ) => {
   assertNonEmptyString(node.id, `${path}.id`);
   assertUniqueId(ids, node.id, `${path}.id`);
@@ -246,6 +277,19 @@ const validateChannel = (
           operationList: "pause, resume",
           positionOperations: NO_AUDIO_PLAYBACK_POSITION_OPERATIONS,
         });
+
+  if (node.transition !== undefined) {
+    inlineTransitions.set(
+      node.id,
+      validateInlineAudioTransition(node.transition, `${path}.transition`, {
+        nodeType: "audio-channel",
+        propertyValues: {
+          volume,
+          pan: node.pan ?? 0,
+        },
+      }),
+    );
+  }
 
   flattenedChannels.push({
     id: node.id,
@@ -290,7 +334,14 @@ const validateChannel = (
       );
     }
 
-    validateSound(child, childPath, ids, flattenedSounds, node.id);
+    validateSound(
+      child,
+      childPath,
+      ids,
+      flattenedSounds,
+      inlineTransitions,
+      node.id,
+    );
   }
 };
 
@@ -301,6 +352,7 @@ const validateAudioNodes = (audio, ids) => {
 
   const flattenedChannels = [];
   const flattenedSounds = [];
+  const inlineTransitions = new Map();
   const builtinNodeIds = new Set();
 
   for (const [index, node] of audio.entries()) {
@@ -314,7 +366,14 @@ const validateAudioNodes = (audio, ids) => {
     }
 
     if (node.type === "audio-channel") {
-      validateChannel(node, path, ids, flattenedChannels, flattenedSounds);
+      validateChannel(
+        node,
+        path,
+        ids,
+        flattenedChannels,
+        flattenedSounds,
+        inlineTransitions,
+      );
       builtinNodeIds.add(node.id);
       for (const sound of flattenedSounds) {
         if (sound.channelId === node.id) {
@@ -322,7 +381,7 @@ const validateAudioNodes = (audio, ids) => {
         }
       }
     } else {
-      validateSound(node, path, ids, flattenedSounds);
+      validateSound(node, path, ids, flattenedSounds, inlineTransitions);
       builtinNodeIds.add(node.id);
     }
   }
@@ -330,6 +389,7 @@ const validateAudioNodes = (audio, ids) => {
   return {
     channels: flattenedChannels,
     sounds: flattenedSounds,
+    inlineTransitions,
     builtinNodeIds,
     builtinNodeTypes: new Map(
       [...flattenedChannels, ...flattenedSounds].map((node) => [
@@ -340,7 +400,12 @@ const validateAudioNodes = (audio, ids) => {
   };
 };
 
-const validateTransitionPhase = (phase, path, propertyName) => {
+const validateTransitionPhase = (
+  phase,
+  path,
+  propertyName,
+  { finalValue } = {},
+) => {
   assertRecord(phase, path);
 
   for (const key of Object.keys(phase)) {
@@ -352,7 +417,7 @@ const validateTransitionPhase = (phase, path, propertyName) => {
   }
 
   if (phase.initialValue !== undefined) {
-    assertNumber(
+    assertFiniteNumber(
       phase.initialValue,
       `${path}.initialValue`,
       AUDIO_TRANSITION_PROPERTY_RANGES[propertyName],
@@ -380,7 +445,7 @@ const validateTransitionPhase = (phase, path, propertyName) => {
     if (keyframe.value === undefined) {
       throw new Error(`Input error: ${keyframePath}.value is required.`);
     }
-    assertNumber(
+    assertFiniteNumber(
       keyframe.value,
       `${keyframePath}.value`,
       keyframe.relative
@@ -391,7 +456,13 @@ const validateTransitionPhase = (phase, path, propertyName) => {
     if (keyframe.duration === undefined) {
       throw new Error(`Input error: ${keyframePath}.duration is required.`);
     }
-    assertNumber(keyframe.duration, `${keyframePath}.duration`, { min: 0 });
+    assertFiniteNumber(keyframe.duration, `${keyframePath}.duration`, {
+      min: 0,
+    });
+
+    if (keyframe.delay !== undefined) {
+      assertFiniteNumber(keyframe.delay, `${keyframePath}.delay`, { min: 0 });
+    }
 
     if (keyframe.easing !== undefined && !AUDIO_EASINGS.has(keyframe.easing)) {
       throw new Error(
@@ -401,7 +472,67 @@ const validateTransitionPhase = (phase, path, propertyName) => {
 
     assertOptionalBoolean(keyframe.relative, `${keyframePath}.relative`);
   }
+
+  if (finalValue !== undefined) {
+    const finalKeyframe = phase.keyframes[phase.keyframes.length - 1];
+    if (finalKeyframe.relative === true) {
+      throw new Error(
+        `Input error: ${path}.keyframes must end with an absolute value.`,
+      );
+    }
+    if (finalKeyframe.value !== finalValue) {
+      throw new Error(
+        `Input error: ${path}.keyframes must end at the node's declared ${propertyName} value ${finalValue}.`,
+      );
+    }
+  }
 };
+
+function validateInlineAudioTransition(
+  transition,
+  path,
+  { nodeType, propertyValues },
+) {
+  assertNonEmptyRecord(transition, path);
+  const normalizedProperties = {};
+
+  for (const [phaseName, propertyTracks] of Object.entries(transition)) {
+    if (!AUDIO_TRANSITION_PHASES.has(phaseName)) {
+      throw new Error(
+        `Input error: unsupported inline audio transition phase "${phaseName}" at ${path}.`,
+      );
+    }
+
+    assertNonEmptyRecord(propertyTracks, `${path}.${phaseName}`);
+    for (const [propertyName, track] of Object.entries(propertyTracks)) {
+      if (!AUDIO_TRANSITION_PROPERTIES.has(propertyName)) {
+        throw new Error(
+          `Input error: unsupported inline audio transition property "${propertyName}" at ${path}.${phaseName}.`,
+        );
+      }
+      if (
+        !AUDIO_TRANSITION_PROPERTIES_BY_NODE_TYPE[nodeType].has(propertyName)
+      ) {
+        throw new Error(
+          `Input error: inline audio transition property "${propertyName}" is not supported for node type "${nodeType}" at ${path}.${phaseName}.`,
+        );
+      }
+
+      validateTransitionPhase(
+        track,
+        `${path}.${phaseName}.${propertyName}`,
+        propertyName,
+        phaseName === "enter" || phaseName === "update"
+          ? { finalValue: propertyValues[propertyName] }
+          : {},
+      );
+      normalizedProperties[propertyName] ??= {};
+      normalizedProperties[propertyName][phaseName] = track;
+    }
+  }
+
+  return normalizedProperties;
+}
 
 const validateAudioTransition = (effect, path, nodeTypes) => {
   assertNonEmptyString(effect.targetId, `${path}.targetId`);
@@ -458,6 +589,7 @@ const validateAudioEffects = (audioEffects, ids, nodeTypes) => {
   }
 
   const transitionTargetIds = new Set();
+  const transitions = new Map();
 
   for (const [index, effect] of audioEffects.entries()) {
     const path = `audioEffects[${index}]`;
@@ -479,8 +611,11 @@ const validateAudioEffects = (audioEffects, ids, nodeTypes) => {
         );
       }
       transitionTargetIds.add(effect.targetId);
+      transitions.set(effect.targetId, effect.properties);
     }
   }
+
+  return transitions;
 };
 
 export const flattenAudioNodes = (audio = []) => {
@@ -494,13 +629,27 @@ export const normalizeAudioRenderState = ({
 } = {}) => {
   const ids = new Set();
   const flattened = validateAudioNodes(audio, ids);
-  validateAudioEffects(audioEffects, ids, flattened.builtinNodeTypes);
+  const transitions = validateAudioEffects(
+    audioEffects,
+    ids,
+    flattened.builtinNodeTypes,
+  );
+
+  for (const [targetId, properties] of flattened.inlineTransitions) {
+    if (transitions.has(targetId)) {
+      throw new Error(
+        `Input error: audio node "${targetId}" cannot define both inline transition and legacy audio-transition input.`,
+      );
+    }
+    transitions.set(targetId, properties);
+  }
 
   return {
     audio,
     audioEffects,
     channels: flattened.channels,
     sounds: flattened.sounds,
+    transitions,
   };
 };
 

--- a/vt/specs/audio/channel-pan-transition.yaml
+++ b/vt/specs/audio/channel-pan-transition.yaml
@@ -16,44 +16,37 @@ states:
       - id: music
         type: audio-channel
         pan: 1
+        transition:
+          enter:
+            pan:
+              initialValue: -1
+              keyframes:
+                - { value: 1, duration: 3000, easing: linear }
         children:
           - id: channel-pan-transition-bgm
             type: sound
             src: bgm-1
             loop: true
             volume: 80
-    audioEffects:
-      - id: channel-pan-enter
-        type: audio-transition
-        targetId: music
-        properties:
-          pan:
-            enter:
-              initialValue: -1
-              keyframes:
-                - { value: 1, duration: 3000, easing: linear }
   - id: channel-pan-transition-update
     audio:
       - id: music
         type: audio-channel
         pan: -1
+        transition:
+          update:
+            pan:
+              keyframes:
+                - { value: -1, duration: 3000, easing: linear }
+          exit:
+            pan:
+              keyframes:
+                - { value: 1, duration: 2000, easing: linear }
         children:
           - id: channel-pan-transition-bgm
             type: sound
             src: bgm-1
             loop: true
             volume: 80
-    audioEffects:
-      - id: channel-pan-update-exit
-        type: audio-transition
-        targetId: music
-        properties:
-          pan:
-            update:
-              keyframes:
-                - { value: -1, duration: 3000, easing: linear }
-            exit:
-              keyframes:
-                - { value: 1, duration: 2000, easing: linear }
   - id: channel-pan-transition-exit
     audio: []

--- a/vt/specs/audio/channel-volume-transition.yaml
+++ b/vt/specs/audio/channel-volume-transition.yaml
@@ -16,42 +16,35 @@ states:
       - id: music
         type: audio-channel
         volume: 80
+        transition:
+          enter:
+            volume:
+              initialValue: 0
+              keyframes:
+                - { value: 80, duration: 2000, easing: linear }
         children:
           - id: channel-volume-transition-bgm
             type: sound
             src: bgm-1
             loop: true
-    audioEffects:
-      - id: channel-volume-enter
-        type: audio-transition
-        targetId: music
-        properties:
-          volume:
-            enter:
-              initialValue: 0
-              keyframes:
-                - { value: 80, duration: 2000, easing: linear }
   - id: channel-volume-transition-update
     audio:
       - id: music
         type: audio-channel
         volume: 25
+        transition:
+          update:
+            volume:
+              keyframes:
+                - { value: 25, duration: 2000, easing: linear }
+          exit:
+            volume:
+              keyframes:
+                - { value: 0, duration: 2000, easing: linear }
         children:
           - id: channel-volume-transition-bgm
             type: sound
             src: bgm-1
             loop: true
-    audioEffects:
-      - id: channel-volume-update-exit
-        type: audio-transition
-        targetId: music
-        properties:
-          volume:
-            update:
-              keyframes:
-                - { value: 25, duration: 2000, easing: linear }
-            exit:
-              keyframes:
-                - { value: 0, duration: 2000, easing: linear }
   - id: channel-volume-transition-exit
     audio: []

--- a/vt/specs/audio/longest-exit-transition.yaml
+++ b/vt/specs/audio/longest-exit-transition.yaml
@@ -19,22 +19,16 @@ states:
         volume: 80
         pan: 0
         playbackRate: 1
-    audioEffects:
-      - id: longest-exit-properties
-        type: audio-transition
-        targetId: longest-exit-bgm
-        properties:
-          volume:
-            exit:
+        transition:
+          exit:
+            volume:
               keyframes:
                 - { value: 60, duration: 1000, easing: linear }
                 - { value: 80, duration: 1000, easing: linear }
-          pan:
-            exit:
+            pan:
               keyframes:
                 - { value: 1, duration: 1000, easing: linear }
-          playbackRate:
-            exit:
+            playbackRate:
               keyframes:
                 - { value: 0.75, duration: 1000, easing: linear }
                 - { value: 0.25, duration: 2000, easing: linear }

--- a/vt/specs/audio/playback-rate-transition.yaml
+++ b/vt/specs/audio/playback-rate-transition.yaml
@@ -19,13 +19,9 @@ states:
         loop: true
         volume: 80
         playbackRate: 1
-    audioEffects:
-      - id: playback-rate-enter
-        type: audio-transition
-        targetId: playback-rate-transition-bgm
-        properties:
-          playbackRate:
-            enter:
+        transition:
+          enter:
+            playbackRate:
               initialValue: 0.5
               keyframes:
                 - { value: 1, duration: 3000, easing: linear }
@@ -37,16 +33,13 @@ states:
         loop: true
         volume: 80
         playbackRate: 1.5
-    audioEffects:
-      - id: playback-rate-update-exit
-        type: audio-transition
-        targetId: playback-rate-transition-bgm
-        properties:
-          playbackRate:
-            update:
+        transition:
+          update:
+            playbackRate:
               keyframes:
                 - { value: 1.5, duration: 3000, easing: linear }
-            exit:
+          exit:
+            playbackRate:
               keyframes:
                 - { value: 0.25, duration: 2000, easing: linear }
   - id: playback-rate-transition-exit

--- a/vt/specs/audio/sound-pan-transition.yaml
+++ b/vt/specs/audio/sound-pan-transition.yaml
@@ -19,13 +19,9 @@ states:
         loop: true
         volume: 80
         pan: 1
-    audioEffects:
-      - id: sound-pan-enter
-        type: audio-transition
-        targetId: sound-pan-transition-bgm
-        properties:
-          pan:
-            enter:
+        transition:
+          enter:
+            pan:
               initialValue: -1
               keyframes:
                 - { value: 1, duration: 3000, easing: linear }
@@ -37,16 +33,13 @@ states:
         loop: true
         volume: 80
         pan: -1
-    audioEffects:
-      - id: sound-pan-update-exit
-        type: audio-transition
-        targetId: sound-pan-transition-bgm
-        properties:
-          pan:
-            update:
+        transition:
+          update:
+            pan:
               keyframes:
                 - { value: -1, duration: 3000, easing: linear }
-            exit:
+          exit:
+            pan:
               keyframes:
                 - { value: 1, duration: 2000, easing: linear }
   - id: sound-pan-transition-exit

--- a/vt/specs/audio/sound-volume-transition.yaml
+++ b/vt/specs/audio/sound-volume-transition.yaml
@@ -18,13 +18,9 @@ states:
         src: bgm-1
         loop: true
         volume: 80
-    audioEffects:
-      - id: sound-volume-enter
-        type: audio-transition
-        targetId: sound-volume-transition-bgm
-        properties:
-          volume:
-            enter:
+        transition:
+          enter:
+            volume:
               initialValue: 0
               keyframes:
                 - { value: 80, duration: 2000, easing: easeInOutSine }
@@ -35,17 +31,14 @@ states:
         src: bgm-1
         loop: true
         volume: 25
-    audioEffects:
-      - id: sound-volume-update-exit
-        type: audio-transition
-        targetId: sound-volume-transition-bgm
-        properties:
-          volume:
-            update:
+        transition:
+          update:
+            volume:
               keyframes:
                 - { value: 60, duration: 1000, easing: easeOutQuad }
                 - { value: 25, duration: 1000, easing: easeInQuad }
-            exit:
+          exit:
+            volume:
               keyframes:
                 - { value: 0, duration: 2000, easing: easeInOutSine }
   - id: sound-volume-transition-exit

--- a/vt/specs/audio/source-replacement-delayed-overlap.yaml
+++ b/vt/specs/audio/source-replacement-delayed-overlap.yaml
@@ -1,0 +1,44 @@
+---
+title: Audio Manual - Delayed Replacement Overlap
+description: Inline replacement fixture where both sides hold silence or full volume before a crossfade.
+skipScreenshot: true
+specs:
+  - state 1 is silent so pressing n or clicking Next starts audio from a user gesture
+  - state 2 should start looping bgm-1 at volume 80
+  - state 3 should hold bgm-1 at full volume and bgm-2 at silence for one second, then crossfade over two seconds
+  - state 4 should fade out and stop bgm-2
+---
+states:
+  - id: replacement-delayed-ready
+    audio: []
+  - id: replacement-delayed-first
+    audio:
+      - id: replacement-delayed-bgm
+        type: sound
+        src: bgm-1
+        loop: true
+        volume: 80
+        transition:
+          exit:
+            volume:
+              keyframes:
+                - { delay: 1000, value: 0, duration: 2000, easing: linear }
+  - id: replacement-delayed-second
+    audio:
+      - id: replacement-delayed-bgm
+        type: sound
+        src: bgm-2
+        loop: true
+        volume: 80
+        transition:
+          enter:
+            volume:
+              initialValue: 0
+              keyframes:
+                - { delay: 1000, value: 80, duration: 2000, easing: linear }
+          exit:
+            volume:
+              keyframes:
+                - { value: 0, duration: 1200, easing: linear }
+  - id: replacement-delayed-stopped
+    audio: []

--- a/vt/specs/audio/source-replacement-full-volume-overlap.yaml
+++ b/vt/specs/audio/source-replacement-full-volume-overlap.yaml
@@ -1,0 +1,39 @@
+---
+title: Audio Manual - Full-Volume Replacement Overlap
+description: Inline replacement fixture where both sources overlap at full volume before the outgoing fade.
+skipScreenshot: true
+specs:
+  - state 1 is silent so pressing n or clicking Next starts audio from a user gesture
+  - state 2 should start looping bgm-1 at volume 80
+  - state 3 should start bgm-2 immediately, overlap both tracks at full volume for one second, then fade out bgm-1 over two seconds
+  - state 4 should fade out and stop bgm-2
+---
+states:
+  - id: replacement-full-ready
+    audio: []
+  - id: replacement-full-first
+    audio:
+      - id: replacement-full-bgm
+        type: sound
+        src: bgm-1
+        loop: true
+        volume: 80
+        transition:
+          exit:
+            volume:
+              keyframes:
+                - { delay: 1000, value: 0, duration: 2000, easing: linear }
+  - id: replacement-full-second
+    audio:
+      - id: replacement-full-bgm
+        type: sound
+        src: bgm-2
+        loop: true
+        volume: 80
+        transition:
+          exit:
+            volume:
+              keyframes:
+                - { value: 0, duration: 1200, easing: linear }
+  - id: replacement-full-stopped
+    audio: []

--- a/vt/specs/audio/source-replacement-src.yaml
+++ b/vt/specs/audio/source-replacement-src.yaml
@@ -18,13 +18,9 @@ states:
         src: bgm-1
         loop: true
         volume: 80
-    audioEffects:
-      - id: replacement-src-first-exit
-        type: audio-transition
-        targetId: replacement-src-bgm
-        properties:
-          volume:
-            exit:
+        transition:
+          exit:
+            volume:
               keyframes:
                 - { value: 0, duration: 1200, easing: linear }
   - id: replacement-src-second
@@ -34,17 +30,14 @@ states:
         src: bgm-2
         loop: true
         volume: 80
-    audioEffects:
-      - id: replacement-src-second-enter-exit
-        type: audio-transition
-        targetId: replacement-src-bgm
-        properties:
-          volume:
-            enter:
+        transition:
+          enter:
+            volume:
               initialValue: 0
               keyframes:
                 - { value: 80, duration: 1200, easing: linear }
-            exit:
+          exit:
+            volume:
               keyframes:
                 - { value: 0, duration: 1200, easing: linear }
   - id: replacement-src-stopped

--- a/vt/specs/audio/transition-interruption.yaml
+++ b/vt/specs/audio/transition-interruption.yaml
@@ -18,13 +18,9 @@ states:
         src: bgm-1
         loop: true
         volume: 100
-    audioEffects:
-      - id: interrupted-enter
-        type: audio-transition
-        targetId: interrupted-bgm
-        properties:
-          volume:
-            enter:
+        transition:
+          enter:
+            volume:
               initialValue: 0
               keyframes:
                 - { value: 100, duration: 6000, easing: linear }
@@ -35,13 +31,9 @@ states:
         src: bgm-1
         loop: true
         volume: 10
-    audioEffects:
-      - id: interrupted-update
-        type: audio-transition
-        targetId: interrupted-bgm
-        properties:
-          volume:
-            update:
+        transition:
+          update:
+            volume:
               keyframes:
                 - { value: 10, duration: 2000, easing: linear }
   - id: transition-interruption-stopped


### PR DESCRIPTION
## Summary

- add lifecycle-first inline `transition` fields to sounds and audio channels, normalized with legacy `audioEffects`
- implement keyframe holds, delayed/decode-safe enter automation, replacement overlap, independent mute gating, and persistent playback-rate timelines
- make `loopEnd` cleanup wait for both exit automation and completable tails, with a finite zero-rate fallback
- preserve pending enter tracks across failed source starts without allowing failed automation to affect intervening updates
- checkpoint controlled playback cursors across rate changes so loop-end cleanup retains complete rate history
- add schemas, public JSDoc types, validation, migrated manual fixtures, and immediate/delayed/full-volume overlap examples

## Tests

- `bun run test` — 1,521 passed
- focused audio transition suite — 133 passed
- `bun run lint`
- `bun run build`
- `bunx oxlint src/AudioStage.js src/util/normalizeAudio.js spec/audio/normalizeAudio.spec.js spec/audio/audioStage.spec.js spec/audio/controlledPlayback.spec.js`
- all 29 audio fixtures parsed and normalized
- manually verified delayed replacement overlap and full-volume replacement overlap

## Review note

This is stacked on the documentation PR #325 so this PR contains only implementation, test, and implementation-status changes. Legacy `audioEffects` remains supported and explicitly tested.