### PR TITLE
feat(animations): support delayed transition mask arrays

### DIFF
--- a/conformance/timeline/v1/timeline-program.schema.json
+++ b/conformance/timeline/v1/timeline-program.schema.json
@@ -249,7 +249,20 @@
           "type": "object",
           "required": ["kind"],
           "properties": {
-            "kind": { "enum": ["transitionMask", "transitionCompositor"] }
+            "kind": { "const": "transitionMask" },
+            "index": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": ["kind"],
+          "properties": {
+            "kind": { "const": "transitionCompositor" }
           },
           "additionalProperties": false
         }

--- a/docs/animation-model.md
+++ b/docs/animation-model.md
@@ -503,17 +503,18 @@ animations:
     targetId: "scene-root"
     type: "transition"
     mask:
-      kind: "single"
-      texture: "masks/spiral-07.png"
-      channel: "red"
-      softness: 0.08
-      invert: false
-      progress:
-        initialValue: 0
-        keyframes:
-          - duration: 900
-            value: 1
-            easing: "linear"
+      - kind: "single"
+        texture: "masks/spiral-07.png"
+        channel: "red"
+        softness: 0.08
+        invert: false
+        delay: 200
+        progress:
+          initialValue: 0
+          keyframes:
+            - duration: 900
+              value: 1
+              easing: "linear"
 ```
 
 ## Parent Transition Rule
@@ -526,24 +527,61 @@ When an ancestor `transition` is active for a state change:
 
 This keeps transition composition aligned with the current snapshot-based runtime.
 
-## Mask
+## Masks
 
-Mask is always a transition primitive.
+`mask` is always a transition primitive. It accepts either a single mask object
+for backward compatibility or a non-empty array. The single-object shape is
+normalized internally to a one-entry array, so the timeline and renderer use
+one implementation. New multi-mask authoring uses the array shape.
 
-A mask defines a reveal field that controls how previous and next visuals hand
-off over time.
+Each normalized entry defines an independently timed reveal field that controls
+how previous and next visuals hand off over time.
+
+When entries overlap, their reveal values are combined with a per-pixel
+`max`. This is union behavior: the strongest reveal wins, and overlapping soft
+edges do not compound. A delayed entry contributes `0` until it becomes active.
+
+```yaml
+mask:
+  - kind: single
+    texture: masks/from-left.png
+    progress:
+      keyframes: [{ duration: 800, value: 1 }]
+  - kind: single
+    texture: masks/from-right.png
+    delay: 250
+    progress:
+      keyframes: [{ duration: 550, value: 1 }]
+```
 
 Supported kinds:
 
 - `single`
 - `sequence`
 
-### Common Mask Fields
+### Common Mask Entry Fields
 
 - `channel`
+- optional `delay`
 - `progress`
 - optional `invert`
 - `softness` for `single` masks only
+
+### `delay`
+
+Defines how many milliseconds the mask remains completely inactive before its
+progress timeline begins. While inactive, the previous surface passes through
+unchanged, including for sequence masks whose first frame already contains
+revealed pixels.
+
+`delay` defaults to `0`, contributes to transition duration, follows playback
+speed and authored repeat/yoyo mapping, and is added before any delay on the
+first `progress` keyframe. A progress-keyframe delay still means “hold the
+current progress value”; mask-level `delay` means “do not apply this mask yet.”
+
+Top-level orchestrated `gsap` transitions cannot use an entry's `delay`, because
+the GSAP timeline is their sole timing authority. Put the delay or start
+position on the action targeting that indexed `transitionMask` instead.
 
 ### `channel`
 
@@ -575,22 +613,22 @@ amount.
 
 ```yaml
 mask:
-  kind: "sequence"
-  progress:
-    initialValue: 0
-    keyframes:
-      - duration: 1000
-        value: 1
-        easing: "linear"
-  sample: "linear"
-  frames:
-    - at: 0
-      texture: "masks/a.png"
-    - at: 0.5
-      texture: "masks/b.png"
-    - at: 1
-      texture: "masks/c.png"
-  channel: "alpha"
+  - kind: "sequence"
+    progress:
+      initialValue: 0
+      keyframes:
+        - duration: 1000
+          value: 1
+          easing: "linear"
+    sample: "linear"
+    frames:
+      - at: 0
+        texture: "masks/a.png"
+      - at: 0.5
+        texture: "masks/b.png"
+      - at: 1
+        texture: "masks/c.png"
+    channel: "alpha"
 ```
 
 Sequence rules:

--- a/docs/portable-gsap-timelines.md
+++ b/docs/portable-gsap-timelines.md
@@ -238,11 +238,17 @@ crossing `direction`, and domain `iteration` tuple.
 
 A transition can use top-level `gsap` to coordinate `prev`/`next` surfaces,
 mask progress, and compositor progress/parameters. Target aliases use
-`transitionSurface: prev | next`, `transitionMask: true`, or
-`transitionCompositor: true`. The timeline must be finite, and configured mask
-or compositor progress must resolve to exactly 1 at the terminal millisecond.
+`transitionSurface: prev | next`, `transitionMask: true`,
+`transitionMask: <zero-based-index>`, or `transitionCompositor: true`.
+`true` targets every mask entry; an index targets one entry. The timeline must
+be finite, and every configured mask plus compositor progress must resolve to
+exactly 1 at the terminal millisecond.
 Static mask/compositor resources remain outside the timeline and are validated
 before overlay allocation.
+
+Because this mode makes the portable timeline the sole timing authority,
+mask-entry `delay` and `progress` fields are not accepted alongside top-level
+`gsap`. Use each indexed target action's `delay` or scheduled start position.
 
 ## Inspection, Performance, And Portability
 

--- a/docs/shared-timeline-plan-design-and-roadmap.md
+++ b/docs/shared-timeline-plan-design-and-roadmap.md
@@ -1556,10 +1556,10 @@ animations:
     type: transition
 
     mask:
-      kind: single
-      texture: masks/spiral.png
-      channel: red
-      softness: 0.08
+      - kind: single
+        texture: masks/spiral.png
+        channel: red
+        softness: 0.08
 
     compositor:
       type: shader
@@ -1644,16 +1644,18 @@ synthetic transition alias. The implicit `self` target and ordinary
 transition program. Live descendant animation remains deferred rather than
 being mixed into snapshot orchestration.
 
-`transitionMask` requires a mask configuration. `transitionCompositor` requires
-a compositor configuration. Missing previous or next content remains a
-transparent surface as in the current transition model.
+`transitionMask: true` requires at least one mask entry and targets all of them;
+`transitionMask: <zero-based-index>` targets one existing entry.
+`transitionCompositor` requires a compositor configuration. Missing previous or
+next content remains a transparent surface as in the current transition model.
 
-In orchestrated mode, a configured mask must have an effective terminal
-`progress: 1` write and a configured compositor must have an effective terminal
-`progress: 1` write. The compiler does not silently generate an independent
-progress tween because that would create timing outside the authored timeline.
-Surface motion is optional. Finalization still removes the overlay and reveals
-the live next subtree through the existing transition lifecycle.
+In orchestrated mode, every configured mask entry must have an effective
+terminal `progress: 1` write and a configured compositor must have an effective
+terminal `progress: 1` write. The compiler does not silently generate an
+independent progress tween because that would create timing outside the
+authored timeline. Surface motion is optional. Finalization still removes the
+overlay and reveals the live next subtree through the existing transition
+lifecycle.
 
 Terminal validation evaluates the composed effective value at the exact finite
 root endpoint after repeats, yoyo direction, overwrite, and fill semantics; it

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/pages/docs/guides/shaders.md
+++ b/playground/pages/docs/guides/shaders.md
@@ -296,8 +296,8 @@ animations:
     targetId: scene
     type: transition
     mask:
-      kind: single
-      texture: paper-mask
+      - kind: single
+        texture: paper-mask
     compositor:
       type: shader
       parameters:

--- a/playground/pages/docs/nodes/tween.md
+++ b/playground/pages/docs/nodes/tween.md
@@ -390,56 +390,71 @@ animations:
 
 ## Transition Masks
 
-`mask` is valid only on `type: transition`. It can be combined with `prev` and
-`next` surface motion.
+`mask` is valid only on `type: transition`. It accepts either the existing
+single-object shape or a non-empty array; a single object is normalized to a
+one-entry array. Its entries can be combined with `prev` and `next` surface
+motion. Overlapping entries use the per-pixel maximum reveal, so the strongest
+mask wins without compounding soft edges. A delayed entry contributes zero
+reveal until its start time.
 
 Common fields:
 
-| Field      | Type    | Default   | Notes                                     |
-| ---------- | ------- | --------- | ----------------------------------------- |
-| `kind`     | string  | -         | Required: `single` or `sequence`.         |
-| `channel`  | string  | `red`     | `red`, `green`, `blue`, or `alpha`.       |
-| `invert`   | boolean | `false`   | Reverses the sampled reveal field.        |
-| `progress` | object  | immediate | Manual keyframe timeline from `0` to `1`. |
+| Field      | Type    | Default   | Notes                                        |
+| ---------- | ------- | --------- | -------------------------------------------- |
+| `kind`     | string  | -         | Required: `single` or `sequence`.            |
+| `channel`  | string  | `red`     | `red`, `green`, `blue`, or `alpha`.          |
+| `invert`   | boolean | `false`   | Reverses the sampled reveal field.           |
+| `delay`    | integer | `0`       | Milliseconds before the mask becomes active. |
+| `progress` | object  | immediate | Manual keyframe timeline from `0` to `1`.    |
 
 ### Single Mask
 
 ```yaml
 mask:
-  kind: single
-  texture: spiral-mask
-  channel: red
-  softness: 0.08
-  progress:
-    initialValue: 0
-    keyframes:
-      - duration: 900
-        value: 1
-        easing: linear
+  - kind: single
+    texture: spiral-mask
+    channel: red
+    softness: 0.08
+    delay: 200
+    progress:
+      initialValue: 0
+      keyframes:
+        - duration: 900
+          value: 1
+          easing: linear
 ```
 
 `texture` is required. `softness` controls the feathered reveal threshold.
+
+`delay` keeps the mask completely inactive and holds the previous surface
+unchanged. After that time, the progress timeline begins. It is additive with a
+delay on the first progress keyframe: mask delay controls activation, while
+keyframe delay holds the initial progress after activation.
+
+For a top-level portable `gsap` transition, put timing on the action targeting
+the indexed `transitionMask`; mask-entry `delay` is not accepted in that
+authoring mode.
 
 ### Sequence Mask
 
 ```yaml
 mask:
