### PR TITLE
fix: preserve anchor pivot during scale animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/animations/animationBus.spec.js
+++ b/spec/animations/animationBus.spec.js
@@ -806,7 +806,7 @@ describe("animationBus auto tween shorthand", () => {
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps a pixel transform origin stable throughout scale tweens", () => {
+  it("keeps the transform pivot fixed in local coordinates during scale tweens", () => {
     const animationBus = createAnimationBus();
     const element = {
       x: 0,
@@ -849,13 +849,13 @@ describe("animationBus auto tween shorthand", () => {
 
     expect(element.scale.x).toBeCloseTo(1);
     expect(element.scale.y).toBeCloseTo(0.5);
-    expect(element.pivot.x * element.scale.x).toBeCloseTo(20);
-    expect(element.pivot.y * element.scale.y).toBeCloseTo(10);
+    expect(element.pivot.x).toBeCloseTo(40);
+    expect(element.pivot.y).toBeCloseTo(40);
 
     animationBus.tick(100);
 
-    expect(element.pivot.x * element.scale.x).toBeCloseTo(20);
-    expect(element.pivot.y * element.scale.y).toBeCloseTo(10);
+    expect(element.pivot.x).toBeCloseTo(40);
+    expect(element.pivot.y).toBeCloseTo(40);
   });
 
   it("applies property path mapping for blur tweens", () => {

--- a/spec/elements/animatedSpriteRendering.spec.js
+++ b/spec/elements/animatedSpriteRendering.spec.js
@@ -205,6 +205,7 @@ describe("spritesheet animation rendering", () => {
     });
 
     const sprite = parent.addChild.mock.calls[0][0];
+    sprite.texture = { orig: { width: 100, height: 100 } };
     sprite.x = 333;
     sprite.y = 222;
     sprite.rotation = 1.25;
@@ -249,6 +250,45 @@ describe("spritesheet animation rendering", () => {
 
     expect(sprite.pivot.x).toBeCloseTo(pivotBeforeFrameChange.x);
     expect(sprite.pivot.y).toBeCloseTo(pivotBeforeFrameChange.y);
+  });
+
+  it("recomputes the geometry pivot without folding in the live scale", async () => {
+    const parent = {
+      destroyed: false,
+      addChild: vi.fn(),
+    };
+
+    await addAnimatedSprite({
+      app: {
+        debug: false,
+        render: vi.fn(),
+      },
+      parent,
+      element: createAnimatedSpriteElement({
+        width: 100,
+        height: 100,
+        originX: 20,
+        originY: 30,
+      }),
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker: {},
+      renderContext: {},
+      zIndex: 3,
+      signal: undefined,
+    });
+
+    const sprite = parent.addChild.mock.calls[0][0];
+    sprite.texture = { orig: { width: 200, height: 50 } };
+    sprite.scale.x = 0.75;
+    sprite.scale.y = 1;
+
+    sprite.onFrameChange(1);
+
+    expect(sprite.pivot.x).toBeCloseTo(40);
+    expect(sprite.pivot.y).toBeCloseTo(15);
+    expect(sprite.scale.x).toBeCloseTo(0.75);
+    expect(sprite.scale.y).toBeCloseTo(1);
   });
 
   it("keeps the previous origin during a live update tween", async () => {
@@ -515,6 +555,76 @@ describe("spritesheet animation rendering", () => {
       { frameName: "frame-1.png" },
       { frameName: "frame-2.png" },
     ]);
+  });
+
+  it("recomputes the pivot after a replacement atlas changes frame geometry", async () => {
+    const app = {
+      debug: false,
+      render: vi.fn(),
+    };
+    const animatedSpriteElement = new MockAnimatedSprite([
+      { frameName: "old" },
+    ]);
+    animatedSpriteElement.label = "animated-sprite-1";
+    let assignedTextures = animatedSpriteElement.textures;
+    Object.defineProperty(animatedSpriteElement, "textures", {
+      configurable: true,
+      get: () => assignedTextures,
+      set: (textures) => {
+        assignedTextures = textures;
+        animatedSpriteElement.texture = {
+          orig: { width: 200, height: 50 },
+        };
+        animatedSpriteElement.scale.x = animatedSpriteElement.width / 200;
+        animatedSpriteElement.scale.y = animatedSpriteElement.height / 50;
+      },
+    });
+    const parent = {
+      children: [animatedSpriteElement],
+    };
+    const prevElement = createAnimatedSpriteElement({
+      width: 100,
+      height: 100,
+      originX: 20,
+      originY: 30,
+    });
+    const nextElement = createAnimatedSpriteElement({
+      width: 100,
+      height: 100,
+      originX: 20,
+      originY: 30,
+      src: "fighter-spritesheet-v2",
+      atlas: {
+        frames: {
+          "frame-0.png": { x: 0, y: 0, width: 200, height: 50 },
+          "frame-1.png": { x: 200, y: 0, width: 200, height: 50 },
+          "frame-2.png": { x: 400, y: 0, width: 200, height: 50 },
+        },
+        width: 600,
+        height: 50,
+      },
+    });
+
+    await updateAnimatedSprite({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations: [],
+      animationBus: {},
+      completionTracker: {},
+      zIndex: 4,
+      signal: undefined,
+    });
+
+    expect(animatedSpriteElement.pivot.x).toBeCloseTo(40);
+    expect(animatedSpriteElement.pivot.y).toBeCloseTo(15);
+    expect(
+      animatedSpriteElement.pivot.x * animatedSpriteElement.scale.x,
+    ).toBeCloseTo(20);
+    expect(
+      animatedSpriteElement.pivot.y * animatedSpriteElement.scale.y,
+    ).toBeCloseTo(30);
   });
 
   it("reloads changed spritesheet resources before dispatching update animations", async () => {

--- a/spec/elements/animatedSpriteRendering.spec.js
+++ b/spec/elements/animatedSpriteRendering.spec.js
@@ -92,6 +92,7 @@ vi.mock("../../src/plugins/animations/planAnimations.js", () => ({
 import { addAnimatedSprite } from "../../src/plugins/elements/animated-sprite/addAnimatedSprite.js";
 import { updateAnimatedSprite } from "../../src/plugins/elements/animated-sprite/updateAnimatedSprite.js";
 import { createAnimationBus } from "../../src/plugins/animations/animationBus.js";
+import { applyElementTransform } from "../../src/plugins/elements/util/transform.js";
 import {
   cleanupDebugMode,
   setupDebugMode,
@@ -212,8 +213,8 @@ describe("spritesheet animation rendering", () => {
 
     sprite.onFrameChange(1);
 
-    expect(sprite.pivot.x * sprite.scale.x).toBeCloseTo(20);
-    expect(sprite.pivot.y * sprite.scale.y).toBeCloseTo(30);
+    expect(sprite.pivot.x).toBeCloseTo(20);
+    expect(sprite.pivot.y).toBeCloseTo(30);
     expect(sprite.x).toBe(333);
     expect(sprite.y).toBe(222);
     expect(sprite.rotation).toBe(1.25);
@@ -237,8 +238,8 @@ describe("spritesheet animation rendering", () => {
     animationBus.flush();
     animationBus.tick(100);
 
-    expect(sprite.pivot.x * sprite.scale.x).toBeCloseTo(20);
-    expect(sprite.pivot.y * sprite.scale.y).toBeCloseTo(30);
+    expect(sprite.pivot.x).toBeCloseTo(20);
+    expect(sprite.pivot.y).toBeCloseTo(30);
 
     const pivotBeforeFrameChange = {
       x: sprite.pivot.x,
@@ -295,6 +296,7 @@ describe("spritesheet animation rendering", () => {
     });
     animatedSpriteElement.x = prevElement.x + prevElement.originX;
     animatedSpriteElement.y = prevElement.y + prevElement.originY;
+    applyElementTransform(animatedSpriteElement, prevElement);
 
     await updateAnimatedSprite({
       app,
@@ -314,12 +316,8 @@ describe("spritesheet animation rendering", () => {
     animatedSpriteElement.scale.y = 0.25;
     animatedSpriteElement.onFrameChange(1);
 
-    expect(
-      animatedSpriteElement.pivot.x * animatedSpriteElement.scale.x,
-    ).toBeCloseTo(10);
-    expect(
-      animatedSpriteElement.pivot.y * animatedSpriteElement.scale.y,
-    ).toBeCloseTo(5);
+    expect(animatedSpriteElement.pivot.x).toBeCloseTo(10);
+    expect(animatedSpriteElement.pivot.y).toBeCloseTo(5);
     expect(animatedSpriteElement.x).toBe(30);
     expect(animatedSpriteElement.y).toBe(35);
 

--- a/spec/elements/managedVideoTextureSizing.spec.js
+++ b/spec/elements/managedVideoTextureSizing.spec.js
@@ -76,6 +76,10 @@ describe("managed video texture sizing", () => {
     expect(sprite.x).toBe(120);
     expect(sprite.y).toBe(75);
     expect(sprite.rotation).toBeCloseTo(Math.PI / 6);
+    const pivotBeforeAnimation = {
+      x: sprite.pivot.x,
+      y: sprite.pivot.y,
+    };
 
     const animationBus = createAnimationBus();
     animationBus.dispatch({
@@ -96,7 +100,7 @@ describe("managed video texture sizing", () => {
     animationBus.flush();
     animationBus.tick(100);
 
-    expect(sprite.pivot.x * sprite.scale.x).toBeCloseTo(element.originX);
-    expect(sprite.pivot.y * sprite.scale.y).toBeCloseTo(element.originY);
+    expect(sprite.pivot.x).toBeCloseTo(pivotBeforeAnimation.x);
+    expect(sprite.pivot.y).toBeCloseTo(pivotBeforeAnimation.y);
   });
 });

--- a/src/plugins/elements/animated-sprite/animatedSpriteTransform.js
+++ b/src/plugins/elements/animated-sprite/animatedSpriteTransform.js
@@ -1,4 +1,7 @@
-import { applyElementPivot, applyElementTransform } from "../util/transform.js";
+import {
+  applyElementTransform,
+  refreshElementPivot,
+} from "../util/transform.js";
 
 const animatedSpriteTransformStates = new WeakMap();
 
@@ -14,7 +17,7 @@ const ensureAnimatedSpriteTransformState = (animatedSprite, element) => {
 
     animatedSprite.onFrameChange = (currentFrame) => {
       state.previousFrameChangeHandler?.call(animatedSprite, currentFrame);
-      applyElementPivot(animatedSprite, state.element);
+      refreshElementPivot(animatedSprite);
     };
   } else {
     state.element = element;
@@ -33,9 +36,5 @@ export const applyAnimatedSpriteTransform = (animatedSprite, element) => {
 };
 
 export const refreshAnimatedSpritePivot = (animatedSprite) => {
-  const state = animatedSpriteTransformStates.get(animatedSprite);
-
-  if (state) {
-    applyElementPivot(animatedSprite, state.element);
-  }
+  refreshElementPivot(animatedSprite);
 };

--- a/src/plugins/elements/animated-sprite/animatedSpriteTransform.js
+++ b/src/plugins/elements/animated-sprite/animatedSpriteTransform.js
@@ -1,9 +1,29 @@
 import {
+  applyElementPivot,
   applyElementTransform,
   refreshElementPivot,
 } from "../util/transform.js";
 
 const animatedSpriteTransformStates = new WeakMap();
+
+const refreshAnimatedSpriteGeometryPivot = (animatedSprite, geometry = {}) => {
+  const state = animatedSpriteTransformStates.get(animatedSprite);
+  const textureWidth = animatedSprite.texture?.orig?.width ?? 0;
+  const textureHeight = animatedSprite.texture?.orig?.height ?? 0;
+
+  if (!state || textureWidth <= 0 || textureHeight <= 0) {
+    refreshElementPivot(animatedSprite);
+    return;
+  }
+
+  const width = geometry.width ?? state.element.width;
+  const height = geometry.height ?? state.element.height;
+
+  applyElementPivot(animatedSprite, state.element, {
+    baseScaleX: width / textureWidth,
+    baseScaleY: height / textureHeight,
+  });
+};
 
 const ensureAnimatedSpriteTransformState = (animatedSprite, element) => {
   let state = animatedSpriteTransformStates.get(animatedSprite);
@@ -17,7 +37,7 @@ const ensureAnimatedSpriteTransformState = (animatedSprite, element) => {
 
     animatedSprite.onFrameChange = (currentFrame) => {
       state.previousFrameChangeHandler?.call(animatedSprite, currentFrame);
-      refreshElementPivot(animatedSprite);
+      refreshAnimatedSpriteGeometryPivot(animatedSprite);
     };
   } else {
     state.element = element;
@@ -35,6 +55,5 @@ export const applyAnimatedSpriteTransform = (animatedSprite, element) => {
   applyElementTransform(animatedSprite, element);
 };
 
-export const refreshAnimatedSpritePivot = (animatedSprite) => {
-  refreshElementPivot(animatedSprite);
-};
+export const refreshAnimatedSpritePivot = (animatedSprite, geometry) =>
+  refreshAnimatedSpriteGeometryPivot(animatedSprite, geometry);

--- a/src/plugins/elements/animated-sprite/updateAnimatedSprite.js
+++ b/src/plugins/elements/animated-sprite/updateAnimatedSprite.js
@@ -248,13 +248,18 @@ export const updateAnimatedSprite = async ({
       return;
     }
 
-    animatedSpriteElement.width = Math.round(
+    const restoredWidth = Math.round(
       hasLiveAnimationTween("width") ? currentWidth : width,
     );
-    animatedSpriteElement.height = Math.round(
+    const restoredHeight = Math.round(
       hasLiveAnimationTween("height") ? currentHeight : height,
     );
-    refreshAnimatedSpritePivot(animatedSpriteElement);
+    animatedSpriteElement.width = restoredWidth;
+    animatedSpriteElement.height = restoredHeight;
+    refreshAnimatedSpritePivot(animatedSpriteElement, {
+      width: restoredWidth,
+      height: restoredHeight,
+    });
 
     if (typeof app.render === "function") {
       app.render();

--- a/src/plugins/elements/util/transform.js
+++ b/src/plugins/elements/util/transform.js
@@ -27,14 +27,14 @@ export const refreshElementPivot = (displayObject) => {
 export const applyElementPivot = (
   displayObject,
   element,
-  { localOriginX, localOriginY } = {},
+  { localOriginX, localOriginY, baseScaleX, baseScaleY } = {},
 ) => {
   const originX = element.originX ?? 0;
   const originY = element.originY ?? 0;
   const pivotX = localOriginX ?? originX;
   const pivotY = localOriginY ?? originY;
-  const scaleX = getFiniteScale(displayObject.scale?.x);
-  const scaleY = getFiniteScale(displayObject.scale?.y);
+  const scaleX = getFiniteScale(baseScaleX ?? displayObject.scale?.x);
+  const scaleY = getFiniteScale(baseScaleY ?? displayObject.scale?.y);
 
   elementPivotValues.set(displayObject, {
     x: pivotX / scaleX,

--- a/src/plugins/elements/util/transform.js
+++ b/src/plugins/elements/util/transform.js
@@ -2,7 +2,7 @@ export const degreesToRadians = (degrees = 0) => (degrees * Math.PI) / 180;
 
 export const radiansToDegrees = (radians = 0) => (radians * 180) / Math.PI;
 
-const scaleAdjustedPivotValues = new WeakMap();
+const elementPivotValues = new WeakMap();
 
 const getFiniteScale = (scale) =>
   typeof scale === "number" && Number.isFinite(scale) && scale !== 0
@@ -15,16 +15,13 @@ export const getElementTransformPosition = (element) => ({
 });
 
 export const refreshElementPivot = (displayObject) => {
-  const pivotValues = scaleAdjustedPivotValues.get(displayObject);
+  const pivotValues = elementPivotValues.get(displayObject);
 
   if (!pivotValues) {
     return;
   }
 
-  const scaleX = getFiniteScale(displayObject.scale?.x);
-  const scaleY = getFiniteScale(displayObject.scale?.y);
-
-  displayObject.pivot?.set?.(pivotValues.x / scaleX, pivotValues.y / scaleY);
+  displayObject.pivot?.set?.(pivotValues.x, pivotValues.y);
 };
 
 export const applyElementPivot = (
@@ -36,10 +33,12 @@ export const applyElementPivot = (
   const originY = element.originY ?? 0;
   const pivotX = localOriginX ?? originX;
   const pivotY = localOriginY ?? originY;
+  const scaleX = getFiniteScale(displayObject.scale?.x);
+  const scaleY = getFiniteScale(displayObject.scale?.y);
 
-  scaleAdjustedPivotValues.set(displayObject, {
-    x: pivotX,
-    y: pivotY,
+  elementPivotValues.set(displayObject, {
+    x: pivotX / scaleX,
+    y: pivotY / scaleY,
   });
   refreshElementPivot(displayObject);
 };

--- a/vt/reference/animatedspritetransition/animated-sprite-update-rotation-02.webp
+++ b/vt/reference/animatedspritetransition/animated-sprite-update-rotation-02.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45c869a2e2edb990c1baff96beea7bd14f20637ba9579b0442a75bbbdecf20e1
-size 7704
+oid sha256:55ebaffe4cc49b830431532a6d56fe59af97801cac40cd8f2db9a9cd2b9eb19e
+size 7694

--- a/vt/reference/spritetransition/sprite-anchor-scale-persistent-render-01.webp
+++ b/vt/reference/spritetransition/sprite-anchor-scale-persistent-render-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24f6db0cc935491c906cf7ef93c7428c76044ff95021655c7900e34a679d1e9a
+size 4032

--- a/vt/reference/spritetransition/sprite-anchor-scale-persistent-render-02.webp
+++ b/vt/reference/spritetransition/sprite-anchor-scale-persistent-render-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7184f87141883d15c02e7a31247c6a175c435a20e8be03fb8dc8d56a32b016fd
+size 5006

--- a/vt/reference/spritetransition/sprite-anchor-scale-persistent-render-03.webp
+++ b/vt/reference/spritetransition/sprite-anchor-scale-persistent-render-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:767bda00b15084a74abfc0ee3ab9b7be5b61049e3dffe93e17897bbbb74970dc
+size 4686

--- a/vt/reference/spritetransition/sprite-anchor-scale-persistent-render-04.webp
+++ b/vt/reference/spritetransition/sprite-anchor-scale-persistent-render-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24f6db0cc935491c906cf7ef93c7428c76044ff95021655c7900e34a679d1e9a
+size 4032

--- a/vt/reference/video/video-update-rotation-02.webp
+++ b/vt/reference/video/video-update-rotation-02.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:350d5cdf0b62ca2f55cf0964692ee7186dac9746fe9128f5609584f46b37c17c
-size 4998
+oid sha256:5a0cb7a9f51a0f343b6b1d632e2f2538cfb4d0a5300c8ee8dda8eef399533858
+size 5034

--- a/vt/specs/spritetransition/sprite-anchor-scale-persistent-render.yaml
+++ b/vt/specs/spritetransition/sprite-anchor-scale-persistent-render.yaml
@@ -1,0 +1,105 @@
+---
+title: Sprite Anchor Scale Across Persistent Render
+description: |
+  A centered sprite should keep scaling around its anchor when a persistent
+  update tween is selected again by an unrelated render. The colored sprite
+  asset is used intentionally to make its bounds and center visible.
+specs:
+  - the sprite should remain centered on the white crosshair while scaling
+  - the scale tween should continue instead of restarting across the render
+  - the sprite should settle at its authored size without shifting its center
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: snapShotKeyFrame
+    detail:
+      deltaMS: 300
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: snapShotKeyFrame
+    detail:
+      deltaMS: 300
+  - action: screenshot
+  - action: customEvent
+    name: snapShotKeyFrame
+    detail:
+      deltaMS: 600
+  - action: screenshot
+---
+states:
+  - elements:
+      - &horizontal-guide
+        id: horizontal-guide
+        type: rect
+        x: 360
+        "y": 359
+        width: 560
+        height: 2
+        fill: "#FFFFFF"
+      - &vertical-guide
+        id: vertical-guide
+        type: rect
+        x: 639
+        "y": 80
+        width: 2
+        height: 560
+        fill: "#FFFFFF"
+      - &centered-sprite
+        id: centered-sprite
+        type: sprite
+        src: circle-blue
+        x: 640
+        "y": 360
+        width: 200
+        height: 200
+        anchorX: 0.5
+        anchorY: 0.5
+  - elements:
+      - *horizontal-guide
+      - *vertical-guide
+      - *centered-sprite
+    animations:
+      - id: centered-persistent-scale
+        targetId: centered-sprite
+        type: update
+        playback:
+          continuity: persistent
+        tween:
+          scaleX:
+            initialValue: 2
+            keyframes:
+              - duration: 1200
+                value: 1
+                easing: linear
+          scaleY:
+            initialValue: 2
+            keyframes:
+              - duration: 1200
+                value: 1
+                easing: linear
+  - elements:
+      - *horizontal-guide
+      - *vertical-guide
+      - *centered-sprite
+    animations:
+      - id: centered-persistent-scale
+        targetId: centered-sprite
+        type: update
+        playback:
+          continuity: persistent
+        tween:
+          scaleX:
+            initialValue: 2
+            keyframes:
+              - duration: 1200
+                value: 1
+                easing: linear
+          scaleY:
+            initialValue: 2
+            keyframes:
+              - duration: 1200
+                value: 1
+                easing: linear


### PR DESCRIPTION
## Summary
- keep element pivots fixed in local coordinates after authored sizing so scale and rotation animations honor their anchors
- keep animated-sprite pivots fixed across live scale tweens, while recomputing them from authored display size and current texture geometry when frames or atlases change dimensions
- add unit coverage for frame and atlas geometry changes plus a persistent-render VT regression, with reviewed rotation baseline updates for animated sprites and video
- bump the package patch version from `1.39.0` to `1.39.1`

## Testing
- `bunx vitest run spec/elements/animatedSpriteRendering.spec.js` (13 passed)
- `bunx vitest run spec/animations/animationBus.spec.js spec/elements/animatedSpriteRendering.spec.js spec/elements/managedVideoTextureSizing.spec.js spec/elements/updateVideo.spec.js` (76 passed)
- `bunx vitest run spec/cli/renderPngCli.spec.js` (6 passed)
- `bun run lint`
- changed-file Prettier check
- focused animated-sprite VT capture: 16/16 pages succeeded
- focused animated-sprite VT report: 87 images, 0 mismatches
- full VT capture: 239/239 pages succeeded
- full VT report: 862 images, 0 mismatches

## Full-suite note
- local `bun run test` is not fully green because the local runtime lacks the Unicode 17 property data required by 13 text-target tests
- the pre-push run also hit one transient PNG byte-size assertion; its isolated six-test CLI suite passes