-  kind: sequence
-  channel: alpha
-  sample: linear
-  progress:
-    initialValue: 0
-    keyframes:
-      - duration: 1000
-        value: 1
-        easing: linear
-  frames:
-    - at: 0
-      texture: masks/frame-0
-    - at: 0.5
-      texture: masks/frame-1
-    - at: 1
-      texture: masks/frame-2
+  - kind: sequence
+    channel: alpha
+    sample: linear
+    progress:
+      initialValue: 0
+      keyframes:
+        - duration: 1000
+          value: 1
+          easing: linear
+    frames:
+      - at: 0
+        texture: masks/frame-0
+      - at: 0.5
+        texture: masks/frame-1
+      - at: 1
+        texture: masks/frame-2
 ```
 
 Sequence rules:

--- a/scripts/testWebGPUShaders.mjs
+++ b/scripts/testWebGPUShaders.mjs
@@ -30,6 +30,22 @@ const loadStates = async (relativePath) => {
   return spec.states;
 };
 
+const multipleMaskStates = await loadStates(
+  "vt/specs/shadertransition/rect-mask-multipass-animated-compositor.yaml",
+);
+multipleMaskStates[1].animations[0].mask.push({
+  kind: "single",
+  texture: "mask-diagonal",
+  channel: "red",
+  invert: true,
+  delay: 200,
+  softness: 0.06,
+  progress: {
+    initialValue: 0,
+    keyframes: [{ duration: 600, value: 1, easing: "linear" }],
+  },
+});
+
 const cases = {
   timedUpdate: {
     states: await loadStates(
@@ -54,6 +70,10 @@ const cases = {
     states: await loadStates(
       "vt/specs/shadertransition/rect-mask-multipass-animated-compositor.yaml",
     ),
+    sampleTime: 400,
+  },
+  multipleMasks: {
+    states: multipleMaskStates,
     sampleTime: 400,
   },
 };

--- a/spec/animations/runReplaceAnimation.spec.js
+++ b/spec/animations/runReplaceAnimation.spec.js
@@ -2410,15 +2410,17 @@ describe("runReplaceAnimation", () => {
             },
           },
         },
-        mask: {
-          kind: "single",
-          texture: maskTexture,
-          channel: "red",
-          progress: {
-            initialValue: 0,
-            keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+        mask: [
+          {
+            kind: "single",
+            texture: maskTexture,
+            channel: "red",
+            progress: {
+              initialValue: 0,
+              keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+            },
           },
-        },
+        ],
       },
       animations: new Map(),
       animationBus,
@@ -2495,17 +2497,19 @@ describe("runReplaceAnimation", () => {
         id: "scene-mask-replace",
         targetId: "scene-root",
         type: "transition",
-        mask: {
-          kind: "single",
-          texture: maskTexture,
-          channel: "red",
-          progress: {
-            initialValue: 0,
-            keyframes: [
-              { delay: 200, duration: 800, value: 1, easing: "linear" },
-            ],
+        playback: { speed: 2 },
+        mask: [
+          {
+            kind: "single",
+            texture: maskTexture,
+            channel: "red",
+            delay: 200,
+            progress: {
+              initialValue: 0,
+              keyframes: [{ duration: 800, value: 1, easing: "linear" }],
+            },
           },
-        },
+        ],
       },
       animations: new Map(),
       animationBus,
@@ -2524,8 +2528,8 @@ describe("runReplaceAnimation", () => {
     const dispatched = animationBus.dispatch.mock.calls[0][0];
 
     expect(app.renderer.extract.pixels).not.toHaveBeenCalled();
-    expect(dispatched.payload.duration).toBe(1000);
-    dispatched.payload.applyFrame(199);
+    expect(dispatched.payload.duration).toBe(500);
+    dispatched.payload.applyFrame(99);
 
     expect(app.renderer.extract.pixels).not.toHaveBeenCalled();
     const overlay = parent.children.find(
@@ -2536,12 +2540,157 @@ describe("runReplaceAnimation", () => {
     expect(
       maskFilter.resources.replaceMaskUniforms.uniforms.uMaskDirectReveal,
     ).toBe(0);
+    expect(maskFilter.resources.replaceMaskUniforms.uniforms.uMaskActive).toBe(
+      0,
+    );
     expect(maskFilter.resources.replaceMaskUniforms.uniforms.uProgress).toBe(0);
 
-    dispatched.payload.applyFrame(600);
+    dispatched.payload.applyFrame(100);
+    expect(maskFilter.resources.replaceMaskUniforms.uniforms.uMaskActive).toBe(
+      1,
+    );
+    expect(maskFilter.resources.replaceMaskUniforms.uniforms.uProgress).toBe(0);
+
+    dispatched.payload.applyFrame(300);
     expect(
       maskFilter.resources.replaceMaskUniforms.uniforms.uProgress,
     ).toBeCloseTo(0.5);
+
+    dispatched.payload.applyFrame(99);
+    expect(maskFilter.resources.replaceMaskUniforms.uniforms.uMaskActive).toBe(
+      0,
+    );
+  });
+
+  it("runs multiple masks independently and combines overlaps with max reveal", () => {
+    const prevDisplayObject = createDisplayObject("scene-root");
+    const nextDisplayObject = createDisplayObject("scene-root");
+    const parent = createParent(prevDisplayObject);
+    prevDisplayObject.parent = parent;
+    const firstTexture = document.createElement("canvas");
+    const secondTexture = document.createElement("canvas");
+    firstTexture.width = secondTexture.width = 1;
+    firstTexture.height = secondTexture.height = 1;
+    const filterFromSpy = vi.spyOn(Filter, "from");
+    const plugin = {
+      add: vi.fn(({ parent: targetParent, element }) => {
+        nextDisplayObject.label = element.id;
+        targetParent.addChild(nextDisplayObject);
+      }),
+      delete: vi.fn(({ parent: targetParent, element }) => {
+        const child = targetParent.children.find(
+          (item) => item.label === element.id,
+        );
+        if (child) targetParent.removeChild(child);
+      }),
+    };
+    const animationBus = { dispatch: vi.fn() };
+    const app = {
+      renderer: {
+        width: 1280,
+        height: 720,
+        generateTexture: vi.fn(() => Texture.EMPTY),
+        render: vi.fn(),
+      },
+    };
+
+    try {
+      runReplaceAnimation({
+        app,
+        parent,
+        prevElement: { id: "scene-root", type: "container" },
+        nextElement: { id: "scene-root", type: "container", children: [] },
+        animation: {
+          id: "scene-multiple-mask-replace",
+          targetId: "scene-root",
+          type: "transition",
+          mask: [
+            {
+              kind: "single",
+              texture: firstTexture,
+              progress: {
+                initialValue: 0,
+                keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+              },
+            },
+            {
+              kind: "single",
+              texture: secondTexture,
+              delay: 400,
+              progress: {
+                initialValue: 0,
+                keyframes: [{ duration: 600, value: 1, easing: "linear" }],
+              },
+            },
+          ],
+        },
+        animations: new Map(),
+        animationBus,
+        completionTracker: {
+          getVersion: () => 11,
+          track: vi.fn(),
+          complete: vi.fn(),
+        },
+        eventHandler: vi.fn(),
+        elementPlugins: [],
+        plugin,
+        zIndex: 0,
+        signal: new AbortController().signal,
+      });
+
+      const accumulatorIndexes = filterFromSpy.mock.calls.flatMap(
+        ([config], index) =>
+          config.gl?.name === "replace-mask-accumulate-filter" ? [index] : [],
+      );
+      const accumulators = accumulatorIndexes.map(
+        (index) => filterFromSpy.mock.results[index].value,
+      );
+      const dispatched = animationBus.dispatch.mock.calls[0][0];
+      const overlay = parent.children.find(
+        (child) => child !== nextDisplayObject,
+      );
+      const finalMaskFilter = overlay.children[0].filters[0];
+
+      expect(dispatched.payload.duration).toBe(1000);
+      expect(accumulators).toHaveLength(2);
+      expect(
+        filterFromSpy.mock.calls[accumulatorIndexes[0]][0].gl.fragment,
+      ).toContain("max(accumulated, reveal)");
+      expect(
+        filterFromSpy.mock.calls[accumulatorIndexes[0]][0].gpu.fragment.source,
+      ).toContain("max(accumulated, reveal)");
+      expect(
+        finalMaskFilter.resources.replaceMaskUniforms.uniforms
+          .uMaskDirectReveal,
+      ).toBe(1);
+
+      dispatched.payload.applyFrame(300);
+      expect(
+        accumulators[0].resources.replaceMaskUniforms.uniforms.uProgress,
+      ).toBeCloseTo(0.3);
+      expect(
+        accumulators[0].resources.replaceMaskUniforms.uniforms.uMaskActive,
+      ).toBe(1);
+      expect(
+        accumulators[1].resources.replaceMaskUniforms.uniforms.uProgress,
+      ).toBe(0);
+      expect(
+        accumulators[1].resources.replaceMaskUniforms.uniforms.uMaskActive,
+      ).toBe(0);
+
+      dispatched.payload.applyFrame(700);
+      expect(
+        accumulators[0].resources.replaceMaskUniforms.uniforms.uProgress,
+      ).toBeCloseTo(0.7);
+      expect(
+        accumulators[1].resources.replaceMaskUniforms.uniforms.uProgress,
+      ).toBeCloseTo(0.5);
+      expect(
+        accumulators[1].resources.replaceMaskUniforms.uniforms.uMaskActive,
+      ).toBe(1);
+    } finally {
+      filterFromSpy.mockRestore();
+    }
   });
 
   it("routes single alpha masks through the alpha preprocessing filter", () => {
@@ -2597,15 +2746,17 @@ describe("runReplaceAnimation", () => {
           id: "scene-mask-replace-alpha",
           targetId: "scene-root",
           type: "transition",
-          mask: {
-            kind: "single",
-            texture: maskTexture,
-            channel: "alpha",
-            progress: {
-              initialValue: 0,
-              keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+          mask: [
+            {
+              kind: "single",
+              texture: maskTexture,
+              channel: "alpha",
+              progress: {
+                initialValue: 0,
+                keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+              },
             },
-          },
+          ],
         },
         animations: new Map(),
         animationBus,
@@ -2707,15 +2858,17 @@ describe("runReplaceAnimation", () => {
         id: "scene-mask-replace",
         targetId: "scene-root",
         type: "transition",
-        mask: {
-          kind: "single",
-          texture: maskTexture,
-          channel: "red",
-          progress: {
-            initialValue: 0,
-            keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+        mask: [
+          {
+            kind: "single",
+            texture: maskTexture,
+            channel: "red",
+            progress: {
+              initialValue: 0,
+              keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+            },
           },
-        },
+        ],
       },
       animations: new Map(),
       animationBus,
@@ -2893,15 +3046,17 @@ describe("runReplaceAnimation", () => {
           id: "scene-mask-replace",
           targetId: "scene-root",
           type: "transition",
-          mask: {
-            kind: "single",
-            texture: maskTexture,
-            channel: "red",
-            progress: {
-              initialValue: 0,
-              keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+          mask: [
+            {
+              kind: "single",
+              texture: maskTexture,
+              channel: "red",
+              progress: {
+                initialValue: 0,
+                keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+              },
             },
-          },
+          ],
         },
         animations: new Map(),
         animationBus,
@@ -2995,20 +3150,23 @@ describe("runReplaceAnimation", () => {
         id: "scene-mask-sequence",
         targetId: "scene-root",
         type: "transition",
-        mask: {
-          kind: "sequence",
-          frames: [
-            { at: 0, texture: leftMask },
-            { at: 1, texture: rightMask },
-          ],
-          channel: "alpha",
-          sample: "linear",
-          invert: true,
-          progress: {
-            initialValue: 0,
-            keyframes: [{ duration: 1000, value: 1, easing: "linear" }],
+        mask: [
+          {
+            kind: "sequence",
+            delay: 200,
+            frames: [
+              { at: 0, texture: leftMask },
+              { at: 1, texture: rightMask },
+            ],
+            channel: "alpha",
+            sample: "linear",
+            invert: true,
+            progress: {
+              initialValue: 0,
+              keyframes: [{ duration: 800, value: 1, easing: "linear" }],
+            },
           },
-        },
+        ],
       },
       animations: new Map(),
       animationBus,
@@ -3027,7 +3185,8 @@ describe("runReplaceAnimation", () => {
     const dispatched = animationBus.dispatch.mock.calls[0][0];
 
     expect(app.renderer.extract.pixels).not.toHaveBeenCalled();
-    dispatched.payload.applyFrame(500);
+    expect(dispatched.payload.duration).toBe(1000);
+    dispatched.payload.applyFrame(199);
 
     expect(app.renderer.extract.pixels).not.toHaveBeenCalled();
     const overlay = parent.children.find(
@@ -3038,6 +3197,17 @@ describe("runReplaceAnimation", () => {
     expect(
       maskFilter.resources.replaceMaskUniforms.uniforms.uMaskDirectReveal,
     ).toBe(1);
+    expect(maskFilter.resources.replaceMaskUniforms.uniforms.uMaskActive).toBe(
+      0,
+    );
+
+    dispatched.payload.applyFrame(600);
+    expect(maskFilter.resources.replaceMaskUniforms.uniforms.uMaskActive).toBe(
+      1,
+    );
+    expect(
+      maskFilter.resources.replaceMaskUniforms.uniforms.uProgress,
+    ).toBeCloseTo(0.5);
   });
 
   it("does not flush deferred activation when a transition is cancelled", () => {

--- a/spec/elements/renderElements.replace.spec.js
+++ b/spec/elements/renderElements.replace.spec.js
@@ -213,14 +213,16 @@ describe("renderElements transition handling", () => {
           id: "rect-transition",
           targetId: "rect1",
           type: "transition",
-          mask: {
-            kind: "single",
-            texture: "mask-diagonal",
-            progress: {
-              initialValue: 0,
-              keyframes: [{ duration: 500, value: 1, easing: "linear" }],
+          mask: [
+            {
+              kind: "single",
+              texture: "mask-diagonal",
+              progress: {
+                initialValue: 0,
+                keyframes: [{ duration: 500, value: 1, easing: "linear" }],
+              },
             },
-          },
+          ],
         },
       ],
       animationBus,

--- a/spec/parser/normalizeRenderState.test.yaml
+++ b/spec/parser/normalizeRenderState.test.yaml
@@ -149,14 +149,52 @@ out:
       targetId: scene-root
       type: transition
       mask:
-        kind: single
-        texture: masks/wipe.png
-        progress:
-          initialValue: 0
-          keyframes:
-            - duration: 0
-              value: 1
-              easing: linear
+        - kind: single
+          texture: masks/wipe.png
+          progress:
+            initialValue: 0
+            keyframes:
+              - duration: 0
+                value: 1
+                easing: linear
+  audio: []
+  audioEffects: []
+---
+case: Normalize transition animation with mask delay
+in:
+  - id: state-2-delayed-mask
+    animations:
+      - id: anim-delayed-mask
+        targetId: scene-root
+        type: transition
+        mask:
+          - kind: single
+            texture: masks/wipe.png
+            delay: 250
+            progress:
+              initialValue: 0
+              keyframes:
+                - delay: 50
+                  duration: 700
+                  value: 1
+out:
+  id: state-2-delayed-mask
+  elements: []
+  animations:
+    - id: anim-delayed-mask
+      targetId: scene-root
+      type: transition
+      mask:
+        - kind: single
+          delay: 250
+          texture: masks/wipe.png
+          progress:
+            initialValue: 0
+            keyframes:
+              - delay: 50
+                duration: 700
+                value: 1
+                easing: linear
   audio: []
   audioEffects: []
 ---
@@ -168,20 +206,20 @@ in:
         targetId: scene-root
         type: transition
         mask:
-          kind: sequence
-          frames:
-            - at: 0
-              texture: masks/a.png
-            - at: 0.5
-              texture: masks/b.png
-            - at: 1
-              texture: masks/c.png
-          channel: alpha
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
+          - kind: sequence
+            frames:
+              - at: 0
+                texture: masks/a.png
+              - at: 0.5
+                texture: masks/b.png
+              - at: 1
+                texture: masks/c.png
+            channel: alpha
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
 out:
   id: state-2-sequence-mask
   elements: []
@@ -190,22 +228,22 @@ out:
       targetId: scene-root
       type: transition
       mask:
-        kind: sequence
-        channel: alpha
-        progress:
-          initialValue: 0
-          keyframes:
-            - duration: 1000
-              value: 1
-              easing: linear
-        frames:
-          - at: 0
-            texture: masks/a.png
-          - at: 0.5
-            texture: masks/b.png
-          - at: 1
-            texture: masks/c.png
-        sample: hold
+        - kind: sequence
+          channel: alpha
+          progress:
+            initialValue: 0
+            keyframes:
+              - duration: 1000
+                value: 1
+                easing: linear
+          frames:
+            - at: 0
+              texture: masks/a.png
+            - at: 0.5
+              texture: masks/b.png
+            - at: 1
+              texture: masks/c.png
+          sample: hold
   audio: []
   audioEffects: []
 ---
@@ -891,8 +929,8 @@ in:
               - duration: 100
                 value: 20
         mask:
-          kind: single
-          texture: masks/wipe.png
+          - kind: single
+            texture: masks/wipe.png
 throws: animations[0].mask is only valid for transition animations.
 ---
 case: Throw when transition animation defines tween
@@ -1129,11 +1167,11 @@ in:
         targetId: scene-root
         type: transition
         mask:
-          kind: sequence
-          textures:
-            - masks/a.png
-            - masks/b.png
-throws: "animations[0].mask.textures is no longer supported. Use animations[0].mask.frames with texture and at entries instead."
+          - kind: sequence
+            textures:
+              - masks/a.png
+              - masks/b.png
+throws: "animations[0].mask[0].textures is no longer supported. Use animations[0].mask[0].frames with texture and at entries instead."
 ---
 case: Throw when transition mask uses composite kind
 in:
@@ -1143,11 +1181,11 @@ in:
         targetId: scene-root
         type: transition
         mask:
-          kind: composite
-          items:
-            - texture: masks/a.png
-            - texture: masks/b.png
-throws: "animations[0].mask.kind must be one of: single, sequence."
+          - kind: composite
+            items:
+              - texture: masks/a.png
+              - texture: masks/b.png
+throws: "animations[0].mask[0].kind must be one of: single, sequence."
 ---
 case: Throw when sequence mask uses softness
 in:
@@ -1157,14 +1195,14 @@ in:
         targetId: scene-root
         type: transition
         mask:
-          kind: sequence
-          softness: 0.02
-          frames:
-            - at: 0
-              texture: masks/a.png
-            - at: 1
-              texture: masks/b.png
-throws: "animations[0].mask.softness is not valid for sequence masks. Author feathering into animations[0].mask.frames[].texture instead."
+          - kind: sequence
+            softness: 0.02
+            frames:
+              - at: 0
+                texture: masks/a.png
+              - at: 1
+                texture: masks/b.png
+throws: "animations[0].mask[0].softness is not valid for sequence masks. Author feathering into animations[0].mask[0].frames[].texture instead."
 ---
 case: Throw when sequence mask has too few frames
 in:
@@ -1174,11 +1212,11 @@ in:
         targetId: scene-root
         type: transition
         mask:
-          kind: sequence
-          frames:
-            - at: 0
-              texture: masks/a.png
-throws: animations[0].mask.frames must be an array with at least two frames.
+          - kind: sequence
+            frames:
+              - at: 0
+                texture: masks/a.png
+throws: animations[0].mask[0].frames must be an array with at least two frames.
 ---
 case: Throw when sequence mask frames do not start at zero
 in:
@@ -1188,13 +1226,13 @@ in:
         targetId: scene-root
         type: transition
         mask:
-          kind: sequence
-          frames:
-            - at: 0.1
-              texture: masks/a.png
-            - at: 1
-              texture: masks/b.png
-throws: animations[0].mask.frames[0].at must be 0.
+          - kind: sequence
+            frames:
+              - at: 0.1
+                texture: masks/a.png
+              - at: 1
+                texture: masks/b.png
+throws: animations[0].mask[0].frames[0].at must be 0.
 ---
 case: Throw when sequence mask frames do not end at one
 in:
@@ -1204,13 +1242,13 @@ in:
         targetId: scene-root
         type: transition
         mask:
-          kind: sequence
-          frames:
-            - at: 0
-              texture: masks/a.png
-            - at: 0.8
-              texture: masks/b.png
-throws: animations[0].mask.frames[1].at must be 1.
+          - kind: sequence
+            frames:
+              - at: 0
+                texture: masks/a.png
+              - at: 0.8
+                texture: masks/b.png
+throws: animations[0].mask[0].frames[1].at must be 1.
 ---
 case: Throw when sequence mask frames are not sorted and unique
 in:
@@ -1220,17 +1258,17 @@ in:
         targetId: scene-root
         type: transition
         mask:
-          kind: sequence
-          frames:
-            - at: 0
-              texture: masks/a.png
-            - at: 0.5
-              texture: masks/b.png
-            - at: 0.5
-              texture: masks/c.png
-            - at: 1
-              texture: masks/d.png
-throws: animations[0].mask.frames must be sorted by ascending unique at values.
+          - kind: sequence
+            frames:
+              - at: 0
+                texture: masks/a.png
+              - at: 0.5
+                texture: masks/b.png
+              - at: 0.5
+                texture: masks/c.png
+              - at: 1
+                texture: masks/d.png
+throws: animations[0].mask[0].frames must be sorted by ascending unique at values.
 ---
 case: Throw when sequence mask sample is unsupported
 in:
@@ -1240,14 +1278,14 @@ in:
         targetId: scene-root
         type: transition
         mask:
-          kind: sequence
-          sample: nearest
-          frames:
-            - at: 0
-              texture: masks/a.png
-            - at: 1
-              texture: masks/b.png
-throws: "animations[0].mask.sample must be one of: hold, linear."
+          - kind: sequence
+            sample: nearest
+            frames:
+              - at: 0
+                texture: masks/a.png
+              - at: 1
+                texture: masks/b.png
+throws: "animations[0].mask[0].sample must be one of: hold, linear."
 ---
 case: Throw when target mixes update and transition types
 in:

--- a/src/plugins/animations/replace/runReplaceAnimation.js
+++ b/src/plugins/animations/replace/runReplaceAnimation.js
@@ -14,6 +14,7 @@ import {
   compileTransitionAnimation,
   createGsapTimelineEvaluator,
   getEasingCriticalProgresses,
+  mapDomainTime,
 } from "../timeline/index.js";
 import {
   clearDeferredMountOperations,
@@ -209,18 +210,19 @@ const createTransitionTimelineController = ({
   program,
   prevSubject,
   nextSubject,
-  maskController,
+  maskControllers = [],
   compositorEffect,
   validateTerminal = false,
 }) => {
   const valueTypes = new Map(
     program.clipTemplates.map((clip) => [clip.channel, clip.valueType]),
   );
-  const maskHandle = {
+  const maskHandles = (animation.mask ?? []).map((mask, index) => ({
     kind: "mask",
-    progress: animation.mask?.progress?.initialValue ?? 0,
-    apply: (value) => maskController?.apply(clamp01(value)),
-  };
+    index,
+    progress: mask.progress?.initialValue ?? 0,
+    apply: (value) => maskControllers[index]?.apply(clamp01(value)),
+  }));
   const compositorHandle = {
     kind: "compositor",
     progress:
@@ -231,7 +233,10 @@ const createTransitionTimelineController = ({
   const transitionTargets = {
     prev: createTransitionSurfaceTarget("prev", prevSubject),
     next: createTransitionSurfaceTarget("next", nextSubject),
-    mask: { handle: maskHandle, identity: "transition:mask" },
+    mask: maskHandles.map((handle, index) => ({
+      handle,
+      identity: `transition:mask:${index}`,
+    })),
     compositor: {
       handle: compositorHandle,
       identity: "transition:compositor",
@@ -349,17 +354,25 @@ const createTransitionTimelineController = ({
   try {
     const terminalFrame = timelineEvaluator.evaluate(instance.duration);
     if (validateTerminal && animation.gsap) {
-      for (const [configured, channel, label] of [
-        [animation.mask, "transition.mask.progress", "mask"],
-        [animation.compositor, "transition.compositor.progress", "compositor"],
-      ]) {
-        if (!configured) continue;
+      for (const [index] of (animation.mask ?? []).entries()) {
         const value = terminalFrame.values.find(
-          (item) => item.channel === channel,
+          (item) =>
+            item.targetIdentity === `transition:mask:${index}` &&
+            item.channel === "transition.mask.progress",
         )?.value;
         if (value !== 1) {
           throw new Error(
-            `Transition animation "${animation.id}" ${label} must have effective terminal progress 1.`,
+            `Transition animation "${animation.id}" mask[${index}] must have effective terminal progress 1.`,
+          );
+        }
+      }
+      if (animation.compositor) {
+        const value = terminalFrame.values.find(
+          (item) => item.channel === "transition.compositor.progress",
+        )?.value;
+        if (value !== 1) {
+          throw new Error(
+            `Transition animation "${animation.id}" compositor must have effective terminal progress 1.`,
           );
         }
       }
@@ -393,7 +406,17 @@ const createTransitionTimelineController = ({
     backend: timelineEvaluator.backend,
     duration: instance.duration,
     sampleTimes: [...sampleTimes].sort((left, right) => left - right),
-    apply: timelineEvaluator.apply,
+    apply: (time) => {
+      if (maskControllers.length > 0) {
+        const rootTime = mapDomainTime(instance.domains.root, time);
+        for (const [index, mask] of (animation.mask ?? []).entries()) {
+          maskControllers[index]?.setActive(
+            rootTime.localTime >= (mask.delay ?? 0),
+          );
+        }
+      }
+      timelineEvaluator.apply(time);
+    },
     destroy: timelineEvaluator.destroy,
   };
 };
@@ -497,6 +520,7 @@ uniform float uSoftness;
 uniform float uMaskMix;
 uniform float uMaskInvert;
 uniform float uMaskDirectReveal;
+uniform float uMaskActive;
 uniform vec4 uMaskChannelWeights;
 uniform vec4 uSecondaryClamp;
 
@@ -534,7 +558,7 @@ void main()
     vec4 prevColor = texture(uTexture, uv);
     vec4 nextColor = texture(uNextTexture, secondaryUv);
     float maskValue = sampleMaskValue(secondaryUv);
-    float reveal = mix(
+    float reveal = clamp(uMaskActive, 0.0, 1.0) * mix(
         sampleReveal(maskValue),
         clamp(maskValue, 0.0, 1.0),
         clamp(uMaskDirectReveal, 0.0, 1.0)
@@ -560,6 +584,7 @@ struct ReplaceMaskUniforms {
   uMaskMix: f32,
   uMaskInvert: f32,
   uMaskDirectReveal: f32,
+  uMaskActive: f32,
   uMaskChannelWeights: vec4<f32>,
   uSecondaryMatrix: mat3x3<f32>,
   uSecondaryClamp: vec4<f32>,
@@ -649,13 +674,175 @@ fn mainFragment(
   let prevColor = textureSample(uTexture, uSampler, clampedUv);
   let nextColor = textureSample(uNextTexture, uSampler, clampedSecondaryUv);
   let maskValue = sampleMaskValue(clampedSecondaryUv);
-  let reveal = mix(
+  let reveal = clamp(replaceMaskUniforms.uMaskActive, 0.0, 1.0) * mix(
     sampleReveal(maskValue),
     clamp(maskValue, 0.0, 1.0),
     clamp(replaceMaskUniforms.uMaskDirectReveal, 0.0, 1.0),
   );
 
   return mix(prevColor, nextColor, reveal);
+}
+`;
+
+const MASK_ACCUMULATE_FILTER_FRAGMENT = `
+in vec2 vTextureCoord;
+out vec4 finalColor;
+
+uniform sampler2D uTexture;
+uniform sampler2D uMaskTextureA;
+uniform sampler2D uMaskTextureB;
+uniform float uProgress;
+uniform float uSoftness;
+uniform float uMaskMix;
+uniform float uMaskInvert;
+uniform float uMaskDirectReveal;
+uniform float uMaskActive;
+uniform vec4 uMaskChannelWeights;
+
+float sampleAccumulatedMaskValue(vec2 uv)
+{
+    vec4 rawMaskA = texture(uMaskTextureA, uv);
+    vec4 rawMaskB = texture(uMaskTextureB, uv);
+    float maskA = dot(rawMaskA, uMaskChannelWeights);
+    float maskB = dot(rawMaskB, uMaskChannelWeights);
+    float maskValue = mix(maskA, maskB, clamp(uMaskMix, 0.0, 1.0));
+
+    return mix(maskValue, 1.0 - maskValue, clamp(uMaskInvert, 0.0, 1.0));
+}
+
+float sampleAccumulatedReveal(float maskValue)
+{
+    float progress = clamp(uProgress, 0.0, 1.0);
+    float revealThreshold = 1.0 - clamp(maskValue, 0.0, 1.0);
+    float lowerEdge = clamp(revealThreshold - uSoftness, 0.0, 1.0);
+    float upperEdge = clamp(revealThreshold + uSoftness, 0.0, 1.0);
+
+    if (lowerEdge == upperEdge) {
+        return progress < lowerEdge ? 0.0 : 1.0;
+    }
+
+    float t = clamp((progress - lowerEdge) / (upperEdge - lowerEdge), 0.0, 1.0);
+    return t * t * (3.0 - 2.0 * t);
+}
+
+void main()
+{
+    vec2 uv = clamp(vTextureCoord, vec2(0.0), vec2(1.0));
+    float accumulated = texture(uTexture, uv).r;
+    float maskValue = sampleAccumulatedMaskValue(uv);
+    float reveal = clamp(uMaskActive, 0.0, 1.0) * mix(
+        sampleAccumulatedReveal(maskValue),
+        clamp(maskValue, 0.0, 1.0),
+        clamp(uMaskDirectReveal, 0.0, 1.0)
+    );
+    float combined = max(accumulated, reveal);
+
+    finalColor = vec4(combined, combined, combined, 1.0);
+}
+`;
+
+const MASK_ACCUMULATE_FILTER_WGSL = `
+struct GlobalFilterUniforms {
+  uInputSize: vec4<f32>,
+  uInputPixel: vec4<f32>,
+  uInputClamp: vec4<f32>,
+  uOutputFrame: vec4<f32>,
+  uGlobalFrame: vec4<f32>,
+  uOutputTexture: vec4<f32>,
+};
+
+struct ReplaceMaskUniforms {
+  uProgress: f32,
+  uSoftness: f32,
+  uMaskMix: f32,
+  uMaskInvert: f32,
+  uMaskDirectReveal: f32,
+  uMaskActive: f32,
+  uMaskChannelWeights: vec4<f32>,
+  uSecondaryMatrix: mat3x3<f32>,
+  uSecondaryClamp: vec4<f32>,
+};
+
+@group(0) @binding(0) var<uniform> gfu: GlobalFilterUniforms;
+@group(0) @binding(1) var uTexture: texture_2d<f32>;
+@group(0) @binding(2) var uSampler: sampler;
+@group(1) @binding(0) var<uniform> replaceMaskUniforms: ReplaceMaskUniforms;
+@group(1) @binding(1) var uMaskTextureA: texture_2d<f32>;
+@group(1) @binding(2) var uMaskTextureB: texture_2d<f32>;
+
+struct VSOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+};
+
+fn filterVertexPosition(aPosition: vec2<f32>) -> vec4<f32>
+{
+  var position = aPosition * gfu.uOutputFrame.zw + gfu.uOutputFrame.xy;
+
+  position.x = position.x * (2.0 / gfu.uOutputTexture.x) - 1.0;
+  position.y = position.y * (2.0 * gfu.uOutputTexture.z / gfu.uOutputTexture.y) - gfu.uOutputTexture.z;
+
+  return vec4(position, 0.0, 1.0);
+}
+
+fn filterTextureCoord(aPosition: vec2<f32>) -> vec2<f32>
+{
+  return aPosition * (gfu.uOutputFrame.zw * gfu.uInputSize.zw);
+}
+
+fn sampleAccumulatedMaskValue(uv: vec2<f32>) -> f32
+{
+  let rawMaskA = textureSample(uMaskTextureA, uSampler, uv);
+  let rawMaskB = textureSample(uMaskTextureB, uSampler, uv);
+  let maskA = dot(rawMaskA, replaceMaskUniforms.uMaskChannelWeights);
+  let maskB = dot(rawMaskB, replaceMaskUniforms.uMaskChannelWeights);
+  let maskValue = mix(maskA, maskB, clamp(replaceMaskUniforms.uMaskMix, 0.0, 1.0));
+
+  return mix(maskValue, 1.0 - maskValue, clamp(replaceMaskUniforms.uMaskInvert, 0.0, 1.0));
+}
+
+fn sampleAccumulatedReveal(maskValue: f32) -> f32
+{
+  let progress = clamp(replaceMaskUniforms.uProgress, 0.0, 1.0);
+  let revealThreshold = 1.0 - clamp(maskValue, 0.0, 1.0);
+  let lowerEdge = clamp(revealThreshold - replaceMaskUniforms.uSoftness, 0.0, 1.0);
+  let upperEdge = clamp(revealThreshold + replaceMaskUniforms.uSoftness, 0.0, 1.0);
+
+  if (lowerEdge == upperEdge) {
+    if (progress < lowerEdge) {
+      return 0.0;
+    }
+
+    return 1.0;
+  }
+
+  let t = clamp((progress - lowerEdge) / (upperEdge - lowerEdge), 0.0, 1.0);
+  return t * t * (3.0 - 2.0 * t);
+}
+
+@vertex
+fn mainVertex(@location(0) aPosition: vec2<f32>) -> VSOutput
+{
+  return VSOutput(
+    filterVertexPosition(aPosition),
+    filterTextureCoord(aPosition),
+  );
+}
+
+@fragment
+fn mainFragment(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32>
+{
+  let clampedUv = clamp(uv, vec2(0.0), vec2(1.0));
+  let accumulated = textureSample(uTexture, uSampler, clampedUv).r;
+  let maskValue = sampleAccumulatedMaskValue(clampedUv);
+  let reveal = clamp(replaceMaskUniforms.uMaskActive, 0.0, 1.0) * mix(
+    sampleAccumulatedReveal(maskValue),
+    clamp(maskValue, 0.0, 1.0),
+    clamp(replaceMaskUniforms.uMaskDirectReveal, 0.0, 1.0),
+  );
+  let combined = max(accumulated, reveal);
+
+  return vec4(combined, combined, combined, 1.0);
 }
 `;
 
@@ -898,8 +1085,8 @@ const createMaskTextures = (app, mask, width, height) => {
   throw new Error(`Unsupported replace mask kind: ${mask.kind}.`);
 };
 
-const createReplaceMaskFilter = () => {
-  const replaceMaskUniforms = new UniformGroup({
+const createReplaceMaskUniforms = ({ active = true } = {}) =>
+  new UniformGroup({
     uProgress: {
       value: 0,
       type: "f32",
@@ -920,6 +1107,10 @@ const createReplaceMaskFilter = () => {
       value: 0,
       type: "f32",
     },
+    uMaskActive: {
+      value: active ? 1 : 0,
+      type: "f32",
+    },
     uMaskChannelWeights: {
       value: new Float32Array([1, 0, 0, 0]),
       type: "vec4<f32>",
@@ -933,6 +1124,9 @@ const createReplaceMaskFilter = () => {
       type: "vec4<f32>",
     },
   });
+
+const createReplaceMaskFilter = ({ active = true } = {}) => {
+  const replaceMaskUniforms = createReplaceMaskUniforms({ active });
   const filter = Filter.from({
     gpu: {
       vertex: {
@@ -961,6 +1155,34 @@ const createReplaceMaskFilter = () => {
     filter,
     replaceMaskUniforms,
   };
+};
+
+const createMaskAccumulateFilter = ({ active = true } = {}) => {
+  const replaceMaskUniforms = createReplaceMaskUniforms({ active });
+  const filter = Filter.from({
+    gpu: {
+      vertex: {
+        source: MASK_ACCUMULATE_FILTER_WGSL,
+        entryPoint: "mainVertex",
+      },
+      fragment: {
+        source: MASK_ACCUMULATE_FILTER_WGSL,
+        entryPoint: "mainFragment",
+      },
+    },
+    gl: {
+      vertex: REPLACE_MASK_FILTER_VERTEX,
+      fragment: MASK_ACCUMULATE_FILTER_FRAGMENT,
+      name: "replace-mask-accumulate-filter",
+    },
+    resources: {
+      replaceMaskUniforms,
+      uMaskTextureA: Texture.EMPTY.source,
+      uMaskTextureB: Texture.EMPTY.source,
+    },
+  });
+
+  return { filter, replaceMaskUniforms };
 };
 
 export const selectSequenceMaskFrameState = ({
@@ -1048,6 +1270,12 @@ const createMaskTextureController = (app, mask, width, height, filter) => {
   let lastToIndex = -1;
 
   return {
+    setActive: (active) => {
+      const value = active ? 1 : 0;
+      if (replaceMaskUniforms.uniforms.uMaskActive === value) return;
+      replaceMaskUniforms.uniforms.uMaskActive = value;
+      replaceMaskUniforms.update();
+    },
     apply: (progress) => {
       const selection =
         mask?.kind === "sequence"
@@ -1084,6 +1312,133 @@ const createMaskTextureController = (app, mask, width, height, filter) => {
       replaceMaskUniforms.update();
     },
     destroy,
+  };
+};
+
+// Each filter consumes the previous grayscale reveal field and writes the
+// per-pixel maximum with its own reveal, producing an order-independent union.
+const createMaskCompositionController = ({ app, masks, width, height }) => {
+  const outputTexture = createShaderRenderTexture(width, height);
+  const sprite = new Sprite(Texture.WHITE);
+  sprite.width = width;
+  sprite.height = height;
+  sprite.tint = 0x000000;
+  sprite.filterArea = new Rectangle(0, 0, width, height);
+
+  const container = new Container();
+  container.addChild(sprite);
+
+  const entries = masks.map((mask) => {
+    const { filter } = createMaskAccumulateFilter({
+      active: !(mask.delay > 0),
+    });
+    return {
+      filter,
+      controller: createMaskTextureController(app, mask, width, height, filter),
+    };
+  });
+  sprite.filters = entries.map(({ filter }) => filter);
+
+  return {
+    textureSource: outputTexture.source,
+    controllers: entries.map(({ controller }) => controller),
+    render: () => {
+      app.renderer.render({
+        container,
+        target: outputTexture,
+        clear: true,
+        clearColor: [0, 0, 0, 1],
+      });
+    },
+    destroy: () => {
+      sprite.filters = [];
+      for (const { filter } of entries) filter.destroy();
+      for (const { controller } of entries) controller.destroy();
+      container.destroy({ children: true });
+      outputTexture.destroy(true);
+    },
+  };
+};
+
+const bindComposedMaskTexture = (filter, textureSource) => {
+  const uniforms = filter.resources.replaceMaskUniforms;
+  filter.resources.uMaskTextureA = textureSource;
+  filter.resources.uMaskTextureB = textureSource;
+  uniforms.uniforms.uProgress = 0;
+  uniforms.uniforms.uSoftness = 0.001;
+  uniforms.uniforms.uMaskMix = 0;
+  uniforms.uniforms.uMaskInvert = 0;
+  uniforms.uniforms.uMaskDirectReveal = 1;
+  uniforms.uniforms.uMaskActive = 1;
+  uniforms.uniforms.uMaskChannelWeights = OUTPUT_MASK_CHANNEL_WEIGHTS;
+  uniforms.update();
+};
+
+const createOverlayMaskResources = ({
+  app,
+  masks,
+  width,
+  height,
+  nextTextureSource,
+  sprite,
+}) => {
+  if (!masks?.length) {
+    return null;
+  }
+
+  const singleMask = masks.length === 1 ? masks[0] : null;
+  const { filter } = createReplaceMaskFilter({
+    active: singleMask ? !(singleMask.delay > 0) : true,
+  });
+  filter.resources.uNextTexture = nextTextureSource;
+
+  let composition = null;
+  let controllers;
+  if (singleMask) {
+    controllers = [
+      createMaskTextureController(app, singleMask, width, height, filter),
+    ];
+  } else {
+    composition = createMaskCompositionController({
+      app,
+      masks,
+      width,
+      height,
+    });
+    controllers = composition.controllers;
+    bindComposedMaskTexture(filter, composition.textureSource);
+  }
+
+  const secondaryClamp = createFullFrameClamp(width, height);
+  const baseApplyFilter =
+    typeof filter.apply === "function"
+      ? filter.apply.bind(filter)
+      : (filterManager, input, output, clearMode) => {
+          filterManager.applyFilter(filter, input, output, clearMode);
+        };
+  filter.apply = (filterManager, input, output, clearMode) => {
+    const replaceMaskUniforms = filter.resources.replaceMaskUniforms;
+    filterManager.calculateSpriteMatrix(
+      replaceMaskUniforms.uniforms.uSecondaryMatrix,
+      sprite,
+    );
+    replaceMaskUniforms.uniforms.uSecondaryClamp = secondaryClamp;
+    replaceMaskUniforms.update();
+    baseApplyFilter(filterManager, input, output, clearMode);
+  };
+
+  return {
+    filter,
+    controllers,
+    render: () => composition?.render(),
+    destroy: () => {
+      filter.destroy();
+      if (composition) {
+        composition.destroy();
+      } else {
+        controllers[0].destroy();
+      }
+    },
   };
 };
 
@@ -1496,40 +1851,17 @@ const createCompositorOverlay = ({
       return parameter;
     });
 
-  let maskFilter = null;
-  let maskTextureController = null;
-  if (animation.mask) {
-    ({ filter: maskFilter } = createReplaceMaskFilter());
-    maskFilter.resources.uNextTexture = nextTexture.source;
-
-    const baseApplyMaskFilter =
-      typeof maskFilter.apply === "function"
-        ? maskFilter.apply.bind(maskFilter)
-        : (filterManager, input, output, clearMode) => {
-            filterManager.applyFilter(maskFilter, input, output, clearMode);
-          };
-    maskFilter.apply = (filterManager, input, output, clearMode) => {
-      const replaceMaskUniforms = maskFilter.resources.replaceMaskUniforms;
-      filterManager.calculateSpriteMatrix(
-        replaceMaskUniforms.uniforms.uSecondaryMatrix,
-        sprite,
-      );
-      replaceMaskUniforms.uniforms.uSecondaryClamp = nextTextureClamp;
-      replaceMaskUniforms.update();
-      baseApplyMaskFilter(filterManager, input, output, clearMode);
-    };
-
-    maskTextureController = createMaskTextureController(
-      app,
-      animation.mask,
-      unionBounds.width,
-      unionBounds.height,
-      maskFilter,
-    );
-  }
+  const maskResources = createOverlayMaskResources({
+    app,
+    masks: animation.mask,
+    width: unionBounds.width,
+    height: unionBounds.height,
+    nextTextureSource: nextTexture.source,
+    sprite,
+  });
 
   sprite.filters = [
-    ...(maskFilter ? [maskFilter] : []),
+    ...(maskResources ? [maskResources.filter] : []),
     ...compositorEffect.filters,
   ];
 
@@ -1538,7 +1870,7 @@ const createCompositorOverlay = ({
     program,
     prevSubject,
     nextSubject,
-    maskController: maskTextureController,
+    maskControllers: maskResources?.controllers,
     compositorEffect,
     validateTerminal: true,
   });
@@ -1572,6 +1904,7 @@ const createCompositorOverlay = ({
     timelineController,
     apply: (time) => {
       timelineController.apply(time);
+      maskResources?.render();
 
       if (
         prevSubject?.wrapper &&
@@ -1610,8 +1943,7 @@ const createCompositorOverlay = ({
       timelineController.destroy();
       overlay.removeFromParent();
       sprite.filters = [];
-      maskFilter?.destroy();
-      maskTextureController?.destroy();
+      maskResources?.destroy();
       destroyShaderEffect(compositorEffect);
       cleanupParticlesInTree({ app, root: overlay });
       cleanupParticlesInTree({ app, root: prevRoot });
@@ -1684,43 +2016,21 @@ const createMaskedOverlay = ({
   );
   overlay.addChild(sprite);
 
-  const { filter: maskFilter } = createReplaceMaskFilter();
-  maskFilter.resources.uNextTexture = nextTexture.source;
-  sprite.filters = [maskFilter];
-  const secondaryClamp = createFullFrameClamp(
-    unionBounds.width,
-    unionBounds.height,
-  );
-  const baseApplyMaskFilter =
-    typeof maskFilter.apply === "function"
-      ? maskFilter.apply.bind(maskFilter)
-      : (filterManager, input, output, clearMode) => {
-          filterManager.applyFilter(maskFilter, input, output, clearMode);
-        };
-  maskFilter.apply = (filterManager, input, output, clearMode) => {
-    const replaceMaskUniforms = maskFilter.resources.replaceMaskUniforms;
-    filterManager.calculateSpriteMatrix(
-      replaceMaskUniforms.uniforms.uSecondaryMatrix,
-      sprite,
-    );
-    replaceMaskUniforms.uniforms.uSecondaryClamp = secondaryClamp;
-    replaceMaskUniforms.update();
-    baseApplyMaskFilter(filterManager, input, output, clearMode);
-  };
-
-  const maskTextureController = createMaskTextureController(
+  const maskResources = createOverlayMaskResources({
     app,
-    animation.mask,
-    unionBounds.width,
-    unionBounds.height,
-    maskFilter,
-  );
+    masks: animation.mask,
+    width: unionBounds.width,
+    height: unionBounds.height,
+    nextTextureSource: nextTexture.source,
+    sprite,
+  });
+  sprite.filters = [maskResources.filter];
   const timelineController = createTransitionTimelineController({
     animation,
     program,
     prevSubject,
     nextSubject,
-    maskController: maskTextureController,
+    maskControllers: maskResources.controllers,
     validateTerminal: true,
   });
   let prevStaticRendered = false;
@@ -1750,6 +2060,7 @@ const createMaskedOverlay = ({
     timelineController,
     apply: (time) => {
       timelineController.apply(time);
+      maskResources.render();
 
       if (
         prevSubject?.wrapper &&
@@ -1781,7 +2092,7 @@ const createMaskedOverlay = ({
       timelineController.destroy();
       overlay.removeFromParent();
       sprite.filters = [];
-      maskFilter.destroy();
+      maskResources.destroy();
       cleanupParticlesInTree({ app, root: overlay });
       cleanupParticlesInTree({ app, root: prevRoot });
       cleanupParticlesInTree({ app, root: nextRoot });
@@ -1792,7 +2103,6 @@ const createMaskedOverlay = ({
       nextTexture.destroy(true);
       destroySubjectSnapshot(prevSubject, app);
       destroySubjectSnapshot(nextSubject, app);
-      maskTextureController.destroy();
     },
   };
 };
@@ -1954,10 +2264,20 @@ export const runReplaceAnimation = ({
     sourcePath: `animation.${animation.id}`,
   });
   for (const query of Object.values(transitionProgram.targetQueries)) {
-    if (query.kind === "transitionMask" && !animation.mask) {
-      throw new Error(
-        `Transition animation "${animation.id}" targets a mask but has no mask resource.`,
-      );
+    if (query.kind === "transitionMask") {
+      if (!animation.mask?.length) {
+        throw new Error(
+          `Transition animation "${animation.id}" targets a mask but has no mask resource.`,
+        );
+      }
+      if (
+        query.index !== undefined &&
+        animation.mask[query.index] === undefined
+      ) {
+        throw new Error(
+          `Transition animation "${animation.id}" targets missing mask index ${query.index}.`,
+        );
+      }
     }
     if (query.kind === "transitionCompositor" && !animation.compositor) {
       throw new Error(

--- a/src/plugins/animations/timeline/bindProgram.js
+++ b/src/plugins/animations/timeline/bindProgram.js
@@ -68,13 +68,16 @@ const defaultResolveQuery = (query, alias, context) => {
           `transition:${query.surface}`,
         ),
       ].filter(Boolean);
-    case "transitionMask":
-      return [
-        normalizeTarget(
-          getRegistryValue(context.transitionTargets, "mask"),
-          "transition:mask",
-        ),
-      ].filter(Boolean);
+    case "transitionMask": {
+      const registered = getRegistryValue(context.transitionTargets, "mask");
+      const masks = Array.isArray(registered) ? registered : [registered];
+      const selected = query.index === undefined ? masks : [masks[query.index]];
+      return selected
+        .map((mask, index) =>
+          normalizeTarget(mask, `transition:mask:${query.index ?? index}`),
+        )
+        .filter(Boolean);
+    }
     case "transitionCompositor":
       return [
         normalizeTarget(

--- a/src/plugins/animations/timeline/compileLegacyTransition.js
+++ b/src/plugins/animations/timeline/compileLegacyTransition.js
@@ -3,6 +3,17 @@ import { compilePortableGsapAnimation } from "./compilePortableGsap.js";
 const toPortableFrameValue = (frame) =>
   frame.relative ? { by: frame.value } : frame.value;
 
+const addInitialTrackDelay = (config, delay = 0) => {
+  if (delay === 0) return config;
+
+  return {
+    ...config,
+    keyframes: config.keyframes.map((frame, index) =>
+      index === 0 ? { ...frame, delay: (frame.delay ?? 0) + delay } : frame,
+    ),
+  };
+};
+
 const addLegacyTrack = (steps, { target, property, config }) => {
   const children = [];
   if (config.initialValue !== undefined) {
@@ -53,11 +64,11 @@ export const compileLegacyTransitionAnimation = (
   )) {
     addLegacyTrack(parallel, { target: "next", property, config });
   }
-  if (animation.mask?.progress) {
+  for (const [index, mask] of (animation.mask ?? []).entries()) {
     addLegacyTrack(parallel, {
-      target: "mask",
+      target: `mask-${index}`,
       property: "progress",
-      config: animation.mask.progress,
+      config: addInitialTrackDelay(mask.progress, mask.delay),
     });
   }
   for (const [property, config] of Object.entries(
@@ -92,7 +103,12 @@ export const compileLegacyTransitionAnimation = (
         targets: {
           previous: { transitionSurface: "prev" },
           next: { transitionSurface: "next" },
-          ...(animation.mask ? { mask: { transitionMask: true } } : {}),
+          ...Object.fromEntries(
+            (animation.mask ?? []).map((_mask, index) => [
+              `mask-${index}`,
+              { transitionMask: index },
+            ]),
+          ),
           ...(animation.compositor
             ? { compositor: { transitionCompositor: true } }
             : {}),

--- a/src/plugins/animations/timeline/compileLegacyTransition.test.js
+++ b/src/plugins/animations/timeline/compileLegacyTransition.test.js
@@ -11,26 +11,38 @@ const bindVirtualTransition = (program) => {
   const targets = {
     prev: { values: { "transform.x": 10, "appearance.alpha": 1 } },
     next: { values: { "transform.x": 0, "appearance.alpha": 1 } },
-    mask: { values: { "transition.mask.progress": 0 } },
+    mask: [
+      { values: { "transition.mask.progress": 0 } },
+      { values: { "transition.mask.progress": 0 } },
+    ],
     compositor: { values: { "transition.compositor.progress": 0 } },
   };
   return bindTimelineProgram(program, {
     capabilities: new Set(program.requirements),
-    transitionTargets: Object.fromEntries(
-      Object.entries(targets).map(([key, handle]) => [
-        key,
-        {
-          handle,
-          identity: `transition:${key}`,
-          subject: {
-            x: handle.values["transform.x"] ?? 0,
-            y: 0,
-            width: 100,
-            height: 50,
-          },
-        },
-      ]),
-    ),
+    transitionTargets: {
+      ...Object.fromEntries(
+        Object.entries(targets)
+          .filter(([key]) => key !== "mask")
+          .map(([key, handle]) => [
+            key,
+            {
+              handle,
+              identity: `transition:${key}`,
+              subject: {
+                x: handle.values["transform.x"] ?? 0,
+                y: 0,
+                width: 100,
+                height: 50,
+              },
+            },
+          ]),
+      ),
+      mask: targets.mask.map((handle, index) => ({
+        handle,
+        identity: `transition:mask:${index}`,
+        subject: { x: 0, y: 0, width: 100, height: 50 },
+      })),
+    },
     channelRegistry: {
       resolve: (target, channel) => ({
         get: () => target.handle.values[channel] ?? 0,
@@ -63,14 +75,16 @@ describe("legacy transition compiler", () => {
             },
           },
         },
-        mask: {
-          kind: "single",
-          texture: "mask.png",
-          progress: {
-            initialValue: 0,
-            keyframes: [{ value: 1, duration: 100, easing: "linear" }],
+        mask: [
+          {
+            kind: "single",
+            texture: "mask.png",
+            progress: {
+              initialValue: 0,
+              keyframes: [{ value: 1, duration: 100, easing: "linear" }],
+            },
           },
-        },
+        ],
         compositor: {
           type: "shader",
           source: {
@@ -117,5 +131,95 @@ describe("legacy transition compiler", () => {
       type: "transition",
     });
     expect(program.domains.root.cycleDuration).toBe(0);
+  });
+
+  it("compiles each mask into an independently indexed timeline target", () => {
+    const [animation] = normalizeAnimations([
+      {
+        id: "two-masks",
+        targetId: "scene",
+        type: "transition",
+        mask: [
+          {
+            kind: "single",
+            texture: "left.png",
+            progress: {
+              initialValue: 0,
+              keyframes: [{ value: 1, duration: 100, easing: "linear" }],
+            },
+          },
+          {
+            kind: "single",
+            texture: "right.png",
+            delay: 50,
+            progress: {
+              initialValue: 0,
+              keyframes: [{ value: 1, duration: 200, easing: "linear" }],
+            },
+          },
+        ],
+      },
+    ]);
+    const program = compileLegacyTransitionAnimation(animation);
+    const instance = bindVirtualTransition(program);
+    const evaluator = createGsapTimelineEvaluator(instance);
+    const valuesAt = (time) =>
+      Object.fromEntries(
+        evaluator
+          .evaluate(time)
+          .values.map(({ targetIdentity, value }) => [targetIdentity, value]),
+      );
+
+    expect(instance.duration).toBe(250);
+    expect(program.targetQueries).toMatchObject({
+      "mask-0": { kind: "transitionMask", index: 0 },
+      "mask-1": { kind: "transitionMask", index: 1 },
+    });
+    expect(valuesAt(25)).toMatchObject({
+      "transition:mask:0": 0.25,
+      "transition:mask:1": 0,
+    });
+    expect(valuesAt(150)).toMatchObject({
+      "transition:mask:0": 1,
+      "transition:mask:1": 0.5,
+    });
+    evaluator.destroy();
+  });
+
+  it("starts mask progress after mask delay and any progress hold", () => {
+    const [animation] = normalizeAnimations([
+      {
+        id: "delayed-mask",
+        targetId: "scene",
+        type: "transition",
+        mask: [
+          {
+            kind: "single",
+            texture: "mask.png",
+            delay: 200,
+            progress: {
+              initialValue: 0,
+              keyframes: [
+                { value: 1, delay: 50, duration: 100, easing: "linear" },
+              ],
+            },
+          },
+        ],
+      },
+    ]);
+    const program = compileLegacyTransitionAnimation(animation);
+    const instance = bindVirtualTransition(program);
+    const evaluator = createGsapTimelineEvaluator(instance);
+    const sample = (time) =>
+      evaluator
+        .evaluate(time)
+        .values.find(({ channel }) => channel === "transition.mask.progress")
+        ?.value;
+
+    expect(instance.duration).toBe(350);
+    expect(sample(249)).toBe(0);
+    expect(sample(300)).toBeCloseTo(0.5);
+    expect(animation.mask[0].progress.keyframes[0].delay).toBe(50);
+    evaluator.destroy();
   });
 });

--- a/src/plugins/animations/timeline/compilePortableGsap.js
+++ b/src/plugins/animations/timeline/compilePortableGsap.js
@@ -220,7 +220,12 @@ const normalizeTargetQueries = (animation) => {
       };
       kinds.set(alias, "transitionSurface");
     } else if (definition.transitionMask !== undefined) {
-      queries[alias] = { kind: "transitionMask" };
+      queries[alias] = {
+        kind: "transitionMask",
+        ...(definition.transitionMask === true
+          ? {}
+          : { index: definition.transitionMask }),
+      };
       kinds.set(alias, "transitionMask");
     } else {
       queries[alias] = { kind: "transitionCompositor" };
@@ -468,6 +473,9 @@ export const compilePortableGsapAnimation = (
         total += count;
       }
       return total;
+    }
+    if (query.kind === "transitionMask") {
+      return query.index === undefined ? (animation.mask?.length ?? 0) : 1;
     }
     if (query.kind.startsWith("transition")) return 1;
     return null;

--- a/src/plugins/animations/timeline/compilePortableGsap.test.js
+++ b/src/plugins/animations/timeline/compilePortableGsap.test.js
@@ -321,7 +321,10 @@ describe("portable GSAP frontend compiler", () => {
       id: "handoff",
       targetId: "root",
       type: "transition",
-      mask: { kind: "single", texture: "mask.png" },
+      mask: [
+        { kind: "single", texture: "mask-a.png" },
+        { kind: "single", texture: "mask-b.png" },
+      ],
       compositor: {
         type: "shader",
         source: {
@@ -337,6 +340,7 @@ describe("portable GSAP frontend compiler", () => {
         targets: {
           previous: { transitionSurface: "prev" },
           reveal: { transitionMask: true },
+          secondReveal: { transitionMask: 1 },
           effect: { transitionCompositor: true },
         },
         steps: [
@@ -369,6 +373,10 @@ describe("portable GSAP frontend compiler", () => {
       },
     });
     expect(program.duration).toBe(100);
+    expect(program.targetQueries).toMatchObject({
+      reveal: { kind: "transitionMask" },
+      secondReveal: { kind: "transitionMask", index: 1 },
+    });
     expect(program.clipTemplates.map(({ channel }) => channel)).toEqual([
       "appearance.alpha",
       "transition.mask.progress",

--- a/src/plugins/animations/timeline/normalizePortableGsap.js
+++ b/src/plugins/animations/timeline/normalizePortableGsap.js
@@ -435,9 +435,24 @@ const validateTarget = (target, path, animationType) => {
         `${path}.transitionSurface must be prev or next on a transition.`,
       );
     }
-  } else if (kind === "transitionMask" || kind === "transitionCompositor") {
-    if (animationType !== "transition" || target[kind] !== true) {
-      throw new Error(`${path}.${kind} must be true on a transition.`);
+  } else if (kind === "transitionMask") {
+    const selector = target.transitionMask;
+    if (
+      animationType !== "transition" ||
+      (selector !== true && (!Number.isSafeInteger(selector) || selector < 0))
+    ) {
+      throw new Error(
+        `${path}.transitionMask must be true or a non-negative mask index on a transition.`,
+      );
+    }
+  } else if (kind === "transitionCompositor") {
+    if (
+      animationType !== "transition" ||
+      target.transitionCompositor !== true
+    ) {
+      throw new Error(
+        `${path}.transitionCompositor must be true on a transition.`,
+      );
     }
   } else throw new Error(`${path}.${kind} is not a supported target kind.`);
 };

--- a/src/plugins/animations/timeline/validateProgram.js
+++ b/src/plugins/animations/timeline/validateProgram.js
@@ -222,6 +222,14 @@ const validateTargetQuery = (query, path) => {
       }
       break;
     case "transitionMask":
+      assertKnownFields(query, new Set(["kind", "index"]), path);
+      if (
+        query.index !== undefined &&
+        (!Number.isSafeInteger(query.index) || query.index < 0)
+      ) {
+        throw new Error(`${path}.index must be a non-negative safe integer.`);
+      }
+      break;
     case "transitionCompositor":
       assertKnownFields(query, new Set(["kind"]), path);
       break;

--- a/src/plugins/animations/tween/docs/README.md
+++ b/src/plugins/animations/tween/docs/README.md
@@ -169,16 +169,17 @@ states:
         targetId: "scene-root"
         type: "transition"
         mask:
-          kind: "single"
-          texture: "masks/spiral-07.png"
-          channel: "red"
-          softness: 0.08
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 900
-                value: 1
-                easing: linear
+          - kind: "single"
+            texture: "masks/spiral-07.png"
+            channel: "red"
+            softness: 0.08
+            delay: 200
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 900
+                  value: 1
+                  easing: linear
 ```
 
 Sequence mask transition:
@@ -198,22 +199,22 @@ states:
         targetId: "scene-root"
         type: "transition"
         mask:
-          kind: "sequence"
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 900
-                value: 1
-                easing: linear
-          sample: "linear"
-          frames:
-            - at: 0
-              texture: "masks/wipe-a.png"
-            - at: 0.5
-              texture: "masks/wipe-b.png"
-            - at: 1
-              texture: "masks/wipe-c.png"
-          channel: "alpha"
+          - kind: "sequence"
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 900
+                  value: 1
+                  easing: linear
+            sample: "linear"
+            frames:
+              - at: 0
+                texture: "masks/wipe-a.png"
+              - at: 0.5
+                texture: "masks/wipe-b.png"
+              - at: 1
+                texture: "masks/wipe-c.png"
+            channel: "alpha"
 ```
 
 For sequence masks, `progress` drives frame selection. The sampled frame value
@@ -223,10 +224,16 @@ frames must start at `0`, end at `1`, and be sorted by unique `at` values.
 Feathering belongs in the frame alpha; `softness` is not valid for sequence
 masks.
 
+`mask` accepts the existing single-object shape or a non-empty array. A single
+object is normalized internally to a one-entry array. Each entry has its own
+progress and optional delay. Entries combine as a per-pixel maximum reveal: the
+strongest mask wins where they overlap, while delayed masks contribute no reveal
+before they start.
+
 ## Current Transition Rules
 
 - `update` is update-only. Integrations should reject `type: update` for enter, exit, and replace paths.
-- `mask` is transition-only.
+- `mask` is transition-only and accepts one object or a non-empty array.
 - a custom shader-backed transition uses an inline `compositor` with
   `compositor.tween.progress` and optional parameter timelines.
 - `prev.tween` and `next.tween` can be combined with `mask`.

--- a/src/schemas/animations/animation.yaml
+++ b/src/schemas/animations/animation.yaml
@@ -426,6 +426,12 @@ $defs:
       sample:
         type: string
         enum: [hold, linear]
+      delay:
+        type: integer
+        minimum: 0
+        maximum: 9007199254740991
+        default: 0
+        description: Time in milliseconds before the mask becomes active and its progress timeline begins.
       progress:
         $ref: "#/$defs/maskProgress"
     additionalProperties: false
@@ -538,7 +544,11 @@ $defs:
         properties: { transitionSurface: { enum: [prev, next] } }
         additionalProperties: false
       - required: [transitionMask]
-        properties: { transitionMask: { const: true } }
+        properties:
+          transitionMask:
+            oneOf:
+              - { const: true }
+              - { type: integer, minimum: 0, maximum: 9007199254740991 }
         additionalProperties: false
       - required: [transitionCompositor]
         properties: { transitionCompositor: { const: true } }
@@ -892,7 +902,12 @@ properties:
   next:
     $ref: "#/$defs/transitionSide"
   mask:
-    $ref: "#/$defs/mask"
+    oneOf:
+      - $ref: "#/$defs/mask"
+      - type: array
+        minItems: 1
+        items:
+          $ref: "#/$defs/mask"
   compositor:
     $ref: "../shader-config.yaml#/definitions/compositor"
 additionalProperties: false

--- a/src/types.js
+++ b/src/types.js
@@ -930,7 +930,7 @@ export const DEFAULT_TEXT_STYLE = {
  * @property {Object & {filters?: Object<string, ShaderTween>}} [tween] - Standard update properties plus filter parameter timelines grouped by filter id
  * @property {Object} [prev] - Previous transition surface motion
  * @property {Object} [next] - Next transition surface motion
- * @property {Object} [mask] - Transition mask configuration
+ * @property {(Object & {delay?: number}) | (Object & {delay?: number})[]} [mask] - One transition mask or an ordered mask array; normalized internally to an array
  * @property {ShaderCompositor} [compositor] - Inline transition compositor effect with co-located parameter timelines
  */
 

--- a/src/util/normalizeAnimations.js
+++ b/src/util/normalizeAnimations.js
@@ -775,6 +775,13 @@ const normalizeMask = (mask, path) => {
     kind: mask.kind,
   };
 
+  if (mask.delay !== undefined) {
+    assertNonNegativeSafeIntegerMilliseconds(mask.delay, `${path}.delay`);
+    if (mask.delay > 0) {
+      normalized.delay = mask.delay;
+    }
+  }
+
   if (mask.channel !== undefined) {
     if (!MASK_CHANNELS.has(mask.channel)) {
       throw new Error(
@@ -864,6 +871,18 @@ const normalizeMask = (mask, path) => {
   return normalized;
 };
 
+const normalizeMasks = (maskOrMasks, path) => {
+  const usesArrayShape = Array.isArray(maskOrMasks);
+  if (usesArrayShape && maskOrMasks.length === 0) {
+    throw new Error(`${path} must be a non-empty array.`);
+  }
+
+  const masks = usesArrayShape ? maskOrMasks : [maskOrMasks];
+  return masks.map((mask, index) =>
+    normalizeMask(mask, usesArrayShape ? `${path}[${index}]` : path),
+  );
+};
+
 const normalizeReplaceSide = (side, path) => {
   assertPlainObject(side, path);
 
@@ -900,7 +919,7 @@ const normalizeReplacePayload = (animation, path) => {
   }
 
   if (animation.mask !== undefined) {
-    normalized.mask = normalizeMask(animation.mask, `${path}.mask`);
+    normalized.mask = normalizeMasks(animation.mask, `${path}.mask`);
   }
 
   if (animation.compositor !== undefined) {
@@ -1104,16 +1123,31 @@ export const normalizeAnimations = (animations = []) => {
       );
 
       if (animation.mask !== undefined) {
-        if (animation.mask.progress !== undefined) {
-          throw new Error(
-            `${path}.mask.progress cannot be mixed with top-level gsap. Animate the transitionMask target instead.`,
-          );
-        }
-        normalizedAnimation.mask = normalizeMask(
+        const usesArrayShape = Array.isArray(animation.mask);
+        const authoredMasks = usesArrayShape
+          ? animation.mask
+          : [animation.mask];
+        normalizedAnimation.mask = normalizeMasks(
           animation.mask,
           `${path}.mask`,
-        );
-        delete normalizedAnimation.mask.progress;
+        ).map((mask, index) => {
+          const maskPath = usesArrayShape
+            ? `${path}.mask[${index}]`
+            : `${path}.mask`;
+          if (mask.delay > 0) {
+            throw new Error(
+              `${maskPath}.delay cannot be mixed with top-level gsap. Delay the transitionMask action instead.`,
+            );
+          }
+          if (authoredMasks[index].progress !== undefined) {
+            throw new Error(
+              `${maskPath}.progress cannot be mixed with top-level gsap. Animate the transitionMask target instead.`,
+            );
+          }
+          const resource = { ...mask };
+          delete resource.progress;
+          return resource;
+        });
       }
 
       if (animation.compositor !== undefined) {

--- a/src/util/normalizeAnimations.test.js
+++ b/src/util/normalizeAnimations.test.js
@@ -77,13 +77,16 @@ describe("normalizeAnimations shader support", () => {
         id: "delayed-transition",
         targetId: "scene",
         type: "transition",
-        mask: {
-          kind: "single",
-          texture: "wipe",
-          progress: {
-            keyframes: [{ delay: 500, duration: 600, value: 1 }],
+        mask: [
+          {
+            kind: "single",
+            texture: "wipe",
+            delay: 400,
+            progress: {
+              keyframes: [{ delay: 500, duration: 600, value: 1 }],
+            },
           },
-        },
+        ],
         compositor: createCompositor({
           parameters: { edgeWidth: 0.04 },
           tween: {
@@ -117,7 +120,8 @@ describe("normalizeAnimations shader support", () => {
       duration: 400,
       value: [0.2, 0.4, 0.6],
     });
-    expect(transitionAnimation.mask.progress.keyframes[0].delay).toBe(500);
+    expect(transitionAnimation.mask[0].delay).toBe(400);
+    expect(transitionAnimation.mask[0].progress.keyframes[0].delay).toBe(500);
     expect(
       transitionAnimation.compositor.tween.uProgress.keyframes[0].delay,
     ).toBe(700);
@@ -181,20 +185,38 @@ describe("normalizeAnimations shader support", () => {
       "animations[0].tween.filters.grade.amount.keyframes[0].delay",
     ],
     [
+      "mask start",
+      {
+        id: "invalid-mask-start-delay",
+        targetId: "scene",
+        type: "transition",
+        mask: [
+          {
+            kind: "single",
+            texture: "wipe",
+            delay: -1,
+          },
+        ],
+      },
+      "animations[0].mask[0].delay",
+    ],
+    [
       "mask progress",
       {
         id: "invalid-mask-delay",
         targetId: "scene",
         type: "transition",
-        mask: {
-          kind: "single",
-          texture: "wipe",
-          progress: {
-            keyframes: [{ delay: -1, duration: 100, value: 1 }],
+        mask: [
+          {
+            kind: "single",
+            texture: "wipe",
+            progress: {
+              keyframes: [{ delay: -1, duration: 100, value: 1 }],
+            },
           },
-        },
+        ],
       },
-      "animations[0].mask.progress.keyframes[0].delay",
+      "animations[0].mask[0].progress.keyframes[0].delay",
     ],
     [
       "compositor progress",
@@ -215,6 +237,126 @@ describe("normalizeAnimations shader support", () => {
   ])("reports the exact invalid %s delay path", (_name, animation, path) => {
     expect(() => normalizeAnimations([animation])).toThrow(
       `${path} must be a finite number greater than or equal to 0 and an integer number of milliseconds.`,
+    );
+  });
+
+  it("treats an explicit zero mask delay like an omitted delay", () => {
+    const [animation] = normalizeAnimations([
+      {
+        id: "immediate-mask",
+        targetId: "scene",
+        type: "transition",
+        mask: [{ kind: "single", texture: "wipe", delay: 0 }],
+      },
+    ]);
+
+    expect(animation.mask[0]).not.toHaveProperty("delay");
+  });
+
+  it("normalizes multiple masks with independent progress and delay", () => {
+    const [animation] = normalizeAnimations([
+      {
+        id: "multi-mask",
+        targetId: "scene",
+        type: "transition",
+        mask: [
+          { kind: "single", texture: "left" },
+          { kind: "single", texture: "right", delay: 250 },
+        ],
+      },
+    ]);
+
+    expect(animation.mask).toHaveLength(2);
+    expect(animation.mask[0]).toMatchObject({
+      kind: "single",
+      texture: "left",
+    });
+    expect(animation.mask[1]).toMatchObject({
+      kind: "single",
+      texture: "right",
+      delay: 250,
+    });
+  });
+
+  it("normalizes the legacy single-object mask shape to one array entry", () => {
+    const sourceMask = { kind: "single", texture: "wipe", delay: 100 };
+    const [animation] = normalizeAnimations([
+      {
+        id: "legacy-mask-object",
+        targetId: "scene",
+        type: "transition",
+        mask: sourceMask,
+      },
+    ]);
+
+    expect(animation.mask).toEqual([
+      expect.objectContaining({
+        kind: "single",
+        texture: "wipe",
+        delay: 100,
+      }),
+    ]);
+    expect(animation.mask[0]).not.toBe(sourceMask);
+  });
+
+  it("rejects an empty transition mask array", () => {
+    expect(() =>
+      normalizeAnimations([
+        {
+          id: "invalid-mask-array",
+          targetId: "scene",
+          type: "transition",
+          mask: [],
+        },
+      ]),
+    ).toThrow("animations[0].mask must be a non-empty array.");
+  });
+
+  it("preserves legacy mask error paths for top-level gsap", () => {
+    expect(() =>
+      normalizeAnimations([
+        {
+          id: "legacy-gsap-mask-delay",
+          targetId: "scene",
+          type: "transition",
+          mask: { kind: "single", texture: "wipe", delay: 100 },
+          gsap: {
+            profile: "portable-v1",
+            targets: { reveal: { transitionMask: true } },
+            steps: [
+              { kind: "set", targets: "reveal", values: { progress: 1 } },
+            ],
+          },
+        },
+      ]),
+    ).toThrow(
+      "animations[0].mask.delay cannot be mixed with top-level gsap. Delay the transitionMask action instead.",
+    );
+  });
+
+  it("keeps mask resource timing out of orchestrated gsap transitions", () => {
+    expect(() =>
+      normalizeAnimations([
+        {
+          id: "orchestrated-mask-delay",
+          targetId: "scene",
+          type: "transition",
+          mask: [{ kind: "single", texture: "wipe", delay: 100 }],
+          gsap: {
+            profile: "portable-v1",
+            targets: { reveal: { transitionMask: true } },
+            steps: [
+              {
+                kind: "set",
+                targets: "reveal",
+                values: { progress: 1 },
+              },
+            ],
+          },
+        },
+      ]),
+    ).toThrow(
+      "animations[0].mask[0].delay cannot be mixed with top-level gsap. Delay the transitionMask action instead.",
     );
   });
 
@@ -482,14 +624,16 @@ describe("normalizeAnimations shader support", () => {
         targetId: "scene",
         type: "transition",
         compositor: createCompositor(),
-        mask: {
-          kind: "single",
-          texture: "mask-diagonal",
-        },
+        mask: [
+          {
+            kind: "single",
+            texture: "mask-diagonal",
+          },
+        ],
       },
     ]);
 
-    expect(animation.mask.texture).toBe("mask-diagonal");
+    expect(animation.mask[0].texture).toBe("mask-diagonal");
     expect(animation.compositor.type).toBe("shader");
   });
 

--- a/vt/reference/replacetransition/rect-mask-single-array-delay-01.webp
+++ b/vt/reference/replacetransition/rect-mask-single-array-delay-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfd595979ab50a5466e93a5b6295c3f6c6fda7d1c999d12c6f399b986a9eeb7e
+size 1850

--- a/vt/reference/replacetransition/rect-mask-single-array-delay-02.webp
+++ b/vt/reference/replacetransition/rect-mask-single-array-delay-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfd595979ab50a5466e93a5b6295c3f6c6fda7d1c999d12c6f399b986a9eeb7e
+size 1850

--- a/vt/reference/replacetransition/rect-mask-single-array-delay-03.webp
+++ b/vt/reference/replacetransition/rect-mask-single-array-delay-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ceb2abdbcd752387e6cb958b55c898115c095795f84cc72ac8f7d2df82c8fbd
+size 5592

--- a/vt/reference/replacetransition/rect-mask-single-array-delay-04.webp
+++ b/vt/reference/replacetransition/rect-mask-single-array-delay-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56d8d790dea0d82c915643ea261878d18034ca4cda88bed63b7c8902c2600d22
+size 1852

--- a/vt/reference/replacetransition/rect-mask-single-object-delay-01.webp
+++ b/vt/reference/replacetransition/rect-mask-single-object-delay-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfd595979ab50a5466e93a5b6295c3f6c6fda7d1c999d12c6f399b986a9eeb7e
+size 1850

--- a/vt/reference/replacetransition/rect-mask-single-object-delay-02.webp
+++ b/vt/reference/replacetransition/rect-mask-single-object-delay-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cfd595979ab50a5466e93a5b6295c3f6c6fda7d1c999d12c6f399b986a9eeb7e
+size 1850

--- a/vt/reference/replacetransition/rect-mask-single-object-delay-03.webp
+++ b/vt/reference/replacetransition/rect-mask-single-object-delay-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ceb2abdbcd752387e6cb958b55c898115c095795f84cc72ac8f7d2df82c8fbd
+size 5592

--- a/vt/reference/replacetransition/rect-mask-single-object-delay-04.webp
+++ b/vt/reference/replacetransition/rect-mask-single-object-delay-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56d8d790dea0d82c915643ea261878d18034ca4cda88bed63b7c8902c2600d22
+size 1852

--- a/vt/specs/rendercompleteevent/render-complete-replace-mask.yaml
+++ b/vt/specs/rendercompleteevent/render-complete-replace-mask.yaml
@@ -62,13 +62,13 @@ states:
         targetId: rect1
         type: transition
         mask:
-          kind: single
-          texture: mask-diagonal
-          channel: red
-          softness: 0.06
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
-                easing: linear
+          - kind: single
+            texture: mask-diagonal
+            channel: red
+            softness: 0.06
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear

--- a/vt/specs/replacetransition/rect-mask-absolute-position.yaml
+++ b/vt/specs/replacetransition/rect-mask-absolute-position.yaml
@@ -53,12 +53,12 @@ states:
                   value: 160
                   easing: linear
         mask:
-          kind: single
-          texture: mask-full
-          channel: red
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
-                easing: linear
+          - kind: single
+            texture: mask-full
+            channel: red
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear

--- a/vt/specs/replacetransition/rect-mask-channel-showcase.yaml
+++ b/vt/specs/replacetransition/rect-mask-channel-showcase.yaml
@@ -88,16 +88,16 @@ states:
         targetId: rect1
         type: transition
         mask:
-          kind: single
-          texture: mask-rgba-channels
-          channel: red
-          softness: 0.02
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
-                easing: linear
+          - kind: single
+            texture: mask-rgba-channels
+            channel: red
+            softness: 0.02
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear
   - id: channel-green
     elements:
       - id: rect1
@@ -113,16 +113,16 @@ states:
         targetId: rect1
         type: transition
         mask:
-          kind: single
-          texture: mask-rgba-channels
-          channel: green
-          softness: 0.02
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
-                easing: linear
+          - kind: single
+            texture: mask-rgba-channels
+            channel: green
+            softness: 0.02
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear
   - id: channel-blue
     elements:
       - id: rect1
@@ -138,16 +138,16 @@ states:
         targetId: rect1
         type: transition
         mask:
-          kind: single
-          texture: mask-rgba-channels
-          channel: blue
-          softness: 0.02
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
-                easing: linear
+          - kind: single
+            texture: mask-rgba-channels
+            channel: blue
+            softness: 0.02
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear
   - id: channel-alpha
     elements:
       - id: rect1
@@ -163,16 +163,16 @@ states:
         targetId: rect1
         type: transition
         mask:
-          kind: single
-          texture: mask-rgba-channels
-          channel: alpha
-          softness: 0.02
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
-                easing: linear
+          - kind: single
+            texture: mask-rgba-channels
+            channel: alpha
+            softness: 0.02
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear
   - id: channel-red-invert
     elements:
       - id: rect1
@@ -188,14 +188,14 @@ states:
         targetId: rect1
         type: transition
         mask:
-          kind: single
-          texture: mask-rgba-channels
-          channel: red
-          invert: true
-          softness: 0.02
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
-                easing: linear
+          - kind: single
+            texture: mask-rgba-channels
+            channel: red
+            invert: true
+            softness: 0.02
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear

--- a/vt/specs/replacetransition/rect-mask-clockwipe.yaml
+++ b/vt/specs/replacetransition/rect-mask-clockwipe.yaml
@@ -50,13 +50,13 @@ states:
         targetId: rect1
         type: transition
         mask:
-          kind: single
-          texture: mask-clockwipe
-          channel: red
-          softness: 0.12
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
-                easing: linear
+          - kind: single
+            texture: mask-clockwipe
+            channel: red
+            softness: 0.12
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear

--- a/vt/specs/replacetransition/rect-mask-enter.yaml
+++ b/vt/specs/replacetransition/rect-mask-enter.yaml
@@ -37,13 +37,13 @@ states:
         targetId: rect1
         type: transition
         mask:
-          kind: single
-          texture: mask-diagonal
-          channel: red
-          softness: 0.06
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
-                easing: linear
+          - kind: single
+            texture: mask-diagonal
+            channel: red
+            softness: 0.06
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear

--- a/vt/specs/replacetransition/rect-mask-single-array-delay.yaml
+++ b/vt/specs/replacetransition/rect-mask-single-array-delay.yaml
@@ -1,0 +1,64 @@
+---
+title: Rect Mask One-Entry Array Delay
+description: A one-entry mask array waits for its delay before revealing the replacement
+specs:
+  - the one-entry mask array should remain fully hidden before its 300ms delay
+  - the mask should be halfway through its reveal at 600ms
+  - the replacement should be fully revealed at 900ms
+  - these checkpoints should match the legacy single-object compatibility spec
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 299
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 301
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 300
+  - action: screenshot
+---
+states:
+  - id: array-mask-start
+    elements:
+      - id: rect1
+        type: rect
+        x: 160
+        "y": 120
+        width: 960
+        height: 480
+        fill: "#4D4D4D"
+        alpha: 1
+  - id: array-mask-end
+    elements:
+      - id: rect1
+        type: rect
+        x: 160
+        "y": 120
+        width: 960
+        height: 480
+        fill: "#FFFFFF"
+        alpha: 1
+    animations:
+      - id: array-mask-replace
+        targetId: rect1
+        type: transition
+        mask:
+          - kind: single
+            texture: mask-diagonal
+            channel: red
+            softness: 0.06
+            delay: 300
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 600
+                  value: 1
+                  easing: linear

--- a/vt/specs/replacetransition/rect-mask-single-object-delay.yaml
+++ b/vt/specs/replacetransition/rect-mask-single-object-delay.yaml
@@ -1,0 +1,64 @@
+---
+title: Rect Mask Single Object Delay
+description: A legacy single-object mask waits for its delay before revealing the replacement
+specs:
+  - the legacy single-object mask should remain fully hidden before its 300ms delay
+  - the mask should be halfway through its reveal at 600ms
+  - the replacement should be fully revealed at 900ms
+  - these checkpoints should match the one-entry array compatibility spec
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 299
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 301
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 300
+  - action: screenshot
+---
+states:
+  - id: object-mask-start
+    elements:
+      - id: rect1
+        type: rect
+        x: 160
+        "y": 120
+        width: 960
+        height: 480
+        fill: "#4D4D4D"
+        alpha: 1
+  - id: object-mask-end
+    elements:
+      - id: rect1
+        type: rect
+        x: 160
+        "y": 120
+        width: 960
+        height: 480
+        fill: "#FFFFFF"
+        alpha: 1
+    animations:
+      - id: object-mask-replace
+        targetId: rect1
+        type: transition
+        mask:
+          kind: single
+          texture: mask-diagonal
+          channel: red
+          softness: 0.06
+          delay: 300
+          progress:
+            initialValue: 0
+            keyframes:
+              - duration: 600
+                value: 1
+                easing: linear

--- a/vt/specs/replacetransition/rect-push-mask-dissolve.yaml
+++ b/vt/specs/replacetransition/rect-push-mask-dissolve.yaml
@@ -61,13 +61,13 @@ states:
                   value: 0
                   easing: linear
         mask:
-          kind: single
-          texture: mask-diagonal
-          channel: red
-          softness: 0.06
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
-                easing: linear
+          - kind: single
+            texture: mask-diagonal
+            channel: red
+            softness: 0.06
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear

--- a/vt/specs/replacetransition/rect-sequence-mask-linear.yaml
+++ b/vt/specs/replacetransition/rect-sequence-mask-linear.yaml
@@ -45,19 +45,19 @@ states:
         targetId: rect1
         type: transition
         mask:
-          kind: sequence
-          frames:
-            - at: 0
-              texture: mask-empty
-            - at: 0.5
-              texture: mask-left-band
-            - at: 1
-              texture: mask-full
-          channel: alpha
-          sample: linear
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
-                easing: linear
+          - kind: sequence
+            frames:
+              - at: 0
+                texture: mask-empty
+              - at: 0.5
+                texture: mask-left-band
+              - at: 1
+                texture: mask-full
+            channel: alpha
+            sample: linear
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear

--- a/vt/specs/replacetransition/rect-sequence-mask-nonuniform-hold.yaml
+++ b/vt/specs/replacetransition/rect-sequence-mask-nonuniform-hold.yaml
@@ -50,18 +50,18 @@ states:
         targetId: rect1
         type: transition
         mask:
-          kind: sequence
-          frames:
-            - at: 0
-              texture: mask-empty
-            - at: 0.8
-              texture: mask-center-band
-            - at: 1
-              texture: mask-full
-          channel: alpha
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
-                easing: linear
+          - kind: sequence
+            frames:
+              - at: 0
+                texture: mask-empty
+              - at: 0.8
+                texture: mask-center-band
+              - at: 1
+                texture: mask-full
+            channel: alpha
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear

--- a/vt/specs/replacetransition/rect-sequence-mask-nonuniform-linear.yaml
+++ b/vt/specs/replacetransition/rect-sequence-mask-nonuniform-linear.yaml
@@ -50,19 +50,19 @@ states:
         targetId: rect1
         type: transition
         mask:
-          kind: sequence
-          frames:
-            - at: 0
-              texture: mask-empty
-            - at: 0.25
-              texture: mask-left-band
-            - at: 1
-              texture: mask-full
-          channel: alpha
-          sample: linear
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
-                easing: linear
+          - kind: sequence
+            frames:
+              - at: 0
+                texture: mask-empty
+              - at: 0.25
+                texture: mask-left-band
+              - at: 1
+                texture: mask-full
+            channel: alpha
+            sample: linear
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear

--- a/vt/specs/replacetransition/rect-sequence-mask-reverse-progress.yaml
+++ b/vt/specs/replacetransition/rect-sequence-mask-reverse-progress.yaml
@@ -65,24 +65,24 @@ states:
         targetId: rect1
         type: transition
         mask:
-          kind: sequence
-          frames:
-            - at: 0
-              texture: mask-empty
-            - at: 0.5
-              texture: mask-center-band
-            - at: 1
-              texture: mask-full
-          channel: alpha
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 500
-                value: 1
-                easing: linear
-              - duration: 500
-                value: 0
-                easing: linear
-              - duration: 500
-                value: 1
-                easing: linear
+          - kind: sequence
+            frames:
+              - at: 0
+                texture: mask-empty
+              - at: 0.5
+                texture: mask-center-band
+              - at: 1
+                texture: mask-full
+            channel: alpha
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 500
+                  value: 1
+                  easing: linear
+                - duration: 500
+                  value: 0
+                  easing: linear
+                - duration: 500
+                  value: 1
+                  easing: linear

--- a/vt/specs/replacetransition/rect-sequence-mask.yaml
+++ b/vt/specs/replacetransition/rect-sequence-mask.yaml
@@ -46,18 +46,18 @@ states:
         targetId: rect1
         type: transition
         mask:
-          kind: sequence
-          frames:
-            - at: 0
-              texture: mask-empty
-            - at: 0.5
-              texture: mask-center-band
-            - at: 1
-              texture: mask-full
-          channel: alpha
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 1000
-                value: 1
-                easing: linear
+          - kind: sequence
+            frames:
+              - at: 0
+                texture: mask-empty
+              - at: 0.5
+                texture: mask-center-band
+              - at: 1
+                texture: mask-full
+            channel: alpha
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 1000
+                  value: 1
+                  easing: linear

--- a/vt/specs/replacetransition/sprite-mask-asymmetric-alpha-replace.yaml
+++ b/vt/specs/replacetransition/sprite-mask-asymmetric-alpha-replace.yaml
@@ -55,13 +55,13 @@ states:
         targetId: sample-bg
         type: transition
         mask:
-          kind: single
-          texture: sprite-mask-asym-alpha
-          channel: alpha
-          softness: 0.08
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 4000
-                value: 1
-                easing: linear
+          - kind: single
+            texture: sprite-mask-asym-alpha
+            channel: alpha
+            softness: 0.08
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 4000
+                  value: 1
+                  easing: linear

--- a/vt/specs/replacetransition/sprite-mask-asymmetric-replace.yaml
+++ b/vt/specs/replacetransition/sprite-mask-asymmetric-replace.yaml
@@ -55,13 +55,13 @@ states:
         targetId: sample-bg
         type: transition
         mask:
-          kind: single
-          texture: sprite-mask-asym-red
-          channel: red
-          softness: 0.08
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 4000
-                value: 1
-                easing: linear
+          - kind: single
+            texture: sprite-mask-asym-red
+            channel: red
+            softness: 0.08
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 4000
+                  value: 1
+                  easing: linear

--- a/vt/specs/shadertransition/rect-mask-multipass-animated-compositor.yaml
+++ b/vt/specs/shadertransition/rect-mask-multipass-animated-compositor.yaml
@@ -53,14 +53,14 @@ states:
         targetId: masked-compositor-rect
         type: transition
         mask:
-          kind: single
-          texture: mask-diagonal
-          progress:
-            initialValue: 0
-            keyframes:
-              - duration: 800
-                value: 1
-                easing: linear
+          - kind: single
+            texture: mask-diagonal
+            progress:
+              initialValue: 0
+              keyframes:
+                - duration: 800
+                  value: 1
+                  easing: linear
         compositor:
           type: shader
           parameters:

--- a/vt/specs/timeline/gsap-masked-sampled-overshoot.yaml
+++ b/vt/specs/timeline/gsap-masked-sampled-overshoot.yaml
@@ -48,9 +48,9 @@ states:
         targetId: sampled-target
         type: transition
         mask:
-          kind: single
-          texture: mask-full
-          channel: red
+          - kind: single
+            texture: mask-full
+            channel: red
         gsap:
           profile: portable-v1
           targets:


### PR DESCRIPTION
## Summary
- accept legacy single-object transition masks and normalize them to one-entry arrays
- add independent per-mask delay/progress timelines and indexed portable GSAP targets
- combine overlapping reveal fields with a per-pixel maximum in WebGL and WebGPU
- migrate schemas, types, docs, parser fixtures, and visual-test specs

## Behavior
- before its delay, a mask contributes zero reveal
- overlapping masks use the strongest reveal via max(mask1, mask2, ...)
- transitionMask: true targets all masks; transitionMask: <index> targets one

## Testing
- bun run build
- focused mask/parser/timeline/runtime tests: 188 passed
- pre-commit: oxlint and prettier passed
- full suite: 1,474 passed, with 14 unrelated host/environment failures:
  - Unicode 17 property data is unavailable under Node 24.1.0
  - a PNG byte-size assertion produced 20,831 bytes versus the expected greater than 50,000 on this host
- WebGPU browser integration could not initialize the host software Vulkan device