### PR TITLE
feat(elements): support negative scales

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.39.1",
+  "version": "1.40.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/elements/addParticles.spec.js
+++ b/spec/elements/addParticles.spec.js
@@ -33,6 +33,59 @@ function collectPositions(emitter) {
 }
 
 describe("addParticle", () => {
+  it("keeps particle bounds local and applies the full signed live scale", () => {
+    const parent = new Container();
+    const app = createApp();
+    const element = {
+      id: "mirrored-particles",
+      type: "particles",
+      x: 200,
+      y: 120,
+      width: 100,
+      height: 80,
+      originX: -50,
+      originY: 40,
+      scaleX: -1.5,
+      scaleY: 2,
+      count: 1,
+      texture: {
+        shape: "circle",
+        radius: 2,
+        color: "#ffffff",
+      },
+      behaviors: [],
+      emitter: {
+        lifetime: { min: 1, max: 1 },
+        frequency: 1,
+        maxParticles: 1,
+      },
+    };
+
+    addParticle({
+      app,
+      parent,
+      element,
+      animations: [],
+      animationBus: createAnimationBus(),
+      completionTracker: {
+        getVersion: () => 1,
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      renderContext: {},
+      zIndex: 0,
+    });
+
+    const particles = parent.getChildByLabel(element.id);
+    expect(particles.scale.x).toBe(-1.5);
+    expect(particles.scale.y).toBe(2);
+    expect(particles.pivot).toMatchObject({ x: 100 / 3, y: 20 });
+    expect(particles.x).toBe(150);
+    expect(particles.y).toBe(160);
+    particles.emitter.destroy();
+    particles.destroy({ children: true });
+  });
+
   it("installs shader filters before dispatching mount animations", () => {
     const parent = new Container();
     const app = createApp();

--- a/spec/elements/addRect.spec.js
+++ b/spec/elements/addRect.spec.js
@@ -4,6 +4,51 @@ import { addRect } from "../../src/plugins/elements/rect/addRect.js";
 import { parseRect } from "../../src/plugins/elements/rect/parseRect.js";
 
 describe("addRect", () => {
+  it("renders negative scale as a live reflection over positive geometry", () => {
+    const parent = new Container();
+    const element = parseRect({
+      state: {
+        id: "mirrored-rect",
+        type: "rect",
+        x: 300,
+        y: 200,
+        width: 120,
+        height: 80,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        fill: "#737373",
+        scaleX: -1.5,
+        scaleY: -0.5,
+      },
+    });
+
+    addRect({
+      app: { audioStage: { add: vi.fn() } },
+      parent,
+      element,
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker: {
+        getVersion: () => 0,
+        track: () => {},
+        complete: () => {},
+      },
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    const rectElement = parent.getChildByLabel("mirrored-rect");
+
+    expect(element).toMatchObject({ width: 180, height: 40 });
+    expect(rectElement.scale.x).toBe(-1);
+    expect(rectElement.scale.y).toBe(-1);
+    expect(rectElement.width).toBe(180);
+    expect(rectElement.height).toBe(40);
+    expect(rectElement.x).toBe(300);
+    expect(rectElement.y).toBe(200);
+    expect(rectElement.pivot).toMatchObject({ x: 90, y: 20 });
+  });
+
   it("renders scaled rect geometry without double-applying the live scale", () => {
     const parent = new Container();
     const element = parseRect({

--- a/spec/elements/addSprite.spec.js
+++ b/spec/elements/addSprite.spec.js
@@ -4,6 +4,50 @@ import { addSprite } from "../../src/plugins/elements/sprite/addSprite.js";
 import { parseSprite } from "../../src/plugins/elements/sprite/parseSprite.js";
 
 describe("addSprite", () => {
+  it("preserves texture sizing while applying negative scale signs", () => {
+    const parent = new Container();
+    const element = parseSprite({
+      state: {
+        id: "mirrored-sprite",
+        type: "sprite",
+        x: 300,
+        y: 200,
+        width: 120,
+        height: 80,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        scaleX: -1.5,
+        scaleY: -0.5,
+      },
+    });
+
+    addSprite({
+      app: { audioStage: { add: vi.fn() } },
+      parent,
+      element,
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker: {
+        getVersion: () => 0,
+        track: () => {},
+        complete: () => {},
+      },
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    const spriteElement = parent.getChildByLabel("mirrored-sprite");
+
+    expect(spriteElement.width).toBe(180);
+    expect(spriteElement.height).toBe(40);
+    expect(spriteElement.scale.x).toBeLessThan(0);
+    expect(spriteElement.scale.y).toBeLessThan(0);
+    expect(spriteElement.x).toBe(300);
+    expect(spriteElement.y).toBe(200);
+    expect(spriteElement.pivot.x * spriteElement.scale.x).toBeCloseTo(-90);
+    expect(spriteElement.pivot.y * spriteElement.scale.y).toBeCloseTo(-20);
+  });
+
   it("uses explicit origin independently from anchor for rotation", () => {
     const parent = new Container();
     const element = parseSprite({

--- a/spec/elements/addTextRevealing.spec.js
+++ b/spec/elements/addTextRevealing.spec.js
@@ -19,6 +19,7 @@ import {
   flushDeferredMountOperations,
 } from "../../src/plugins/elements/renderContext.js";
 import { addTextRevealing } from "../../src/plugins/elements/text-revealing/addTextRevealing.js";
+import { parseTextRevealing } from "../../src/plugins/elements/text-revealing/parseTextRevealing.js";
 import { createAnimationBus } from "../../src/plugins/animations/animationBus.js";
 import {
   createAnimatedShaderFilterFixture,
@@ -104,6 +105,54 @@ describe("addTextRevealing", () => {
     expect(text.pivot.x).toBe(16);
     expect(text.pivot.y).toBe(10);
     expect(text.rotation).toBeCloseTo(Math.PI / 3);
+  });
+
+  it("renders full positive and negative scale around the computed anchor", async () => {
+    const parent = new Container();
+    const element = parseTextRevealing({
+      state: {
+        id: "scaled-line",
+        type: "text-revealing",
+        x: 300,
+        y: 180,
+        width: 100,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        scaleX: -2,
+        scaleY: 1.5,
+        alpha: 1,
+        speed: 100,
+        content: [
+          {
+            text: "Asymmetric line",
+            textStyle: { fontFamily: "Arial", fontSize: 20 },
+          },
+        ],
+      },
+    });
+
+    await addTextRevealing({
+      parent,
+      element,
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker: {
+        getVersion: () => 0,
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      zIndex: 0,
+      signal: new AbortController().signal,
+    });
+
+    const text = parent.getChildByLabel("scaled-line");
+
+    expect(element.width).toBe(200);
+    expect(text.scale.x).toBe(-2);
+    expect(text.scale.y).toBe(1.5);
+    expect(text.pivot.x).toBe(50);
+    expect(text.x).toBe(300);
+    expect(text.y).toBe(180);
   });
 
   it("pauses reveal work during suppressed mounts and starts it after finalize", async () => {

--- a/spec/elements/addVideo.spec.js
+++ b/spec/elements/addVideo.spec.js
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { MockBlurFilter, MockSprite, textureFrom } = vi.hoisted(() => {
+  class HoistedMockBlurFilter {
+    constructor(options = {}) {
+      this.strengthX = options.strengthX ?? options.strength ?? 0;
+      this.strengthY = options.strengthY ?? options.strength ?? 0;
+      this.quality = options.quality ?? 4;
+      this.kernelSize = options.kernelSize ?? 5;
+      this.destroy = vi.fn();
+    }
+  }
+
+  class HoistedMockSprite {
+    constructor(texture) {
+      this.texture = texture;
+      this.destroyed = false;
+      this.scale = { x: 1, y: 1 };
+      this.pivot = {
+        set: (x, y) => {
+          this.pivot.x = x;
+          this.pivot.y = y;
+        },
+      };
+      this._once = new Map();
+    }
+
+    get width() {
+      return Math.abs(this.scale.x) * this.texture.source.width;
+    }
+
+    set width(value) {
+      const sign = Math.sign(this.scale.x) || 1;
+      this.scale.x = (sign * value) / this.texture.source.width;
+    }
+
+    get height() {
+      return Math.abs(this.scale.y) * this.texture.source.height;
+    }
+
+    set height(value) {
+      const sign = Math.sign(this.scale.y) || 1;
+      this.scale.y = (sign * value) / this.texture.source.height;
+    }
+
+    once(event, callback) {
+      this._once.set(event, callback);
+    }
+  }
+
+  return {
+    MockBlurFilter: HoistedMockBlurFilter,
+    MockSprite: HoistedMockSprite,
+    textureFrom: vi.fn(),
+  };
+});
+
+vi.mock("pixi.js", () => ({
+  BlurFilter: MockBlurFilter,
+  Sprite: MockSprite,
+  Texture: { from: textureFrom },
+}));
+
+import { addVideo } from "../../src/plugins/elements/video/addVideo.js";
+import {
+  captureManagedVideoSpriteSizes,
+  restoreManagedVideoSpriteSizes,
+} from "../../src/plugins/elements/video/managedVideoTextureSizing.js";
+
+describe("addVideo", () => {
+  beforeEach(() => {
+    textureFrom.mockReset();
+  });
+
+  it("waits for real texture dimensions before binding auto scale targets", () => {
+    const video = {
+      videoWidth: 0,
+      videoHeight: 0,
+      pause: vi.fn(),
+      play: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      currentTime: 0,
+      volume: 1,
+      muted: false,
+      loop: true,
+    };
+    const source = {
+      width: 1,
+      height: 1,
+      resource: video,
+      __routeGraphicsVideoTextureRuntime: {
+        requestUpdate: vi.fn().mockReturnValue(false),
+      },
+    };
+    textureFrom.mockReturnValue({ source });
+    const parent = {
+      children: [],
+      addChild(child) {
+        this.children.push(child);
+        child.parent = this;
+      },
+    };
+    const animationBus = { dispatch: vi.fn() };
+    const completionTracker = {
+      getVersion: vi.fn().mockReturnValue(3),
+      track: vi.fn(),
+      complete: vi.fn(),
+    };
+
+    addVideo({
+      parent,
+      element: {
+        id: "video-1",
+        type: "video",
+        src: "video.mp4",
+        x: 0,
+        y: 0,
+        width: 320,
+        height: 180,
+        scaleX: 1,
+        scaleY: 1,
+        loop: true,
+        alpha: 1,
+      },
+      animations: [
+        {
+          id: "video-scale-auto",
+          targetId: "video-1",
+          type: "update",
+          tween: {
+            scaleX: { auto: { duration: 300, easing: "linear" } },
+            scaleY: { auto: { duration: 300, easing: "linear" } },
+          },
+        },
+      ],
+      animationBus,
+      completionTracker,
+      zIndex: 0,
+      signal: new AbortController().signal,
+    });
+
+    expect(animationBus.dispatch).not.toHaveBeenCalled();
+
+    const metadataOnlySizes = captureManagedVideoSpriteSizes(source);
+    video.videoWidth = 640;
+    video.videoHeight = 360;
+    restoreManagedVideoSpriteSizes(metadataOnlySizes);
+
+    expect(animationBus.dispatch).not.toHaveBeenCalled();
+
+    const sizes = captureManagedVideoSpriteSizes(source);
+    source.width = 640;
+    source.height = 360;
+    restoreManagedVideoSpriteSizes(sizes);
+
+    expect(animationBus.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "START",
+        payload: expect.objectContaining({
+          targetState: expect.objectContaining({
+            scaleX: 0.5,
+            scaleY: 0.5,
+          }),
+        }),
+      }),
+    );
+    expect(completionTracker.complete).toHaveBeenCalledWith(3);
+  });
+});

--- a/spec/elements/animatedSpriteRendering.spec.js
+++ b/spec/elements/animatedSpriteRendering.spec.js
@@ -414,6 +414,65 @@ describe("spritesheet animation rendering", () => {
     expect(animatedSpriteElement.y).toBe(172);
   });
 
+  it("targets the signed post-sizing scale for animated sprite auto tweens", async () => {
+    const liveAnimations = [
+      {
+        id: "animated-sprite-scale",
+        targetId: "animated-sprite-1",
+        type: "update",
+        tween: {
+          scaleX: { auto: { duration: 300 } },
+          scaleY: { auto: { duration: 300 } },
+        },
+      },
+    ];
+    dispatchLiveAnimations.mockReturnValue(true);
+    getLiveAnimations.mockReturnValue(liveAnimations);
+
+    const animatedSpriteElement = new MockAnimatedSprite([
+      { frameName: "old" },
+    ]);
+    animatedSpriteElement.label = "animated-sprite-1";
+    animatedSpriteElement.texture = {
+      orig: { width: 50, height: 25 },
+    };
+    animatedSpriteElement.width = 100;
+    animatedSpriteElement.height = 50;
+    animatedSpriteElement.scale.x = -2;
+    animatedSpriteElement.scale.y = 2;
+    const prevElement = createAnimatedSpriteElement({
+      width: 100,
+      height: 50,
+      scaleX: -1,
+    });
+    const nextElement = createAnimatedSpriteElement({
+      width: 200,
+      height: 100,
+      scaleX: -1,
+    });
+
+    await updateAnimatedSprite({
+      app: { debug: false, render: vi.fn() },
+      parent: { children: [animatedSpriteElement] },
+      prevElement,
+      nextElement,
+      animations: liveAnimations,
+      animationBus: {},
+      completionTracker: {},
+      zIndex: 4,
+      signal: undefined,
+    });
+
+    expect(dispatchLiveAnimations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetState: expect.objectContaining({
+          scaleX: -4,
+          scaleY: 4,
+        }),
+      }),
+    );
+  });
+
   it("renders after asynchronously adding a spritesheet animation in debug/manual flows", async () => {
     const app = {
       debug: true,

--- a/spec/elements/managedVideoTextureSizing.spec.js
+++ b/spec/elements/managedVideoTextureSizing.spec.js
@@ -7,7 +7,7 @@ import {
   setManagedVideoSpriteResizeHandler,
 } from "../../src/plugins/elements/video/managedVideoTextureSizing.js";
 import {
-  applyElementPivot,
+  applyElementScaleAndPivot,
   applyElementTransform,
 } from "../../src/plugins/elements/util/transform.js";
 
@@ -60,7 +60,9 @@ describe("managed video texture sizing", () => {
     sprite.height = element.height;
     applyElementTransform(sprite, element);
     setManagedVideoSpriteResizeHandler(sprite, () => {
-      applyElementPivot(sprite, element);
+      applyElementScaleAndPivot(sprite, element, {
+        preserveScaleMagnitude: true,
+      });
     });
     registerManagedVideoSprite(sprite);
 
@@ -102,5 +104,79 @@ describe("managed video texture sizing", () => {
 
     expect(sprite.pivot.x).toBeCloseTo(pivotBeforeAnimation.x);
     expect(sprite.pivot.y).toBeCloseTo(pivotBeforeAnimation.y);
+  });
+
+  it("restores a negative scale and pivot without resetting an in-flight transform", () => {
+    const source = { width: 1, height: 1 };
+    const sprite = {
+      destroyed: false,
+      texture: { source },
+      scale: { x: 1, y: 1 },
+      pivot: {
+        set(x, y) {
+          this.x = x;
+          this.y = y;
+        },
+      },
+      once: vi.fn(),
+    };
+
+    Object.defineProperties(sprite, {
+      width: {
+        get() {
+          return Math.abs(this.scale.x) * this.texture.source.width;
+        },
+        set(value) {
+          this.scale.x = value / this.texture.source.width;
+        },
+      },
+      height: {
+        get() {
+          return Math.abs(this.scale.y) * this.texture.source.height;
+        },
+        set(value) {
+          this.scale.y = value / this.texture.source.height;
+        },
+      },
+    });
+
+    const element = {
+      x: 40,
+      y: 30,
+      width: 320,
+      height: 180,
+      originX: -80,
+      originY: 45,
+      rotation: 30,
+      scaleX: -1,
+      scaleY: 1,
+    };
+
+    sprite.width = element.width;
+    sprite.height = element.height;
+    applyElementTransform(sprite, element, { preserveScaleMagnitude: true });
+    setManagedVideoSpriteResizeHandler(sprite, () => {
+      applyElementScaleAndPivot(sprite, element, {
+        preserveScaleMagnitude: true,
+      });
+    });
+    registerManagedVideoSprite(sprite);
+
+    sprite.x = 173;
+    sprite.y = 91;
+    sprite.rotation = 0.42;
+
+    const spriteSizes = captureManagedVideoSpriteSizes(source);
+    source.width = 640;
+    source.height = 360;
+    restoreManagedVideoSpriteSizes(spriteSizes);
+
+    expect(sprite.scale.x).toBeCloseTo(-0.5);
+    expect(sprite.scale.y).toBeCloseTo(0.5);
+    expect(sprite.pivot.x * sprite.scale.x).toBeCloseTo(element.originX);
+    expect(sprite.pivot.y * sprite.scale.y).toBeCloseTo(element.originY);
+    expect(sprite.x).toBe(173);
+    expect(sprite.y).toBe(91);
+    expect(sprite.rotation).toBe(0.42);
   });
 });

--- a/spec/elements/negativeScaleParsing.spec.js
+++ b/spec/elements/negativeScaleParsing.spec.js
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+import { parseContainerForTesting } from "../../src/plugins/elements/container/parseContainerForTestingPurposes.js";
+import { parseRect } from "../../src/plugins/elements/rect/parseRect.js";
+import { parseSprite } from "../../src/plugins/elements/sprite/parseSprite.js";
+import { parseCommonObject } from "../../src/plugins/elements/util/parseCommonObject.js";
+
+const commonState = (overrides = {}) => ({
+  id: "subject",
+  type: "sprite",
+  x: 200,
+  y: 100,
+  width: 80,
+  height: 50,
+  ...overrides,
+});
+
+describe("negative scale parsing", () => {
+  it("keeps scaled dimensions positive and derives signed anchor origins", () => {
+    const result = parseCommonObject(
+      commonState({
+        anchorX: 0.25,
+        anchorY: 0.5,
+        scaleX: -1.5,
+        scaleY: -2,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      width: 120,
+      height: 100,
+      x: 230,
+      y: 150,
+      originX: -30,
+      originY: -50,
+      scaleX: -1.5,
+      scaleY: -2,
+    });
+  });
+
+  it("preserves the established output shape for positive baked scales", () => {
+    const result = parseCommonObject(commonState({ scaleX: 1.5, scaleY: 2 }));
+
+    expect(result).toMatchObject({ width: 120, height: 100 });
+    expect(result).not.toHaveProperty("scaleX");
+    expect(result).not.toHaveProperty("scaleY");
+  });
+
+  it("keeps a zero scale instead of treating it as an omitted value", () => {
+    const result = parseCommonObject(
+      commonState({ anchorX: 0.5, anchorY: 1, scaleX: 0, scaleY: 0 }),
+    );
+
+    expect(result).toMatchObject({
+      width: 0,
+      height: 0,
+      x: 200,
+      y: 100,
+      originX: 0,
+      originY: 0,
+      scaleX: 0,
+      scaleY: 0,
+    });
+  });
+
+  it("retains explicit transform origins with negative scale", () => {
+    const result = parseCommonObject(
+      commonState({
+        anchorX: 0.5,
+        anchorY: 0.5,
+        originX: 12,
+        originY: 7,
+        scaleX: -2,
+        scaleY: -3,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      width: 160,
+      height: 150,
+      x: 280,
+      y: 175,
+      originX: 12,
+      originY: 7,
+    });
+  });
+
+  it("keeps dimensions local and the full scale live for particles", () => {
+    const result = parseCommonObject(
+      commonState({
+        type: "particles",
+        anchorX: 0.25,
+        anchorY: 0.5,
+        scaleX: -1.5,
+        scaleY: 2,
+      }),
+      { scaleMode: "live" },
+    );
+
+    expect(result).toMatchObject({
+      width: 80,
+      height: 50,
+      x: 230,
+      y: 50,
+      originX: -30,
+      originY: 50,
+      scaleX: -1.5,
+      scaleY: 2,
+    });
+  });
+
+  it("does not bake a container scale magnitude into its own bounds", () => {
+    const result = parseCommonObject(
+      commonState({
+        type: "container",
+        anchorX: 0.5,
+        scaleX: -3,
+      }),
+    );
+
+    expect(result).toMatchObject({
+      width: 80,
+      x: 240,
+      originX: -40,
+      scaleX: -3,
+    });
+  });
+
+  it.each([
+    ["NaN", Number.NaN],
+    ["positive infinity", Infinity],
+    ["negative infinity", -Infinity],
+    ["a string", "-1"],
+  ])("rejects %s as scale", (_label, scaleX) => {
+    expect(() => parseCommonObject(commonState({ scaleX }))).toThrow(
+      "scaleX and scaleY must be finite numbers",
+    );
+  });
+
+  it("parses a mirrored rect with drawable positive geometry", () => {
+    const result = parseRect({
+      state: {
+        id: "rect",
+        type: "rect",
+        x: 300,
+        y: 180,
+        width: 100,
+        height: 60,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        scaleX: -2,
+        scaleY: -0.5,
+        fill: "red",
+      },
+    });
+
+    expect(result).toMatchObject({
+      width: 200,
+      height: 30,
+      x: 400,
+      y: 195,
+      originX: -100,
+      originY: -15,
+      scaleX: -2,
+      scaleY: -0.5,
+    });
+  });
+
+  it("parses a mirrored sprite without negative width or height", () => {
+    const result = parseSprite({
+      state: commonState({ scaleX: -1, scaleY: -2, src: "asymmetric" }),
+    });
+
+    expect(result).toMatchObject({
+      width: 80,
+      height: 100,
+      scaleX: -1,
+      scaleY: -2,
+      src: "asymmetric",
+    });
+  });
+
+  it("bakes a container magnitude into children but keeps its sign on the group", () => {
+    const result = parseContainerForTesting({
+      state: {
+        id: "group",
+        type: "container",
+        x: 300,
+        y: 200,
+        width: 200,
+        height: 100,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        scaleX: -2,
+        scaleY: 3,
+        children: [
+          {
+            id: "child",
+            type: "rect",
+            x: 20,
+            y: 10,
+            width: 30,
+            height: 20,
+            fill: "red",
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchObject({
+      width: 200,
+      height: 100,
+      x: 400,
+      y: 150,
+      originX: -100,
+      originY: 50,
+      scaleX: -2,
+    });
+    expect(result).not.toHaveProperty("scaleY");
+    expect(result.children[0]).toMatchObject({
+      width: 60,
+      height: 60,
+      scaleX: 2,
+      scaleY: 3,
+    });
+  });
+
+  it("composes nested negative signs without losing scale magnitude", () => {
+    const result = parseContainerForTesting({
+      state: {
+        id: "outer",
+        type: "container",
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 100,
+        scaleX: -2,
+        children: [
+          {
+            id: "inner",
+            type: "container",
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 50,
+            scaleX: -3,
+            children: [
+              {
+                id: "leaf",
+                type: "rect",
+                x: 0,
+                y: 0,
+                width: 10,
+                height: 10,
+                fill: "blue",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(result.scaleX).toBe(-2);
+    expect(result.children[0].scaleX).toBe(-6);
+    expect(result.children[0].children[0]).toMatchObject({
+      width: 60,
+      scaleX: 6,
+    });
+  });
+});

--- a/spec/elements/negativeScaleTransform.spec.js
+++ b/spec/elements/negativeScaleTransform.spec.js
@@ -1,0 +1,200 @@
+import { Container, Sprite, Texture } from "pixi.js";
+import { describe, expect, it } from "vitest";
+import { parseSprite } from "../../src/plugins/elements/sprite/parseSprite.js";
+import {
+  applyElementTransform,
+  getElementTransformTargetState,
+  refreshElementPivot,
+} from "../../src/plugins/elements/util/transform.js";
+import { hitTestElementBounds } from "../../src/util/hitTestElementBounds.js";
+
+const createDisplay = (scale = { x: 1, y: 1 }) => ({
+  x: 0,
+  y: 0,
+  rotation: 0,
+  scale: { ...scale },
+  pivot: {
+    set(x, y) {
+      this.x = x;
+      this.y = y;
+    },
+  },
+});
+
+describe("negative scale transforms", () => {
+  it("applies only the sign when magnitude is baked into geometry", () => {
+    const display = createDisplay();
+
+    applyElementTransform(display, {
+      x: 250,
+      y: 140,
+      originX: -50,
+      originY: -20,
+      scaleX: -2,
+      scaleY: -0.5,
+    });
+
+    expect(display.scale).toEqual({ x: -1, y: -1 });
+    expect(display).toMatchObject({ x: 200, y: 120 });
+    expect(display.pivot).toMatchObject({ x: 50, y: 20 });
+  });
+
+  it("applies full signed scale for unbaked particle geometry", () => {
+    const display = createDisplay();
+
+    applyElementTransform(
+      display,
+      { originX: -30, originY: 20, scaleX: -1.5, scaleY: 2 },
+      { scaleMode: "full" },
+    );
+
+    expect(display.scale).toEqual({ x: -1.5, y: 2 });
+    expect(display.pivot).toMatchObject({ x: 20, y: 10 });
+  });
+
+  it("exposes baked scale signs to update animation target state", () => {
+    expect(
+      getElementTransformTargetState({
+        x: 10,
+        y: 20,
+        originX: -5,
+        originY: 4,
+        scaleX: -2,
+        scaleY: 0,
+      }),
+    ).toMatchObject({ x: 5, y: 24, scaleX: -1, scaleY: 0 });
+  });
+
+  it("allows full live particle scale to override the generic sign target", () => {
+    expect(
+      getElementTransformTargetState(
+        { scaleX: -2, scaleY: 3 },
+        { scaleX: -2, scaleY: 3 },
+      ),
+    ).toMatchObject({ scaleX: -2, scaleY: 3 });
+  });
+
+  it("preserves texture sizing magnitude while replacing its sign", () => {
+    const display = createDisplay({ x: 3, y: -4 });
+
+    applyElementTransform(
+      display,
+      { scaleX: -2, scaleY: 0.5 },
+      { preserveScaleMagnitude: true },
+    );
+
+    expect(display.scale).toEqual({ x: -3, y: 4 });
+  });
+
+  it("does not overwrite unrelated existing Pixi scale", () => {
+    const display = createDisplay({ x: 0.5, y: 0.25 });
+
+    applyElementTransform(display, { originX: 10, originY: 5 });
+
+    expect(display.scale).toEqual({ x: 0.5, y: 0.25 });
+    expect(display.pivot).toMatchObject({ x: 20, y: 20 });
+  });
+
+  it("restores the positive sign when a previously mirrored axis is omitted", () => {
+    const display = createDisplay({ x: 5, y: 7 });
+
+    applyElementTransform(
+      display,
+      { scaleX: -1, scaleY: -1 },
+      { preserveScaleMagnitude: true },
+    );
+    applyElementTransform(display, {}, { preserveScaleMagnitude: true });
+
+    expect(display.scale).toEqual({ x: 5, y: 7 });
+  });
+
+  it("collapses zero scale on either axis", () => {
+    const display = createDisplay({ x: 8, y: 6 });
+
+    applyElementTransform(
+      display,
+      { originX: 12, originY: 9, scaleX: 0, scaleY: 0 },
+      { preserveScaleMagnitude: true },
+    );
+
+    expect(display.scale).toEqual({ x: 0, y: 0 });
+    expect(display.pivot).toMatchObject({ x: 12, y: 9 });
+  });
+
+  it("keeps the pixel origin stable when a mirrored scale changes", () => {
+    const display = createDisplay();
+    applyElementTransform(display, {
+      originX: -20,
+      originY: 10,
+      scaleX: -1,
+      scaleY: 1,
+    });
+
+    display.scale.x = -2.5;
+    display.scale.y = 0.5;
+    refreshElementPivot(display);
+
+    expect(display.pivot.x * display.scale.x).toBeCloseTo(-20);
+    expect(display.pivot.y * display.scale.y).toBeCloseTo(10);
+  });
+
+  it("mirrors an asymmetric sprite around its center anchor", () => {
+    const element = parseSprite({
+      state: {
+        id: "sprite",
+        type: "sprite",
+        x: 200,
+        y: 100,
+        width: 100,
+        height: 40,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        scaleX: -1,
+        src: "",
+      },
+    });
+    const sprite = new Sprite(Texture.WHITE);
+    sprite.width = element.width;
+    sprite.height = element.height;
+    applyElementTransform(sprite, element, { preserveScaleMagnitude: true });
+
+    const leftLocal = sprite.toGlobal({ x: 0, y: 0 });
+    const rightLocal = sprite.toGlobal({ x: 1, y: 0 });
+
+    expect(leftLocal.x).toBeCloseTo(250);
+    expect(rightLocal.x).toBeCloseTo(150);
+    expect(sprite.x).toBe(200);
+    expect(sprite.pivot.x * sprite.scale.x).toBeCloseTo(-50);
+  });
+
+  it("hit-tests the reflected world-space bounds", () => {
+    const element = parseSprite({
+      state: {
+        id: "sprite",
+        type: "sprite",
+        x: 200,
+        y: 100,
+        width: 100,
+        height: 40,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        scaleX: -1,
+        src: "",
+      },
+    });
+    const stage = new Container();
+    const sprite = new Sprite(Texture.WHITE);
+    sprite.label = element.id;
+    sprite.width = element.width;
+    sprite.height = element.height;
+    applyElementTransform(sprite, element, { preserveScaleMagnitude: true });
+    stage.addChild(sprite);
+
+    expect(
+      hitTestElementBounds({ stage, elements: [element], x: 175, y: 100 }),
+    ).toHaveLength(1);
+    expect(
+      hitTestElementBounds({ stage, elements: [element], x: 260, y: 100 }),
+    ).toHaveLength(0);
+  });
+});

--- a/spec/elements/negativeScaleTransform.spec.js
+++ b/spec/elements/negativeScaleTransform.spec.js
@@ -1,9 +1,11 @@
 import { Container, Sprite, Texture } from "pixi.js";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { addSprite } from "../../src/plugins/elements/sprite/addSprite.js";
 import { parseSprite } from "../../src/plugins/elements/sprite/parseSprite.js";
 import {
   applyElementTransform,
   getElementTransformTargetState,
+  getTextureBackedScaleTargetState,
   refreshElementPivot,
 } from "../../src/plugins/elements/util/transform.js";
 import { hitTestElementBounds } from "../../src/util/hitTestElementBounds.js";
@@ -84,6 +86,115 @@ describe("negative scale transforms", () => {
     );
 
     expect(display.scale).toEqual({ x: -3, y: 4 });
+  });
+
+  it("targets the signed display scale implied by texture-backed dimensions", () => {
+    const display = {
+      ...createDisplay({ x: -2, y: 3 }),
+      width: 200,
+      height: 90,
+      texture: {
+        orig: { width: 50, height: 30 },
+      },
+    };
+
+    expect(
+      getTextureBackedScaleTargetState(
+        display,
+        { scaleX: -1.5, scaleY: 2 },
+        { width: 240, height: 120 },
+      ),
+    ).toEqual({ scaleX: -4.8, scaleY: 4 });
+  });
+
+  it("uses the mounted sprite display scale as its auto tween destination", () => {
+    const parent = new Container();
+    const animationBus = { dispatch: vi.fn() };
+    const element = parseSprite({
+      state: {
+        id: "mounted-sprite",
+        type: "sprite",
+        src: "",
+        x: 100,
+        y: 80,
+        width: 90,
+        height: 40,
+        scaleX: -1.5,
+      },
+    });
+
+    addSprite({
+      app: {},
+      parent,
+      element,
+      animations: [
+        {
+          id: "mounted-scale-auto",
+          targetId: "mounted-sprite",
+          type: "update",
+          tween: {
+            scaleX: { auto: { duration: 300 } },
+            scaleY: { auto: { duration: 300 } },
+          },
+        },
+      ],
+      animationBus,
+      completionTracker: {
+        getVersion: () => 1,
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      zIndex: 0,
+    });
+
+    const sprite = parent.getChildByLabel("mounted-sprite");
+    const targetState =
+      animationBus.dispatch.mock.calls[0][0].payload.targetState;
+
+    expect(targetState.scaleX).toBe(sprite.scale.x);
+    expect(targetState.scaleY).toBe(sprite.scale.y);
+    expect(targetState.scaleX).toBeLessThan(-1);
+  });
+
+  it("falls back to source and inferred texture dimensions", () => {
+    expect(
+      getTextureBackedScaleTargetState(
+        {
+          ...createDisplay({ x: -4, y: 2 }),
+          width: 320,
+          height: 180,
+          texture: { source: { width: 640, height: 360 } },
+        },
+        { scaleX: -1 },
+      ),
+    ).toEqual({ scaleX: -0.5, scaleY: 0.5 });
+
+    expect(
+      getTextureBackedScaleTargetState(
+        {
+          ...createDisplay({ x: -4, y: 2 }),
+          width: 320,
+          height: 180,
+          texture: {},
+        },
+        { scaleX: -1 },
+        { width: 160, height: 270 },
+      ),
+    ).toEqual({ scaleX: -2, scaleY: 3 });
+  });
+
+  it("keeps zero authored texture scale collapsed", () => {
+    expect(
+      getTextureBackedScaleTargetState(
+        {
+          ...createDisplay(),
+          width: 100,
+          height: 50,
+          texture: { orig: { width: 25, height: 10 } },
+        },
+        { scaleX: 0, scaleY: 0 },
+      ),
+    ).toEqual({ scaleX: 0, scaleY: 0 });
   });
 
   it("does not overwrite unrelated existing Pixi scale", () => {

--- a/spec/elements/rectConfig.spec.js
+++ b/spec/elements/rectConfig.spec.js
@@ -113,7 +113,6 @@ describe("rect runtime validation", () => {
     ["infinite position", { x: Infinity }, "rect.x"],
     ["infinite anchor", { anchorX: -Infinity }, "rect.anchorX"],
     ["NaN rotation", { rotation: Number.NaN }, "rect.rotation"],
-    ["zero scale", { scaleX: 0 }, "rect.scaleX"],
     ["infinite scale", { scaleY: Infinity }, "rect.scaleY"],
     ["out-of-range alpha", { alpha: 1.1 }, "rect.alpha"],
     ["invalid solid color", { fill: "not-a-real-color()" }, "rect.fill"],
@@ -185,6 +184,15 @@ describe("rect runtime validation", () => {
     ],
   ])("rejects %s", (_name, overrides, message) => {
     expect(() => parseRect({ state: createRect(overrides) })).toThrow(message);
+  });
+
+  it.each([
+    ["negative horizontal scale", { scaleX: -1 }],
+    ["negative vertical scale", { scaleY: -2.5 }],
+    ["zero horizontal scale", { scaleX: 0 }],
+    ["zero vertical scale", { scaleY: 0 }],
+  ])("accepts %s", (_name, overrides) => {
+    expect(() => parseRect({ state: createRect(overrides) })).not.toThrow();
   });
 
   it.each([

--- a/spec/elements/rectStyleAnimation.spec.js
+++ b/spec/elements/rectStyleAnimation.spec.js
@@ -3,8 +3,10 @@ import { describe, expect, it, vi } from "vitest";
 import { createAnimationBus } from "../../src/plugins/animations/animationBus.js";
 import { addRect } from "../../src/plugins/elements/rect/addRect.js";
 import { updateRect } from "../../src/plugins/elements/rect/updateRect.js";
+import { rectPlugin } from "../../src/plugins/elements/rect/index.js";
 import { parseRect } from "../../src/plugins/elements/rect/parseRect.js";
 import { getRectStyleAnimationValue } from "../../src/plugins/elements/rect/rectStyleRuntime.js";
+import { renderElements } from "../../src/plugins/elements/renderElements.js";
 import { normalizeAnimations } from "../../src/util/normalizeAnimations.js";
 
 const app = {
@@ -331,6 +333,87 @@ describe("rect style animation", () => {
     expect(rect.scale.x).toBe(1);
     expect(rect.scale.y).toBe(1);
   });
+
+  it.each([1, -1])(
+    "restores authored reflection signs and baked geometry after a transient scale tween ending at %s",
+    (transientScale) => {
+      const parent = new Container();
+      const animationBus = createAnimationBus();
+      const element = createRect({
+        width: 100,
+        height: 80,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        scaleX: -2,
+        scaleY: -0.5,
+      });
+      const rect = mountRect(parent, element, animationBus);
+      const animations = normalizeAnimations([
+        {
+          id: "transient-sign",
+          targetId: "panel",
+          type: "update",
+          tween: {
+            scaleX: {
+              initialValue: -2,
+              keyframes: [
+                { duration: 100, value: transientScale, easing: "linear" },
+              ],
+            },
+            scaleY: {
+              initialValue: -0.5,
+              keyframes: [
+                { duration: 100, value: transientScale, easing: "linear" },
+              ],
+            },
+          },
+        },
+      ]);
+
+      updateRect({
+        app,
+        parent,
+        prevElement: element,
+        nextElement: element,
+        animations,
+        animationBus,
+        completionTracker,
+        eventHandler: vi.fn(),
+        zIndex: 0,
+      });
+      animationBus.flush();
+      animationBus.tick(100);
+
+      expect(rect.scale.x).toBe(transientScale);
+      expect(rect.scale.y).toBe(transientScale);
+      expect(getRectStyleAnimationValue(rect, "rect.width")).toBe(100);
+      expect(getRectStyleAnimationValue(rect, "rect.height")).toBe(80);
+
+      renderElements({
+        app,
+        parent,
+        prevComputedTree: [element],
+        nextComputedTree: [element],
+        animations: [],
+        animationBus,
+        completionTracker,
+        eventHandler: vi.fn(),
+        elementPlugins: [rectPlugin],
+        signal: new AbortController().signal,
+      });
+
+      expect(rect.scale.x).toBe(-1);
+      expect(rect.scale.y).toBe(-1);
+      expect(getRectStyleAnimationValue(rect, "rect.width")).toBe(
+        element.width,
+      );
+      expect(getRectStyleAnimationValue(rect, "rect.height")).toBe(
+        element.height,
+      );
+      expect(rect.pivot.x * rect.scale.x).toBeCloseTo(element.originX);
+      expect(rect.pivot.y * rect.scale.y).toBeCloseTo(element.originY);
+    },
+  );
 
   it("reveals an authored zero-width border without losing its styling", () => {
     const parent = new Container();

--- a/spec/elements/updateParticles.spec.js
+++ b/spec/elements/updateParticles.spec.js
@@ -81,6 +81,47 @@ describe("updateParticles", () => {
     renderContext.deferredMountOperations.length = 0;
   });
 
+  it("applies full signed scale when only the particle transform changes", () => {
+    const parent = new Container();
+    const container = new Container();
+    container.label = "snow-effect";
+    parent.addChild(container);
+    const prevElement = createParticleNode({
+      originX: 20,
+      originY: 10,
+      scaleX: 1,
+      scaleY: 1,
+    });
+    const nextElement = createParticleNode({
+      x: 100,
+      y: 80,
+      originX: -30,
+      originY: 20,
+      scaleX: -1.5,
+      scaleY: 2,
+    });
+
+    updateParticles({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations,
+      animationBus,
+      completionTracker,
+      renderContext,
+      zIndex: 3,
+    });
+
+    expect(deleteParticles).not.toHaveBeenCalled();
+    expect(addParticle).not.toHaveBeenCalled();
+    expect(container.scale.x).toBe(-1.5);
+    expect(container.scale.y).toBe(2);
+    expect(container.pivot).toMatchObject({ x: 20, y: 10 });
+    expect(container.x).toBe(70);
+    expect(container.y).toBe(100);
+  });
+
   it("passes renderContext when adding particles to a missing container", () => {
     const parent = new Container();
     const nextElement = createParticleNode();

--- a/spec/elements/updateRect.spec.js
+++ b/spec/elements/updateRect.spec.js
@@ -1,10 +1,84 @@
 import { Container, Graphics } from "pixi.js";
 import { describe, expect, it, vi } from "vitest";
 import { updateRect } from "../../src/plugins/elements/rect/updateRect.js";
+import { addRect } from "../../src/plugins/elements/rect/addRect.js";
 import { parseRect } from "../../src/plugins/elements/rect/parseRect.js";
 import { getElementRenderState } from "../../src/plugins/elements/elementRenderState.js";
 
 describe("updateRect", () => {
+  it("updates cleanly between negative and positive static scale", () => {
+    const parent = new Container();
+    const app = { audioStage: { add: vi.fn() } };
+    const completionTracker = {
+      getVersion: () => 0,
+      track: () => {},
+      complete: () => {},
+    };
+    const prevElement = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 200,
+        y: 100,
+        width: 100,
+        height: 60,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        scaleX: -2,
+        scaleY: -1,
+        fill: "red",
+      },
+    });
+    const nextElement = parseRect({
+      state: {
+        id: "rect-1",
+        type: "rect",
+        x: 200,
+        y: 100,
+        width: 100,
+        height: 60,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        scaleX: 1.5,
+        scaleY: 0.5,
+        fill: "red",
+      },
+    });
+
+    addRect({
+      app,
+      parent,
+      element: prevElement,
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+    const rectElement = parent.getChildByLabel("rect-1");
+    expect(rectElement.scale.x).toBe(-1);
+    expect(rectElement.scale.y).toBe(-1);
+
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations: [],
+      animationBus: { dispatch: vi.fn() },
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    expect(rectElement.scale.x).toBe(1);
+    expect(rectElement.scale.y).toBe(1);
+    expect(rectElement.width).toBe(150);
+    expect(rectElement.height).toBe(30);
+    expect(rectElement.x).toBe(200);
+    expect(rectElement.y).toBe(100);
+  });
+
   it("resets transient rect scale when returning to an unscaled state", () => {
     const parent = new Container();
     const rectElement = new Graphics();

--- a/spec/elements/updateSprite.spec.js
+++ b/spec/elements/updateSprite.spec.js
@@ -293,6 +293,76 @@ describe("updateSprite", () => {
     );
   });
 
+  it("dispatches auto scale tweens to the signed post-sizing display scale", () => {
+    const spriteElement = {
+      label: "sprite-1",
+      texture: { orig: { width: 50, height: 25 } },
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 50,
+      scale: { x: -2, y: 2 },
+      alpha: 1,
+      zIndex: 0,
+      removeAllListeners: vi.fn(),
+      on: vi.fn(),
+    };
+    const animationBus = { dispatch: vi.fn() };
+    const prevElement = {
+      id: "sprite-1",
+      type: "sprite",
+      src: "sprite",
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 50,
+      scaleX: -1,
+      alpha: 1,
+    };
+    const nextElement = {
+      ...prevElement,
+      width: 200,
+      height: 100,
+    };
+
+    updateSprite({
+      app: { audioStage: { add: vi.fn() } },
+      parent: { children: [spriteElement] },
+      prevElement,
+      nextElement,
+      animations: [
+        {
+          id: "sprite-scale-auto",
+          targetId: "sprite-1",
+          type: "update",
+          tween: {
+            scaleX: { auto: { duration: 300 } },
+            scaleY: { auto: { duration: 300 } },
+          },
+        },
+      ],
+      animationBus,
+      completionTracker: {
+        getVersion: () => 1,
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      eventHandler: vi.fn(),
+      zIndex: 4,
+    });
+
+    expect(animationBus.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          targetState: expect.objectContaining({
+            scaleX: -4,
+            scaleY: 4,
+          }),
+        }),
+      }),
+    );
+  });
+
   it("uses explicit origin independently from anchor when applying rotation", () => {
     const spriteElement = {
       label: "sprite-1",

--- a/spec/elements/updateTextRevealing.spec.js
+++ b/spec/elements/updateTextRevealing.spec.js
@@ -59,6 +59,50 @@ describe("updateTextRevealing", () => {
     });
   });
 
+  it("uses full authored scales as auto tween targets", async () => {
+    const parent = new Container();
+    const child = new Container();
+    child.label = "line-1";
+    parent.addChild(child);
+    const previous = createElement({ scaleX: -1, scaleY: 1 });
+    const next = createElement({ scaleX: -2, scaleY: 1.5 });
+    const animationBus = { dispatch: vi.fn() };
+
+    await updateTextRevealing({
+      parent,
+      prevElement: previous,
+      nextElement: next,
+      animations: [
+        {
+          id: "line-scale",
+          targetId: "line-1",
+          type: "update",
+          tween: {
+            scaleX: { auto: { duration: 300 } },
+            scaleY: { auto: { duration: 300 } },
+          },
+        },
+      ],
+      animationBus,
+      renderContext: createRenderContext(),
+      completionTracker: createCompletionTracker(),
+      zIndex: 0,
+      signal: new AbortController().signal,
+    });
+
+    expect(animationBus.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "START",
+        payload: expect.objectContaining({
+          targetState: expect.objectContaining({
+            scaleX: -2,
+            scaleY: 1.5,
+          }),
+        }),
+      }),
+    );
+  });
+
   it("restarts reveal when position or alpha changes", async () => {
     const parent = new Container();
     const child = new Container();

--- a/spec/elements/updateVideo.spec.js
+++ b/spec/elements/updateVideo.spec.js
@@ -26,6 +26,11 @@ vi.mock("pixi.js", () => ({
 }));
 
 import { updateVideo } from "../../src/plugins/elements/video/updateVideo.js";
+import {
+  captureManagedVideoSpriteSizes,
+  registerManagedVideoSprite,
+  restoreManagedVideoSpriteSizes,
+} from "../../src/plugins/elements/video/managedVideoTextureSizing.js";
 
 const createMockVideo = () => ({
   addEventListener: vi.fn(),
@@ -636,6 +641,206 @@ describe("updateVideo", () => {
     expect(videoElement.texture.source.resource).toBe(nextVideo);
     expect(videoElement.width).toBe(100);
     expect(videoElement.height).toBe(80);
+  });
+
+  it("dispatches auto scale tweens to the signed post-sizing display scale", () => {
+    const currentVideo = createMockVideo();
+    const videoElement = {
+      label: "video-1",
+      texture: {
+        source: {
+          width: 640,
+          height: 360,
+          resource: currentVideo,
+        },
+      },
+      scale: { x: -0.25, y: 0.25 },
+      zIndex: 0,
+      x: 10,
+      y: 20,
+      width: 160,
+      height: 90,
+      alpha: 1,
+    };
+    const animationBus = { dispatch: vi.fn() };
+    const prevElement = {
+      id: "video-1",
+      src: "video.mp4",
+      loop: true,
+      volume: 50,
+      x: 10,
+      y: 20,
+      width: 160,
+      height: 90,
+      scaleX: -1,
+      alpha: 1,
+    };
+    const nextElement = {
+      ...prevElement,
+      width: 320,
+      height: 180,
+    };
+
+    updateVideo({
+      parent: { children: [videoElement] },
+      prevElement,
+      nextElement,
+      animations: [
+        {
+          id: "video-scale-auto",
+          targetId: "video-1",
+          type: "update",
+          tween: {
+            scaleX: { auto: { duration: 300 } },
+            scaleY: { auto: { duration: 300 } },
+          },
+        },
+      ],
+      animationBus,
+      eventHandler: vi.fn(),
+      completionTracker: {
+        getVersion: () => 1,
+        track: vi.fn(),
+        complete: vi.fn(),
+      },
+      zIndex: 3,
+    });
+
+    expect(animationBus.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          targetState: expect.objectContaining({
+            scaleX: -0.5,
+            scaleY: 0.5,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("defers auto scale updates until asynchronous texture sizing settles", () => {
+    const currentVideo = {
+      ...createMockVideo(),
+      videoWidth: 0,
+      videoHeight: 0,
+    };
+    const source = {
+      width: 1,
+      height: 1,
+      resource: currentVideo,
+      __routeGraphicsVideoTextureRuntime: {
+        requestUpdate: vi.fn().mockReturnValue(false),
+      },
+    };
+    const videoElement = {
+      label: "video-1",
+      texture: { source },
+      scale: { x: 1, y: 1 },
+      pivot: {
+        set(x, y) {
+          this.x = x;
+          this.y = y;
+        },
+      },
+      once: vi.fn(),
+      zIndex: 0,
+      x: 0,
+      y: 0,
+      alpha: 1,
+    };
+    Object.defineProperties(videoElement, {
+      width: {
+        get() {
+          return Math.abs(this.scale.x) * this.texture.source.width;
+        },
+        set(value) {
+          const sign = Math.sign(this.scale.x) || 1;
+          this.scale.x = (sign * value) / this.texture.source.width;
+        },
+      },
+      height: {
+        get() {
+          return Math.abs(this.scale.y) * this.texture.source.height;
+        },
+        set(value) {
+          const sign = Math.sign(this.scale.y) || 1;
+          this.scale.y = (sign * value) / this.texture.source.height;
+        },
+      },
+    });
+    videoElement.width = 160;
+    videoElement.height = 90;
+    registerManagedVideoSprite(videoElement);
+    const prevElement = {
+      id: "video-1",
+      src: "video.mp4",
+      loop: true,
+      volume: 50,
+      x: 0,
+      y: 0,
+      width: 160,
+      height: 90,
+      scaleX: 1,
+      scaleY: 1,
+      alpha: 1,
+    };
+    const nextElement = {
+      ...prevElement,
+      width: 320,
+      height: 180,
+    };
+    const animationBus = { dispatch: vi.fn() };
+    const completionTracker = {
+      getVersion: vi.fn().mockReturnValue(4),
+      track: vi.fn(),
+      complete: vi.fn(),
+    };
+    const deferRenderStateCommit = vi.fn();
+
+    updateVideo({
+      parent: { children: [videoElement] },
+      prevElement,
+      nextElement,
+      animations: [
+        {
+          id: "video-scale-auto",
+          targetId: "video-1",
+          type: "update",
+          tween: {
+            scaleX: { auto: { duration: 300 } },
+            scaleY: { auto: { duration: 300 } },
+          },
+        },
+      ],
+      animationBus,
+      completionTracker,
+      deferRenderStateCommit,
+      commitRenderState: vi.fn(),
+      signal: new AbortController().signal,
+      zIndex: 0,
+    });
+
+    expect(animationBus.dispatch).not.toHaveBeenCalled();
+    expect(deferRenderStateCommit).toHaveBeenCalledOnce();
+
+    const sizes = captureManagedVideoSpriteSizes(source);
+    currentVideo.videoWidth = 640;
+    currentVideo.videoHeight = 360;
+    source.width = 640;
+    source.height = 360;
+    restoreManagedVideoSpriteSizes(sizes);
+
+    expect(animationBus.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          targetState: expect.objectContaining({
+            scaleX: 0.5,
+            scaleY: 0.5,
+          }),
+        }),
+      }),
+    );
+    expect(completionTracker.complete).toHaveBeenCalledWith(4);
   });
 
   it("does not re-track pre-synced non-looping video playback on animation completion", () => {

--- a/spec/parser/parseTextRevealing.scale.spec.js
+++ b/spec/parser/parseTextRevealing.scale.spec.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { parseTextRevealing } from "../../src/plugins/elements/text-revealing/parseTextRevealing.js";
+
+const createState = (overrides = {}) => ({
+  id: "scaled-line",
+  type: "text-revealing",
+  x: 300,
+  y: 180,
+  width: 100,
+  anchorX: 0.5,
+  anchorY: 0.5,
+  content: [
+    {
+      text: "Asymmetric line",
+      textStyle: {
+        fontFamily: "Arial",
+        fontSize: 20,
+      },
+    },
+  ],
+  revealEffect: "none",
+  ...overrides,
+});
+
+describe("parseTextRevealing scale", () => {
+  it("preserves scaled layout dimensions and signed anchor origins", () => {
+    const unscaled = parseTextRevealing({ state: createState() });
+    const scaled = parseTextRevealing({
+      state: createState({ scaleX: -2, scaleY: 1.5 }),
+    });
+
+    expect(scaled.width).toBe(200);
+    expect(scaled.height).toBe(Math.round(unscaled.height * 1.5));
+    expect(scaled.scaleX).toBe(-2);
+    expect(scaled.scaleY).toBe(1.5);
+    expect(scaled.originX).toBe(-100);
+    expect(scaled.x + scaled.originX).toBe(300);
+  });
+
+  it("keeps the authored width only as the local wrapping width", () => {
+    const unscaled = parseTextRevealing({ state: createState() });
+    const scaled = parseTextRevealing({
+      state: createState({ scaleX: 2.25 }),
+    });
+
+    expect(scaled.width).toBe(225);
+    expect(scaled.scaleX).toBe(2.25);
+    expect(scaled.content).toEqual(unscaled.content);
+  });
+});

--- a/src/plugins/elements/animated-sprite/addAnimatedSprite.js
+++ b/src/plugins/elements/animated-sprite/addAnimatedSprite.js
@@ -20,7 +20,10 @@ import {
   playbackFpsToAnimationSpeed,
   resolveAnimatedSpriteFrameTextures,
 } from "./animatedSpriteConfig.js";
-import { getElementTransformTargetState } from "../util/transform.js";
+import {
+  getElementTransformTargetState,
+  getTextureBackedScaleTargetState,
+} from "../util/transform.js";
 import { applyAnimatedSpriteTransform } from "./animatedSpriteTransform.js";
 
 /**
@@ -120,6 +123,10 @@ export const addAnimatedSprite = async ({
       element: animatedSprite,
       targetState: {
         ...getElementTransformTargetState(element),
+        ...getTextureBackedScaleTargetState(animatedSprite, element, {
+          width,
+          height,
+        }),
         width,
         height,
         alpha,

--- a/src/plugins/elements/animated-sprite/animatedSpriteTransform.js
+++ b/src/plugins/elements/animated-sprite/animatedSpriteTransform.js
@@ -29,7 +29,9 @@ export const setAnimatedSpriteTransformElement = (animatedSprite, element) => {
 
 export const applyAnimatedSpriteTransform = (animatedSprite, element) => {
   ensureAnimatedSpriteTransformState(animatedSprite, element);
-  applyElementTransform(animatedSprite, element);
+  applyElementTransform(animatedSprite, element, {
+    preserveScaleMagnitude: true,
+  });
 };
 
 export const refreshAnimatedSpritePivot = (animatedSprite) => {

--- a/src/plugins/elements/animated-sprite/updateAnimatedSprite.js
+++ b/src/plugins/elements/animated-sprite/updateAnimatedSprite.js
@@ -25,7 +25,10 @@ import {
   resolveAnimatedSpriteFrameTextures,
 } from "./animatedSpriteConfig.js";
 import { setElementRenderState } from "../elementRenderState.js";
-import { getElementTransformTargetState } from "../util/transform.js";
+import {
+  getElementTransformTargetState,
+  getTextureBackedScaleTargetState,
+} from "../util/transform.js";
 import {
   applyAnimatedSpriteTransform,
   refreshAnimatedSpritePivot,
@@ -276,6 +279,10 @@ export const updateAnimatedSprite = async ({
     element: animatedSpriteElement,
     targetState: {
       ...getElementTransformTargetState(nextElement),
+      ...getTextureBackedScaleTargetState(animatedSpriteElement, nextElement, {
+        width,
+        height,
+      }),
       width,
       height,
       alpha,

--- a/src/plugins/elements/container/parseContainer.js
+++ b/src/plugins/elements/container/parseContainer.js
@@ -69,8 +69,8 @@ export const parseContainer = ({ state, parserPlugins = [] }) => {
         child.scaleX !== undefined || state.scaleX !== undefined;
       const hasScaleY =
         child.scaleY !== undefined || state.scaleY !== undefined;
-      const childScaleX = (child.scaleX ?? 1) * (state.scaleX ?? 1);
-      const childScaleY = (child.scaleY ?? 1) * (state.scaleY ?? 1);
+      const childScaleX = (child.scaleX ?? 1) * Math.abs(state.scaleX ?? 1);
+      const childScaleY = (child.scaleY ?? 1) * Math.abs(state.scaleY ?? 1);
 
       child = plugin.parse({
         state: {

--- a/src/plugins/elements/particles/addParticles.js
+++ b/src/plugins/elements/particles/addParticles.js
@@ -128,7 +128,7 @@ export const addParticle = ({
 
   const width = element.width;
   const height = element.height;
-  applyElementTransform(container, element);
+  applyElementTransform(container, element, { scaleMode: "full" });
 
   // Build emitter config from custom behaviors
   const emitterConfig = {
@@ -242,6 +242,8 @@ export const addParticle = ({
     element: container,
     targetState: getElementTransformTargetState(element, {
       alpha: element.alpha ?? container.alpha,
+      ...(element.scaleX !== undefined ? { scaleX: element.scaleX } : {}),
+      ...(element.scaleY !== undefined ? { scaleY: element.scaleY } : {}),
     }),
     renderContext,
   });

--- a/src/plugins/elements/particles/compileParticleModules.js
+++ b/src/plugins/elements/particles/compileParticleModules.js
@@ -28,11 +28,7 @@ export function compileParticleModules(state) {
 
   const texture = compileTexture(state.modules.appearance.texture);
   const count = emitter.maxParticles;
-  const computedObj = parseCommonObject({
-    ...state,
-    scaleX: undefined,
-    scaleY: undefined,
-  });
+  const computedObj = parseCommonObject(state, { scaleMode: "live" });
 
   return {
     ...computedObj,

--- a/src/plugins/elements/particles/parseParticles.js
+++ b/src/plugins/elements/particles/parseParticles.js
@@ -44,11 +44,7 @@ export const parseParticles = ({ state }) => {
 
   // Reconcile count with emitter.maxParticles
   const count = state.emitter?.maxParticles ?? state.count ?? 100;
-  const computedObj = parseCommonObject({
-    ...state,
-    scaleX: undefined,
-    scaleY: undefined,
-  });
+  const computedObj = parseCommonObject(state, { scaleMode: "live" });
 
   // Build emitter config with count synced to maxParticles
   let emitter = state.emitter;

--- a/src/plugins/elements/particles/updateParticles.js
+++ b/src/plugins/elements/particles/updateParticles.js
@@ -107,7 +107,7 @@ export const updateParticles = ({
       if (nextElement.alpha !== undefined) {
         container.alpha = nextElement.alpha;
       }
-      applyElementTransform(container, nextElement);
+      applyElementTransform(container, nextElement, { scaleMode: "full" });
       setElementRenderState(container, nextElement);
       commitRenderState?.(container);
     };
@@ -120,6 +120,12 @@ export const updateParticles = ({
       element: container,
       targetState: getElementTransformTargetState(nextElement, {
         alpha: nextElement.alpha ?? container.alpha,
+        ...(nextElement.scaleX !== undefined
+          ? { scaleX: nextElement.scaleX }
+          : {}),
+        ...(nextElement.scaleY !== undefined
+          ? { scaleY: nextElement.scaleY }
+          : {}),
       }),
       onComplete: updateElement,
     });

--- a/src/plugins/elements/rect/index.js
+++ b/src/plugins/elements/rect/index.js
@@ -1,6 +1,6 @@
 import { createElementPlugin } from "../elementPlugin.js";
 import { addRect } from "./addRect.js";
-import { updateRect } from "./updateRect.js";
+import { shouldRestoreStaticRectTransform, updateRect } from "./updateRect.js";
 import { deleteRect } from "./deleteRect.js";
 import { parseRect } from "./parseRect.js";
 import { shouldUpdateUnchangedShaderFilterProgress } from "../util/shaderFilterEffect.js";
@@ -12,5 +12,7 @@ export const rectPlugin = createElementPlugin({
   update: updateRect,
   delete: deleteRect,
   parse: parseRect,
-  shouldUpdateUnchanged: shouldUpdateUnchangedShaderFilterProgress,
+  shouldUpdateUnchanged: (options) =>
+    shouldRestoreStaticRectTransform(options) ||
+    shouldUpdateUnchangedShaderFilterProgress(options),
 });

--- a/src/plugins/elements/rect/rectConfig.js
+++ b/src/plugins/elements/rect/rectConfig.js
@@ -402,9 +402,7 @@ export const validateRectState = (state, path = "rect") => {
     assertOptionalFiniteNumber(state[key], `${path}.${key}`);
   }
   for (const key of ["scaleX", "scaleY"]) {
-    if (state[key] !== undefined) {
-      assertPositiveNumber(state[key], `${path}.${key}`);
-    }
+    assertOptionalFiniteNumber(state[key], `${path}.${key}`);
   }
   if (state.alpha !== undefined) {
     assertRange(state.alpha, `${path}.alpha`, 0, 1);

--- a/src/plugins/elements/rect/rectStyleRuntime.js
+++ b/src/plugins/elements/rect/rectStyleRuntime.js
@@ -355,7 +355,9 @@ const addFillTargetState = (targetState, fill) => {
 };
 
 const removeBakedScale = (dimension, scale) =>
-  typeof scale === "number" && scale !== 0 ? dimension / scale : dimension;
+  typeof scale === "number" && scale !== 0
+    ? dimension / Math.abs(scale)
+    : dimension;
 
 export const getRectStyleTargetState = (
   element,

--- a/src/plugins/elements/rect/updateRect.js
+++ b/src/plugins/elements/rect/updateRect.js
@@ -121,14 +121,15 @@ export const updateRect = ({
   });
   const hasBakedWidth =
     liveScaleX &&
-    rectElement.scale.x === 1 &&
+    Math.abs(rectElement.scale.x) === 1 &&
     rectStyleRuntime.state.width === prevElement.width;
   const hasBakedHeight =
     liveScaleY &&
-    rectElement.scale.y === 1 &&
+    Math.abs(rectElement.scale.y) === 1 &&
     rectStyleRuntime.state.height === prevElement.height;
-  const shouldFlattenWidth = !liveScaleX && rectElement.scale.x !== 1;
-  const shouldFlattenHeight = !liveScaleY && rectElement.scale.y !== 1;
+  const shouldFlattenWidth = !liveScaleX && Math.abs(rectElement.scale.x) !== 1;
+  const shouldFlattenHeight =
+    !liveScaleY && Math.abs(rectElement.scale.y) !== 1;
 
   if (
     hasBakedWidth ||

--- a/src/plugins/elements/rect/updateRect.js
+++ b/src/plugins/elements/rect/updateRect.js
@@ -4,9 +4,9 @@ import {
   getLiveAnimations,
 } from "../../animations/planAnimations.js";
 import {
+  applyElementPivot,
   applyElementTransform,
   getElementTransformTargetState,
-  refreshElementPivot,
 } from "../util/transform.js";
 import {
   getBlurTargetState,
@@ -24,10 +24,31 @@ import { setElementRenderState } from "../elementRenderState.js";
 import { drawRectVisual } from "./rectDrawing.js";
 import { bindRectInteractions } from "./rectInteractions.js";
 import {
+  RECT_STYLE_STATE_KEY,
   getRectStyleTargetState,
   installRectStyleRuntime,
   syncRectStyleRuntime,
 } from "./rectStyleRuntime.js";
+
+export const shouldRestoreStaticRectTransform = ({ parent, nextElement }) => {
+  const rectElement = parent.children.find(
+    (child) => child.label === nextElement.id,
+  );
+
+  if (!rectElement) {
+    return false;
+  }
+
+  const styleRuntime = rectElement[RECT_STYLE_STATE_KEY];
+
+  return (
+    rectElement.scale.x !== Math.sign(nextElement.scaleX ?? 1) ||
+    rectElement.scale.y !== Math.sign(nextElement.scaleY ?? 1) ||
+    (styleRuntime !== undefined &&
+      (styleRuntime.state.width !== nextElement.width ||
+        styleRuntime.state.height !== nextElement.height))
+  );
+};
 
 /**
  * Update rectangle element (synchronous)
@@ -119,41 +140,55 @@ export const updateRect = ({
     liveScaleX,
     liveScaleY,
   });
-  const hasBakedWidth =
+  const authoredScaleX = prevElement.scaleX ?? 1;
+  const authoredScaleY = prevElement.scaleY ?? 1;
+  const staticScaleX = Math.sign(authoredScaleX);
+  const staticScaleY = Math.sign(authoredScaleY);
+  const shouldUnbakeWidth =
     liveScaleX &&
-    Math.abs(rectElement.scale.x) === 1 &&
-    rectStyleRuntime.state.width === prevElement.width;
-  const hasBakedHeight =
+    Math.abs(authoredScaleX) > 0 &&
+    rectStyleRuntime.state.width === prevElement.width &&
+    rectStyleRuntime.state.width !== rectStyleStartState["rect.width"];
+  const shouldUnbakeHeight =
     liveScaleY &&
-    Math.abs(rectElement.scale.y) === 1 &&
-    rectStyleRuntime.state.height === prevElement.height;
-  const shouldFlattenWidth = !liveScaleX && Math.abs(rectElement.scale.x) !== 1;
-  const shouldFlattenHeight =
-    !liveScaleY && Math.abs(rectElement.scale.y) !== 1;
+    Math.abs(authoredScaleY) > 0 &&
+    rectStyleRuntime.state.height === prevElement.height &&
+    rectStyleRuntime.state.height !== rectStyleStartState["rect.height"];
+  const shouldBakeWidth =
+    !liveScaleX &&
+    (rectStyleRuntime.state.width !== prevElement.width ||
+      rectElement.scale.x !== staticScaleX);
+  const shouldBakeHeight =
+    !liveScaleY &&
+    (rectStyleRuntime.state.height !== prevElement.height ||
+      rectElement.scale.y !== staticScaleY);
 
   if (
-    hasBakedWidth ||
-    hasBakedHeight ||
-    shouldFlattenWidth ||
-    shouldFlattenHeight
+    shouldUnbakeWidth ||
+    shouldUnbakeHeight ||
+    shouldBakeWidth ||
+    shouldBakeHeight
   ) {
     rectStyleRuntime.beginBatch();
-    if (shouldFlattenWidth) {
-      rectElement.scale.x = 1;
+    if (shouldBakeWidth) {
+      rectElement.scale.x = staticScaleX;
       rectStyleRuntime["rect.width"] = prevElement.width;
-    } else if (hasBakedWidth) {
-      rectElement.scale.x = prevElement.scaleX ?? 1;
+    } else if (shouldUnbakeWidth) {
+      rectElement.scale.x *= Math.abs(authoredScaleX);
       rectStyleRuntime["rect.width"] = rectStyleStartState["rect.width"];
     }
-    if (shouldFlattenHeight) {
-      rectElement.scale.y = 1;
+    if (shouldBakeHeight) {
+      rectElement.scale.y = staticScaleY;
       rectStyleRuntime["rect.height"] = prevElement.height;
-    } else if (hasBakedHeight) {
-      rectElement.scale.y = prevElement.scaleY ?? 1;
+    } else if (shouldUnbakeHeight) {
+      rectElement.scale.y *= Math.abs(authoredScaleY);
       rectStyleRuntime["rect.height"] = rectStyleStartState["rect.height"];
     }
-    refreshElementPivot(rectElement);
     rectStyleRuntime.endBatch();
+    applyElementPivot(rectElement, prevElement, {
+      baseScaleX: liveScaleX ? authoredScaleX : staticScaleX,
+      baseScaleY: liveScaleY ? authoredScaleY : staticScaleY,
+    });
   }
   const targetState = getElementTransformTargetState(nextElement, { alpha });
 

--- a/src/plugins/elements/sprite/addSprite.js
+++ b/src/plugins/elements/sprite/addSprite.js
@@ -48,7 +48,7 @@ export const addSprite = ({
   sprite.width = Math.round(width);
   sprite.height = Math.round(height);
   sprite.alpha = alpha;
-  applyElementTransform(sprite, element);
+  applyElementTransform(sprite, element, { preserveScaleMagnitude: true });
   const shouldForceBlur = hasBlurUpdateAnimation(animations, id);
   syncBlurEffect(sprite, element.blur, { force: shouldForceBlur });
   const shouldForceShaderProgress = hasShaderProgressUpdateAnimation(

--- a/src/plugins/elements/sprite/addSprite.js
+++ b/src/plugins/elements/sprite/addSprite.js
@@ -21,6 +21,7 @@ import { setupScrollInteraction } from "../util/setupScrollInteraction.js";
 import {
   applyElementTransform,
   getElementTransformTargetState,
+  getTextureBackedScaleTargetState,
 } from "../util/transform.js";
 
 /**
@@ -240,6 +241,7 @@ export const addSprite = ({
     element: sprite,
     targetState: {
       ...getElementTransformTargetState(element),
+      ...getTextureBackedScaleTargetState(sprite, element, { width, height }),
       width,
       height,
       alpha,

--- a/src/plugins/elements/sprite/updateSprite.js
+++ b/src/plugins/elements/sprite/updateSprite.js
@@ -30,6 +30,7 @@ import { setupScrollInteraction } from "../util/setupScrollInteraction.js";
 import {
   applyElementTransform,
   getElementTransformTargetState,
+  getTextureBackedScaleTargetState,
 } from "../util/transform.js";
 import { setElementRenderState } from "../elementRenderState.js";
 
@@ -336,6 +337,10 @@ export const updateSprite = ({
     element: spriteElement,
     targetState: {
       ...getElementTransformTargetState(nextElement),
+      ...getTextureBackedScaleTargetState(spriteElement, nextElement, {
+        width,
+        height,
+      }),
       width,
       height,
       alpha,

--- a/src/plugins/elements/sprite/updateSprite.js
+++ b/src/plugins/elements/sprite/updateSprite.js
@@ -301,7 +301,9 @@ export const updateSprite = ({
       spriteElement.width = Math.round(width);
       spriteElement.height = Math.round(height);
       spriteElement.alpha = alpha;
-      applyElementTransform(spriteElement, nextElement);
+      applyElementTransform(spriteElement, nextElement, {
+        preserveScaleMagnitude: true,
+      });
       syncBlurEffect(spriteElement, nextElement.blur, {
         force: shouldForceBlur,
       });

--- a/src/plugins/elements/text-revealing/addTextRevealing.js
+++ b/src/plugins/elements/text-revealing/addTextRevealing.js
@@ -32,7 +32,7 @@ export const addTextRevealing = async ({
   container.label = element.id;
   container.zIndex = zIndex;
 
-  applyElementTransform(container, element);
+  applyElementTransform(container, element, { scaleMode: "full" });
   if (element.alpha !== undefined) container.alpha = element.alpha;
   parent.addChild(container);
   syncShaderFilters(container, element.filters, {
@@ -48,6 +48,8 @@ export const addTextRevealing = async ({
     element: container,
     targetState: getElementTransformTargetState(element, {
       alpha: element.alpha ?? container.alpha,
+      ...(element.scaleX !== undefined && { scaleX: element.scaleX }),
+      ...(element.scaleY !== undefined && { scaleY: element.scaleY }),
     }),
     renderContext,
   });

--- a/src/plugins/elements/text-revealing/parseTextRevealing.js
+++ b/src/plugins/elements/text-revealing/parseTextRevealing.js
@@ -689,7 +689,8 @@ export const parseTextRevealing = ({ state }) => {
       ),
     }),
     ...(revealSound && { revealSound }),
-    ...(state.width !== undefined && { width: state.width }),
+    ...(state.scaleX !== undefined && { scaleX: state.scaleX }),
+    ...(state.scaleY !== undefined && { scaleY: state.scaleY }),
     ...(state.complete && { complete: state.complete }),
   };
 };

--- a/src/plugins/elements/text-revealing/updateTextRevealing.js
+++ b/src/plugins/elements/text-revealing/updateTextRevealing.js
@@ -75,7 +75,9 @@ export const updateTextRevealing = async ({
   };
 
   const updateElement = async () => {
-    applyElementTransform(textRevealingElement, element);
+    applyElementTransform(textRevealingElement, element, {
+      scaleMode: "full",
+    });
     if (element.alpha !== undefined) {
       textRevealingElement.alpha = element.alpha;
     }
@@ -156,6 +158,8 @@ export const updateTextRevealing = async ({
     element: textRevealingElement,
     targetState: getElementTransformTargetState(element, {
       alpha: element.alpha ?? textRevealingElement.alpha,
+      ...(element.scaleX !== undefined && { scaleX: element.scaleX }),
+      ...(element.scaleY !== undefined && { scaleY: element.scaleY }),
     }),
     onComplete: () => {
       void updateElement();

--- a/src/plugins/elements/util/parseCommonObject.js
+++ b/src/plugins/elements/util/parseCommonObject.js
@@ -13,11 +13,11 @@ const SHADER_FILTER_ELEMENT_TYPES = new Set(Object.values(ComputedNodeType));
 
 /**
  * @param {BaseElement} state
- * @param {ParseCommonObjectOption} option
+ * @param {ParseCommonObjectOption} [option]
  * @returns  {ComputedNode}
  */
-export const parseCommonObject = (state) => {
-  if (!(typeof state.width === "number") || !(typeof state.height === "number"))
+export const parseCommonObject = (state, { scaleMode = "baked" } = {}) => {
+  if (!Number.isFinite(state.width) || !Number.isFinite(state.height))
     throw new Error("Input Error: Width or height is missing");
 
   if (!Object.values(ComputedNodeType).includes(state.type))
@@ -28,15 +28,33 @@ export const parseCommonObject = (state) => {
 
   if (!state.id) throw new Error("Input Error: Id is missing");
 
-  let widthAfterScale = state.scaleX ? state.scaleX * state.width : state.width;
-  let heightAfterScale = state.scaleY
-    ? state.scaleY * state.height
-    : state.height;
+  const scaleX = state.scaleX ?? 1;
+  const scaleY = state.scaleY ?? 1;
 
-  //We don't let scale affect container type for now
+  if (!Number.isFinite(scaleX) || !Number.isFinite(scaleY)) {
+    throw new Error("Input Error: scaleX and scaleY must be finite numbers");
+  }
+
+  let widthAfterScale = Math.abs(scaleX * state.width);
+  let heightAfterScale = Math.abs(scaleY * state.height);
+  let anchorWidth = Math.sign(scaleX) * widthAfterScale;
+  let anchorHeight = Math.sign(scaleY) * heightAfterScale;
+
+  // Container scale magnitudes are baked into descendants. Only the sign is
+  // applied to the container itself so a negative scale mirrors the subtree as
+  // one group instead of mirroring every child around its own origin.
   if (state.type === ComputedNodeType.CONTAINER) {
-    widthAfterScale = state.width;
-    heightAfterScale = state.height;
+    widthAfterScale = Math.abs(state.width);
+    heightAfterScale = Math.abs(state.height);
+    anchorWidth = Math.sign(scaleX) * widthAfterScale;
+    anchorHeight = Math.sign(scaleY) * heightAfterScale;
+  } else if (scaleMode === "live") {
+    // Particle dimensions describe the emitter's local area, so its complete
+    // scale (magnitude and sign) remains a live transform.
+    widthAfterScale = Math.abs(state.width);
+    heightAfterScale = Math.abs(state.height);
+    anchorWidth = scaleX * widthAfterScale;
+    anchorHeight = scaleY * heightAfterScale;
   }
 
   const {
@@ -47,8 +65,8 @@ export const parseCommonObject = (state) => {
   } = calculatePositionAfterAnchor({
     positionX: state.x,
     positionY: state.y,
-    width: widthAfterScale,
-    height: heightAfterScale,
+    width: anchorWidth,
+    height: anchorHeight,
     anchorX: state.anchorX,
     anchorY: state.anchorY,
   });
@@ -58,6 +76,8 @@ export const parseCommonObject = (state) => {
     typeof state.originY === "number" ? state.originY : originY;
 
   // Round all pixel calculations
+  const includeScaleX = scaleMode === "live" || scaleX <= 0;
+  const includeScaleY = scaleMode === "live" || scaleY <= 0;
   let computedObj = {
     id: state.id,
     type: state.type,
@@ -69,6 +89,8 @@ export const parseCommonObject = (state) => {
     originY: Math.round(transformOriginY),
     alpha: state.alpha ?? 1,
     rotation: state.rotation ?? 0,
+    ...(state.scaleX !== undefined && includeScaleX ? { scaleX } : {}),
+    ...(state.scaleY !== undefined && includeScaleY ? { scaleY } : {}),
   };
 
   if (state.hover) {

--- a/src/plugins/elements/util/transform.js
+++ b/src/plugins/elements/util/transform.js
@@ -58,6 +58,26 @@ const applyElementScale = (
   });
 };
 
+export const applyElementScaleAndPivot = (
+  displayObject,
+  element,
+  {
+    localOriginX,
+    localOriginY,
+    scaleMode = "sign",
+    preserveScaleMagnitude = false,
+  } = {},
+) => {
+  applyElementScale(displayObject, element, {
+    scaleMode,
+    preserveScaleMagnitude,
+  });
+  applyElementPivot(displayObject, element, {
+    localOriginX,
+    localOriginY,
+  });
+};
+
 export const getElementTransformPosition = (element) => ({
   x: Math.round((element.x ?? 0) + (element.originX ?? 0)),
   y: Math.round((element.y ?? 0) + (element.originY ?? 0)),
@@ -104,17 +124,78 @@ export const applyElementTransform = (
 ) => {
   const position = getElementTransformPosition(element);
 
-  applyElementScale(displayObject, element, {
-    scaleMode,
-    preserveScaleMagnitude,
-  });
-  applyElementPivot(displayObject, element, {
+  applyElementScaleAndPivot(displayObject, element, {
     localOriginX,
     localOriginY,
+    scaleMode,
+    preserveScaleMagnitude,
   });
   displayObject.x = position.x;
   displayObject.y = position.y;
   displayObject.rotation = degreesToRadians(element.rotation ?? 0);
+};
+
+const getTextureDimension = (displayObject, axis) => {
+  const dimension = axis === "x" ? "width" : "height";
+  const textureDimension =
+    displayObject.texture?.orig?.[dimension] ??
+    displayObject.texture?.source?.[dimension];
+
+  if (Number.isFinite(textureDimension) && textureDimension > 0) {
+    return textureDimension;
+  }
+
+  const renderedDimension = Math.abs(displayObject[dimension]);
+  const currentScale = Math.abs(displayObject.scale?.[axis]);
+  const inferredDimension = renderedDimension / currentScale;
+
+  return Number.isFinite(inferredDimension) && inferredDimension > 0
+    ? inferredDimension
+    : undefined;
+};
+
+const getTextureBackedAxisTarget = (
+  displayObject,
+  element,
+  axis,
+  dimension,
+) => {
+  const authoredScale = getAuthoredScale(
+    axis === "x" ? element.scaleX : element.scaleY,
+  );
+  const scaleSign = Math.sign(authoredScale);
+
+  if (scaleSign === 0) {
+    return 0;
+  }
+
+  const textureDimension = getTextureDimension(displayObject, axis);
+  const targetDimension = Math.abs(dimension);
+
+  if (
+    Number.isFinite(targetDimension) &&
+    Number.isFinite(textureDimension) &&
+    textureDimension > 0
+  ) {
+    return (scaleSign * targetDimension) / textureDimension;
+  }
+
+  const currentMagnitude = Math.abs(displayObject.scale?.[axis]);
+  return scaleSign * (Number.isFinite(currentMagnitude) ? currentMagnitude : 1);
+};
+
+export const getTextureBackedScaleTargetState = (
+  displayObject,
+  element,
+  dimensions = {},
+) => {
+  const width = dimensions.width ?? element.width ?? displayObject.width;
+  const height = dimensions.height ?? element.height ?? displayObject.height;
+
+  return {
+    scaleX: getTextureBackedAxisTarget(displayObject, element, "x", width),
+    scaleY: getTextureBackedAxisTarget(displayObject, element, "y", height),
+  };
 };
 
 export const getElementTransformTargetState = (element, extra = {}) => {

--- a/src/plugins/elements/util/transform.js
+++ b/src/plugins/elements/util/transform.js
@@ -3,11 +3,60 @@ export const degreesToRadians = (degrees = 0) => (degrees * Math.PI) / 180;
 export const radiansToDegrees = (radians = 0) => (radians * 180) / Math.PI;
 
 const scaleAdjustedPivotValues = new WeakMap();
+const appliedElementScaleAxes = new WeakMap();
 
 const getFiniteScale = (scale) =>
   typeof scale === "number" && Number.isFinite(scale) && scale !== 0
     ? scale
     : 1;
+
+const getAuthoredScale = (scale) =>
+  typeof scale === "number" && Number.isFinite(scale) ? scale : 1;
+
+const getFiniteScaleMagnitude = (scale) =>
+  typeof scale === "number" && Number.isFinite(scale) ? Math.abs(scale) : 1;
+
+const applyElementScale = (
+  displayObject,
+  element,
+  { scaleMode = "sign", preserveScaleMagnitude = false } = {},
+) => {
+  if (!displayObject.scale) return;
+
+  const previousAxes = appliedElementScaleAxes.get(displayObject) ?? {
+    x: false,
+    y: false,
+  };
+  const applyScaleX = element.scaleX !== undefined || previousAxes.x;
+  const applyScaleY = element.scaleY !== undefined || previousAxes.y;
+
+  if (!applyScaleX && !applyScaleY) return;
+
+  const authoredScaleX = getAuthoredScale(element.scaleX);
+  const authoredScaleY = getAuthoredScale(element.scaleY);
+  const targetScaleX =
+    scaleMode === "full" ? authoredScaleX : Math.sign(authoredScaleX);
+  const targetScaleY =
+    scaleMode === "full" ? authoredScaleY : Math.sign(authoredScaleY);
+  const currentScaleX = getFiniteScaleMagnitude(displayObject.scale.x);
+  const currentScaleY = getFiniteScaleMagnitude(displayObject.scale.y);
+
+  if (applyScaleX) {
+    displayObject.scale.x = preserveScaleMagnitude
+      ? currentScaleX * targetScaleX
+      : targetScaleX;
+  }
+  if (applyScaleY) {
+    displayObject.scale.y = preserveScaleMagnitude
+      ? currentScaleY * targetScaleY
+      : targetScaleY;
+  }
+
+  appliedElementScaleAxes.set(displayObject, {
+    x: element.scaleX !== undefined,
+    y: element.scaleY !== undefined,
+  });
+};
 
 export const getElementTransformPosition = (element) => ({
   x: Math.round((element.x ?? 0) + (element.originX ?? 0)),
@@ -47,10 +96,19 @@ export const applyElementPivot = (
 export const applyElementTransform = (
   displayObject,
   element,
-  { localOriginX, localOriginY } = {},
+  {
+    localOriginX,
+    localOriginY,
+    scaleMode = "sign",
+    preserveScaleMagnitude = false,
+  } = {},
 ) => {
   const position = getElementTransformPosition(element);
 
+  applyElementScale(displayObject, element, {
+    scaleMode,
+    preserveScaleMagnitude,
+  });
   applyElementPivot(displayObject, element, {
     localOriginX,
     localOriginY,
@@ -65,12 +123,18 @@ export const getElementTransformTargetState = (element, extra = {}) => {
   const targetState = {
     x: position.x,
     y: position.y,
-    ...extra,
   };
+
+  if (element.scaleX !== undefined) {
+    targetState.scaleX = Math.sign(getAuthoredScale(element.scaleX));
+  }
+  if (element.scaleY !== undefined) {
+    targetState.scaleY = Math.sign(getAuthoredScale(element.scaleY));
+  }
 
   if (element.rotation !== undefined) {
     targetState.rotation = element.rotation;
   }
 
-  return targetState;
+  return { ...targetState, ...extra };
 };

--- a/src/plugins/elements/video/addVideo.js
+++ b/src/plugins/elements/video/addVideo.js
@@ -19,7 +19,6 @@ import {
   setManagedVideoSpriteResizeHandler,
 } from "./managedVideoTextureSizing.js";
 import {
-  applyElementPivot,
   applyElementTransform,
   getElementTransformTargetState,
 } from "../util/transform.js";
@@ -57,9 +56,9 @@ export const addVideo = ({
 
   sprite.width = Math.round(width);
   sprite.height = Math.round(height);
-  applyElementTransform(sprite, element);
+  applyElementTransform(sprite, element, { preserveScaleMagnitude: true });
   setManagedVideoSpriteResizeHandler(sprite, () => {
-    applyElementPivot(sprite, element);
+    applyElementTransform(sprite, element, { preserveScaleMagnitude: true });
   });
   registerManagedVideoSprite(sprite);
   sprite.alpha = alpha ?? 1;

--- a/src/plugins/elements/video/addVideo.js
+++ b/src/plugins/elements/video/addVideo.js
@@ -2,7 +2,10 @@ import { Texture, Sprite } from "pixi.js";
 import { syncVideoPlaybackTracking } from "./playbackTracking.js";
 import { queueDeferredVideoPlay } from "../renderContext.js";
 import { normalizeVolume } from "../../../util/normalizeVolume.js";
-import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
+import {
+  dispatchLiveAnimations,
+  getLiveAnimations,
+} from "../../animations/planAnimations.js";
 import {
   getBlurTargetState,
   hasBlurUpdateAnimation,
@@ -14,13 +17,16 @@ import {
   syncShaderFilters,
 } from "../util/shaderFilterEffect.js";
 import {
+  hasManagedVideoTextureDimensions,
   registerManagedVideoSprite,
   requestManagedVideoTextureUpdate,
   setManagedVideoSpriteResizeHandler,
 } from "./managedVideoTextureSizing.js";
 import {
+  applyElementScaleAndPivot,
   applyElementTransform,
   getElementTransformTargetState,
+  getTextureBackedScaleTargetState,
 } from "../util/transform.js";
 
 /**
@@ -35,6 +41,7 @@ export const addVideo = ({
   renderContext,
   completionTracker,
   zIndex,
+  signal,
 }) => {
   const { id, width, height, src, volume, loop, alpha } = element;
 
@@ -57,8 +64,76 @@ export const addVideo = ({
   sprite.width = Math.round(width);
   sprite.height = Math.round(height);
   applyElementTransform(sprite, element, { preserveScaleMagnitude: true });
+  const targetState = {
+    ...getElementTransformTargetState(element),
+    ...getTextureBackedScaleTargetState(sprite, element, { width, height }),
+    width,
+    height,
+    alpha: alpha ?? 1,
+  };
+  let waitingForTextureDimensions = false;
+  let textureWaitVersion;
+
+  const refreshScaleTargetState = () => {
+    Object.assign(
+      targetState,
+      getTextureBackedScaleTargetState(sprite, element, { width, height }),
+    );
+  };
+
+  const releaseTextureWait = () => {
+    if (!waitingForTextureDimensions) return;
+    waitingForTextureDimensions = false;
+    signal?.removeEventListener?.("abort", cancelTextureWait);
+    video.removeEventListener?.("error", cancelTextureWait);
+    completionTracker?.complete?.(textureWaitVersion);
+  };
+
+  const cancelTextureWait = () => {
+    releaseTextureWait();
+  };
+
+  const dispatchAnimations = () => {
+    if (signal?.aborted || sprite.destroyed) {
+      releaseTextureWait();
+      return false;
+    }
+
+    refreshScaleTargetState();
+    Object.assign(
+      targetState,
+      getBlurTargetState(element, { force: shouldForceBlur }),
+      getShaderFilterTargetState(element, {
+        force: shouldForceShaderProgress,
+      }),
+    );
+    try {
+      return dispatchLiveAnimations({
+        animations,
+        targetId: id,
+        animationBus,
+        completionTracker,
+        element: sprite,
+        targetState,
+        renderContext,
+      });
+    } finally {
+      releaseTextureWait();
+    }
+  };
+
   setManagedVideoSpriteResizeHandler(sprite, () => {
-    applyElementTransform(sprite, element, { preserveScaleMagnitude: true });
+    applyElementScaleAndPivot(sprite, element, {
+      preserveScaleMagnitude: true,
+    });
+    refreshScaleTargetState();
+
+    if (
+      waitingForTextureDimensions &&
+      hasManagedVideoTextureDimensions(sprite)
+    ) {
+      dispatchAnimations();
+    }
   });
   registerManagedVideoSprite(sprite);
   sprite.alpha = alpha ?? 1;
@@ -85,22 +160,21 @@ export const addVideo = ({
   requestManagedVideoTextureUpdate(sprite);
   queueDeferredVideoPlay(renderContext, video);
 
-  dispatchLiveAnimations({
-    animations,
-    targetId: id,
-    animationBus,
-    completionTracker,
-    element: sprite,
-    targetState: {
-      ...getElementTransformTargetState(element),
-      width,
-      height,
-      alpha: alpha ?? 1,
-      ...getBlurTargetState(element, { force: shouldForceBlur }),
-      ...getShaderFilterTargetState(element, {
-        force: shouldForceShaderProgress,
-      }),
-    },
-    renderContext,
-  });
+  const needsStableAutoScaleTarget = getLiveAnimations(animations, id).some(
+    (animation) =>
+      animation.tween?.scaleX?.auto !== undefined ||
+      animation.tween?.scaleY?.auto !== undefined,
+  );
+
+  if (needsStableAutoScaleTarget && !hasManagedVideoTextureDimensions(sprite)) {
+    waitingForTextureDimensions = true;
+    textureWaitVersion = completionTracker?.getVersion?.();
+    completionTracker?.track?.(textureWaitVersion);
+    signal?.addEventListener?.("abort", cancelTextureWait, { once: true });
+    video.addEventListener?.("error", cancelTextureWait, { once: true });
+    sprite.once?.("destroyed", cancelTextureWait);
+    return;
+  }
+
+  dispatchAnimations();
 };

--- a/src/plugins/elements/video/managedVideoTextureSizing.js
+++ b/src/plugins/elements/video/managedVideoTextureSizing.js
@@ -45,7 +45,33 @@ export const setManagedVideoSpriteResizeHandler = (sprite, handler) => {
 export const requestManagedVideoTextureUpdate = (sprite) => {
   const runtime = sprite?.texture?.source?.__routeGraphicsVideoTextureRuntime;
 
-  runtime?.requestUpdate?.();
+  return runtime?.requestUpdate?.() ?? false;
+};
+
+export const hasManagedVideoTextureDimensions = (sprite) => {
+  const texture = sprite?.texture;
+  const source = texture?.source;
+  const resource = source?.resource;
+  const width = texture?.orig?.width ?? source?.width;
+  const height = texture?.orig?.height ?? source?.height;
+  const exposesVideoDimensions =
+    resource != null &&
+    ("videoWidth" in Object(resource) || "videoHeight" in Object(resource));
+
+  if (exposesVideoDimensions) {
+    return (
+      Number.isFinite(resource.videoWidth) &&
+      resource.videoWidth > 0 &&
+      Number.isFinite(resource.videoHeight) &&
+      resource.videoHeight > 0 &&
+      width === resource.videoWidth &&
+      height === resource.videoHeight
+    );
+  }
+
+  return (
+    Number.isFinite(width) && width > 0 && Number.isFinite(height) && height > 0
+  );
 };
 
 export const unregisterManagedVideoSprite = (

--- a/src/plugins/elements/video/updateVideo.js
+++ b/src/plugins/elements/video/updateVideo.js
@@ -149,7 +149,9 @@ export const updateVideo = ({
     if (!isDeepEqual(prevElement, nextElement)) {
       videoElement.width = Math.round(width);
       videoElement.height = Math.round(height);
-      applyElementTransform(videoElement, nextElement);
+      applyElementTransform(videoElement, nextElement, {
+        preserveScaleMagnitude: true,
+      });
       videoElement.alpha = alpha ?? 1;
       syncBlurEffect(videoElement, nextElement.blur, {
         force: shouldForceBlur,

--- a/src/plugins/elements/video/updateVideo.js
+++ b/src/plugins/elements/video/updateVideo.js
@@ -22,6 +22,7 @@ import {
   syncShaderFilters,
 } from "../util/shaderFilterEffect.js";
 import {
+  hasManagedVideoTextureDimensions,
   registerManagedVideoSprite,
   requestManagedVideoTextureUpdate,
   setManagedVideoSpriteResizeHandler,
@@ -29,9 +30,10 @@ import {
 } from "./managedVideoTextureSizing.js";
 import { setElementRenderState } from "../elementRenderState.js";
 import {
-  applyElementPivot,
+  applyElementScaleAndPivot,
   applyElementTransform,
   getElementTransformTargetState,
+  getTextureBackedScaleTargetState,
 } from "../util/transform.js";
 
 /**
@@ -44,11 +46,11 @@ export const updateVideo = ({
   nextElement,
   animations,
   animationBus,
-  eventHandler,
   completionTracker,
   zIndex,
   deferRenderStateCommit,
   commitRenderState,
+  signal,
 }) => {
   const videoElement = parent.children.find(
     (child) => child.label === prevElement.id,
@@ -58,8 +60,12 @@ export const updateVideo = ({
 
   videoElement.zIndex = zIndex;
   let managedTransformElement = prevElement;
+  let handleManagedTextureResize = () => {};
   setManagedVideoSpriteResizeHandler(videoElement, () => {
-    applyElementPivot(videoElement, managedTransformElement);
+    applyElementScaleAndPivot(videoElement, managedTransformElement, {
+      preserveScaleMagnitude: true,
+    });
+    handleManagedTextureResize();
   });
 
   const { width, height, alpha } = nextElement;
@@ -97,6 +103,11 @@ export const updateVideo = ({
     liveAnimations.some((animation) =>
       Object.prototype.hasOwnProperty.call(animation.tween ?? {}, property),
     );
+  const needsStableAutoScaleTarget = liveAnimations.some(
+    (animation) =>
+      animation.tween?.scaleX?.auto !== undefined ||
+      animation.tween?.scaleY?.auto !== undefined,
+  );
 
   const syncVideoResource = () => {
     let activeVideo = videoElement.texture.source.resource;
@@ -116,7 +127,9 @@ export const updateVideo = ({
 
       const newTexture = Texture.from(nextElement.src);
       videoElement.texture = newTexture;
-      applyElementPivot(videoElement, managedTransformElement);
+      applyElementScaleAndPivot(videoElement, managedTransformElement, {
+        preserveScaleMagnitude: true,
+      });
       unregisterManagedVideoSprite(videoElement, oldSource);
       registerManagedVideoSprite(videoElement);
       activeVideo = newTexture.source.resource;
@@ -183,30 +196,113 @@ export const updateVideo = ({
     videoElement.height = Math.round(
       hasLiveAnimationTween("height") ? currentHeight : height,
     );
-    applyElementPivot(videoElement, managedTransformElement);
+    applyElementScaleAndPivot(videoElement, managedTransformElement, {
+      preserveScaleMagnitude: true,
+    });
     didSyncResourceBeforeAnimation = true;
   }
 
-  const dispatched = dispatchLiveAnimations({
-    animations,
-    targetId: prevElement.id,
-    animationBus,
-    completionTracker,
-    element: videoElement,
-    targetState: {
-      ...getElementTransformTargetState(nextElement),
+  const targetState = {
+    ...getElementTransformTargetState(nextElement),
+    ...getTextureBackedScaleTargetState(videoElement, nextElement, {
       width,
       height,
-      alpha: alpha ?? 1,
-      ...getBlurTargetState(nextElement, {
-        force: shouldForceBlur,
+    }),
+    width,
+    height,
+    alpha: alpha ?? 1,
+    ...getBlurTargetState(nextElement, {
+      force: shouldForceBlur,
+    }),
+    ...getShaderFilterTargetState(nextElement, {
+      force: shouldForceShaderProgress,
+    }),
+  };
+  let waitingForTextureDimensions = false;
+  let textureWaitVersion;
+  const activeVideo = videoElement.texture?.source?.resource;
+
+  const refreshScaleTargetState = () => {
+    Object.assign(
+      targetState,
+      getTextureBackedScaleTargetState(videoElement, nextElement, {
+        width,
+        height,
       }),
-      ...getShaderFilterTargetState(nextElement, {
-        force: shouldForceShaderProgress,
-      }),
-    },
-    onComplete: updateElement,
-  });
+    );
+  };
+
+  const releaseTextureWait = () => {
+    if (!waitingForTextureDimensions) return;
+    waitingForTextureDimensions = false;
+    signal?.removeEventListener?.("abort", cancelTextureWait);
+    activeVideo?.removeEventListener?.("error", failTextureWait);
+    completionTracker?.complete?.(textureWaitVersion);
+  };
+
+  const cancelTextureWait = () => {
+    releaseTextureWait();
+  };
+
+  const failTextureWait = () => {
+    try {
+      if (!signal?.aborted && !videoElement.destroyed) {
+        updateElement();
+      }
+    } finally {
+      releaseTextureWait();
+    }
+  };
+
+  const dispatchAnimations = () => {
+    if (signal?.aborted || videoElement.destroyed) {
+      releaseTextureWait();
+      return false;
+    }
+
+    refreshScaleTargetState();
+    try {
+      return dispatchLiveAnimations({
+        animations,
+        targetId: prevElement.id,
+        animationBus,
+        completionTracker,
+        element: videoElement,
+        targetState,
+        onComplete: updateElement,
+      });
+    } finally {
+      releaseTextureWait();
+    }
+  };
+
+  handleManagedTextureResize = () => {
+    refreshScaleTargetState();
+    if (
+      waitingForTextureDimensions &&
+      hasManagedVideoTextureDimensions(videoElement)
+    ) {
+      dispatchAnimations();
+    }
+  };
+
+  requestManagedVideoTextureUpdate(videoElement);
+
+  if (
+    needsStableAutoScaleTarget &&
+    !hasManagedVideoTextureDimensions(videoElement)
+  ) {
+    waitingForTextureDimensions = true;
+    textureWaitVersion = completionTracker?.getVersion?.();
+    completionTracker?.track?.(textureWaitVersion);
+    signal?.addEventListener?.("abort", cancelTextureWait, { once: true });
+    activeVideo?.addEventListener?.("error", failTextureWait, { once: true });
+    videoElement.once?.("destroyed", cancelTextureWait);
+    deferRenderStateCommit?.();
+    return;
+  }
+
+  const dispatched = dispatchAnimations();
 
   if (!dispatched) {
     // No animations, update immediately

--- a/src/schemas/elements/animated-sprite.computed.yaml
+++ b/src/schemas/elements/animated-sprite.computed.yaml
@@ -41,6 +41,12 @@ properties:
   originY:
     type: number
     description: Calculated origin Y coordinate based on anchor
+  scaleX:
+    type: number
+    description: Authored horizontal scale when a live sign transform is required
+  scaleY:
+    type: number
+    description: Authored vertical scale when a live sign transform is required
   rotation:
     type: number
     description: Rotation in degrees

--- a/src/schemas/elements/animated-sprite.element.yaml
+++ b/src/schemas/elements/animated-sprite.element.yaml
@@ -46,6 +46,12 @@ properties:
   originY:
     type: number
     description: Vertical transform origin in pixels from the spritesheet animation's top edge. Defaults to the anchor-derived Y origin.
+  scaleX:
+    type: number
+    description: Horizontal scale. Negative values mirror the animation and zero collapses it.
+  scaleY:
+    type: number
+    description: Vertical scale. Negative values mirror the animation and zero collapses it.
   rotation:
     type: number
     description: Rotation in degrees

--- a/src/schemas/elements/container.computed.yaml
+++ b/src/schemas/elements/container.computed.yaml
@@ -42,6 +42,12 @@ properties:
   originY:
     type: number
     description: Calculated origin Y coordinate based on anchor
+  scaleX:
+    type: number
+    description: Authored horizontal scale when a live sign transform is required
+  scaleY:
+    type: number
+    description: Authored vertical scale when a live sign transform is required
   children:
     type: array
     description: Parsed child elements with positions adjusted based on direction, gapX, and gapY

--- a/src/schemas/elements/container.element.yaml
+++ b/src/schemas/elements/container.element.yaml
@@ -40,6 +40,12 @@ properties:
   originY:
     type: number
     description: Vertical transform origin in pixels from the container's top edge. Defaults to the anchor-derived Y origin.
+  scaleX:
+    type: number
+    description: Horizontal scale for the container subtree. Negative values mirror the group and zero collapses it.
+  scaleY:
+    type: number
+    description: Vertical scale for the container subtree. Negative values mirror the group and zero collapses it.
   alpha:
     type: number
     description: Opacity/transparency of the container (0-1)

--- a/src/schemas/elements/input.computed.yaml
+++ b/src/schemas/elements/input.computed.yaml
@@ -36,6 +36,12 @@ properties:
   originY:
     type: number
     description: Transform origin Y in pixels
+  scaleX:
+    type: number
+    description: Authored horizontal scale when a live sign transform is required
+  scaleY:
+    type: number
+    description: Authored vertical scale when a live sign transform is required
   rotation:
     type: number
     description: Rotation in degrees

--- a/src/schemas/elements/input.element.yaml
+++ b/src/schemas/elements/input.element.yaml
@@ -172,6 +172,12 @@ properties:
   originY:
     type: number
     description: Vertical transform origin in pixels from the input's top edge. Defaults to the anchor-derived Y origin.
+  scaleX:
+    type: number
+    description: Horizontal scale. Negative values mirror the input and zero collapses it.
+  scaleY:
+    type: number
+    description: Vertical scale. Negative values mirror the input and zero collapses it.
   rotation:
     type: number
     description: Rotation in degrees

--- a/src/schemas/elements/particle.computed.yaml
+++ b/src/schemas/elements/particle.computed.yaml
@@ -88,6 +88,14 @@ properties:
     type: number
     description: Transform origin Y in pixels
 
+  scaleX:
+    type: number
+    description: Full horizontal live scale for the particle container
+
+  scaleY:
+    type: number
+    description: Full vertical live scale for the particle container
+
   rotation:
     type: number
     description: Element-level emitter container rotation in degrees

--- a/src/schemas/elements/particle.element.yaml
+++ b/src/schemas/elements/particle.element.yaml
@@ -45,6 +45,14 @@ properties:
     type: number
     description: Vertical transform origin in pixels from the emitter container's top edge. Defaults to the anchor-derived Y origin.
 
+  scaleX:
+    type: number
+    description: Horizontal live scale for the particle effect. Negative values mirror the effect and zero collapses it.
+
+  scaleY:
+    type: number
+    description: Vertical live scale for the particle effect. Negative values mirror the effect and zero collapses it.
+
   rotation:
     type: number
     description: Element-level emitter container rotation in degrees. This is separate from per-particle appearance rotation.

--- a/src/schemas/elements/rect.element.yaml
+++ b/src/schemas/elements/rect.element.yaml
@@ -166,12 +166,10 @@ properties:
     description: Vertical transform origin in pixels from the element's top edge. Defaults to the anchor-derived Y origin.
   scaleX:
     type: number
-    exclusiveMinimum: 0
-    description: Horizontal scale baked into rect geometry
+    description: Horizontal scale. Negative values mirror the rectangle and zero collapses it.
   scaleY:
     type: number
-    exclusiveMinimum: 0
-    description: Vertical scale baked into rect geometry
+    description: Vertical scale. Negative values mirror the rectangle and zero collapses it.
   alpha:
     type: number
     description: Opacity/transparency of the rectangle (0-1)

--- a/src/schemas/elements/slider.computed.yaml
+++ b/src/schemas/elements/slider.computed.yaml
@@ -36,6 +36,12 @@ properties:
   originY:
     type: number
     description: Calculated origin Y coordinate based on anchor
+  scaleX:
+    type: number
+    description: Authored horizontal scale when a live sign transform is required
+  scaleY:
+    type: number
+    description: Authored vertical scale when a live sign transform is required
   rotation:
     type: number
     description: Rotation in degrees

--- a/src/schemas/elements/slider.element.yaml
+++ b/src/schemas/elements/slider.element.yaml
@@ -47,6 +47,12 @@ properties:
   originY:
     type: number
     description: Vertical transform origin in pixels from the slider's top edge. Defaults to the anchor-derived Y origin.
+  scaleX:
+    type: number
+    description: Horizontal scale. Negative values mirror the slider and zero collapses it.
+  scaleY:
+    type: number
+    description: Vertical scale. Negative values mirror the slider and zero collapses it.
   rotation:
     type: number
     description: Rotation in degrees

--- a/src/schemas/elements/sprite.computed.yaml
+++ b/src/schemas/elements/sprite.computed.yaml
@@ -38,6 +38,12 @@ properties:
   originY:
     type: number
     description: Calculated origin Y coordinate based on anchor
+  scaleX:
+    type: number
+    description: Authored horizontal scale when a live sign transform is required
+  scaleY:
+    type: number
+    description: Authored vertical scale when a live sign transform is required
   src:
     type: string
     description: URL of the sprite image

--- a/src/schemas/elements/sprite.element.yaml
+++ b/src/schemas/elements/sprite.element.yaml
@@ -43,6 +43,12 @@ properties:
   originY:
     type: number
     description: Vertical transform origin in pixels from the element's top edge. Defaults to the anchor-derived Y origin.
+  scaleX:
+    type: number
+    description: Horizontal scale. Negative values mirror the sprite and zero collapses it.
+  scaleY:
+    type: number
+    description: Vertical scale. Negative values mirror the sprite and zero collapses it.
   src:
     type: string
     description: src of the sprite image. the alias of the pre loaded asset. can be empty

--- a/src/schemas/elements/text-revealing.computed.yaml
+++ b/src/schemas/elements/text-revealing.computed.yaml
@@ -240,6 +240,12 @@ properties:
   originY:
     type: number
     description: Calculated origin Y coordinate based on anchor
+  scaleX:
+    type: number
+    description: Authored horizontal scale when a live sign transform is required
+  scaleY:
+    type: number
+    description: Authored vertical scale when a live sign transform is required
   rotation:
     type: number
     description: Rotation in degrees

--- a/src/schemas/elements/text-revealing.element.yaml
+++ b/src/schemas/elements/text-revealing.element.yaml
@@ -231,6 +231,12 @@ properties:
   originY:
     type: number
     description: Vertical transform origin in pixels from the text layout box's top edge. Defaults to the anchor-derived Y origin.
+  scaleX:
+    type: number
+    description: Horizontal scale. Negative values mirror the text reveal and zero collapses it.
+  scaleY:
+    type: number
+    description: Vertical scale. Negative values mirror the text reveal and zero collapses it.
   rotation:
     type: number
     description: Rotation in degrees

--- a/src/schemas/elements/text.computed.yaml
+++ b/src/schemas/elements/text.computed.yaml
@@ -178,6 +178,12 @@ properties:
   originY:
     type: number
     description: Calculated origin Y coordinate based on anchor
+  scaleX:
+    type: number
+    description: Authored horizontal scale when a live sign transform is required
+  scaleY:
+    type: number
+    description: Authored vertical scale when a live sign transform is required
   rotation:
     type: number
     description: Rotation in degrees

--- a/src/schemas/elements/text.element.yaml
+++ b/src/schemas/elements/text.element.yaml
@@ -152,6 +152,12 @@ properties:
   originY:
     type: number
     description: Vertical transform origin in pixels from the text layout box's top edge. Defaults to the anchor-derived Y origin.
+  scaleX:
+    type: number
+    description: Horizontal scale. Negative values mirror the text and zero collapses it.
+  scaleY:
+    type: number
+    description: Vertical scale. Negative values mirror the text and zero collapses it.
   rotation:
     type: number
     description: Rotation in degrees

--- a/src/schemas/elements/video.computed.yaml
+++ b/src/schemas/elements/video.computed.yaml
@@ -11,8 +11,6 @@ required:
   - height
   - originX
   - originY
-  - scaleX
-  - scaleY
   - alpha
   - volume
   - loop
@@ -48,10 +46,10 @@ properties:
     default: 0
   scaleX:
     type: number
-    description: X scale factor
+    description: Authored horizontal scale when a live sign transform is required
   scaleY:
     type: number
-    description: Y scale factor
+    description: Authored vertical scale when a live sign transform is required
   alpha:
     type: number
     description: Opacity/transparency of the video (0-1)

--- a/src/schemas/elements/video.element.yaml
+++ b/src/schemas/elements/video.element.yaml
@@ -44,6 +44,12 @@ properties:
   originY:
     type: number
     description: Vertical transform origin in pixels from the video's top edge. Defaults to the anchor-derived Y origin.
+  scaleX:
+    type: number
+    description: Horizontal scale. Negative values mirror the video and zero collapses it.
+  scaleY:
+    type: number
+    description: Vertical scale. Negative values mirror the video and zero collapses it.
   rotation:
     type: number
     description: Rotation in degrees

--- a/src/types.js
+++ b/src/types.js
@@ -72,6 +72,8 @@
  * @typedef {Object} BaseElement
  * @property {string} id - Unique identifier for the element
  * @property {string} type - Type of the element
+ * @property {number} [scaleX=1] - Horizontal scale. Negative values mirror the element; zero collapses it.
+ * @property {number} [scaleY=1] - Vertical scale. Negative values mirror the element; zero collapses it.
  * @property {ShaderFilter[]} [filters] - Ordered inline shader effects
  */
 
@@ -90,8 +92,7 @@
 
 /**
  * @typedef {Object} ParseCommonObjectOption
- * @property {number} providedWidth
- * @property {number} providedHeight
+ * @property {"baked" | "live"} [scaleMode="baked"] - Whether scale magnitude is baked into dimensions or kept as a live transform
  */
 
 /**
@@ -124,8 +125,8 @@
  * @property {number} height - Height of the computed node
  * @property {number} originX
  * @property {number} originY
- * @property {number} scaleX
- * @property {number} scaleY
+ * @property {number} [scaleX]
+ * @property {number} [scaleY]
  * @property {number} rotation - Rotation in degrees
  */
 

--- a/vt/reference/container/negative-scale-01.webp
+++ b/vt/reference/container/negative-scale-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16197339179c25bd650a39eb1451dc4760f67a4eeacda0922aa5b5bb008b6c5d
+size 2752

--- a/vt/reference/particles/negative-scale-01.webp
+++ b/vt/reference/particles/negative-scale-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09dbbd3396314268f3045376fea304e83d4fc5d1a1e1058ac22bd3c95ee813eb
+size 4922

--- a/vt/reference/rect/negative-scale-01.webp
+++ b/vt/reference/rect/negative-scale-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8ce62206bd122fbc53d8f45e48c178513df0327e1ee228c1bbf822f6147b196
+size 3348

--- a/vt/reference/recttransition/rect-negative-scale-restore-01.webp
+++ b/vt/reference/recttransition/rect-negative-scale-restore-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c4c830356cd0ebc1d312bee6872dd7e8dcaefc9811aedcf2d70a55146d4b840
+size 2088

--- a/vt/reference/recttransition/rect-negative-scale-restore-02.webp
+++ b/vt/reference/recttransition/rect-negative-scale-restore-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:717e1886e5a711a295df34031c038f5aa1604195981f5ce87bdfe210b03991f4
+size 2138

--- a/vt/reference/recttransition/rect-negative-scale-restore-03.webp
+++ b/vt/reference/recttransition/rect-negative-scale-restore-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c4c830356cd0ebc1d312bee6872dd7e8dcaefc9811aedcf2d70a55146d4b840
+size 2088

--- a/vt/reference/sprite/negative-scale-01.webp
+++ b/vt/reference/sprite/negative-scale-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6dd0fb20d0377b20d71536f5b3fb1b1e0abea660f578808422f1e238fc8b2ecc
+size 10064

--- a/vt/reference/sprite/negative-scale-02.webp
+++ b/vt/reference/sprite/negative-scale-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0df80f680cf4b74bd0934d2afa3a18f9b711b9a685ed96139ae01727e7ba6cb
+size 10318

--- a/vt/reference/sprite/negative-scale-03.webp
+++ b/vt/reference/sprite/negative-scale-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6dd0fb20d0377b20d71536f5b3fb1b1e0abea660f578808422f1e238fc8b2ecc
+size 10064

--- a/vt/reference/spritetransition/sprite-negative-scale-auto-01.webp
+++ b/vt/reference/spritetransition/sprite-negative-scale-auto-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:350b97f59cf4d0ec37e43845eb880fe614c6b9682a6399557db7c5abaf2ef120
+size 3354

--- a/vt/reference/spritetransition/sprite-negative-scale-auto-02.webp
+++ b/vt/reference/spritetransition/sprite-negative-scale-auto-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:637eaff62cddfd6ef177358c087214edeb936581b8453d4ea81113866d207c52
+size 4276

--- a/vt/reference/spritetransition/sprite-negative-scale-auto-03.webp
+++ b/vt/reference/spritetransition/sprite-negative-scale-auto-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88c1f4e74f5d6c7526bcbe7378137504e9034b111077af02a1611964c1dcda42
+size 5108

--- a/vt/reference/textbasic/negative-scale-01.webp
+++ b/vt/reference/textbasic/negative-scale-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a7752a3162631cfa1fae260a4d4c86eb619e7235f96780b81db3610a6cc4131
+size 7522

--- a/vt/reference/textrevealing/negative-scale-01.webp
+++ b/vt/reference/textrevealing/negative-scale-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2ddd4f97cd0be8b6cdefb49d782ada142548108f0953db1c4f43ceb5260d502
+size 12050

--- a/vt/specs/container/negative-scale.yaml
+++ b/vt/specs/container/negative-scale.yaml
@@ -1,0 +1,134 @@
+---
+title: Negative Container Scale
+description: Asymmetric grayscale child groups verify that a container reflects its subtree as one group.
+specs:
+  - a negative container scale should mirror child positions and geometry together
+  - scale magnitude should be baked into descendants while the sign stays on the group
+  - nested negative scales should compose back to a positive orientation
+---
+states:
+  - elements:
+      - id: group-normal
+        type: container
+        x: 240
+        "y": 190
+        width: 260
+        height: 160
+        anchorX: 0.5
+        anchorY: 0.5
+        children:
+          - id: normal-body
+            type: rect
+            x: 20
+            "y": 25
+            width: 150
+            height: 100
+            fill: "#D9D9D9"
+            cornerRadius:
+              topLeft: 36
+              topRight: 0
+              bottomRight: 16
+              bottomLeft: 0
+          - id: normal-tip
+            type: rect
+            x: 175
+            "y": 60
+            width: 65
+            height: 30
+            fill: "#737373"
+      - id: group-flipped
+        type: container
+        x: 640
+        "y": 190
+        width: 260
+        height: 160
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -1
+        children:
+          - id: flipped-body
+            type: rect
+            x: 20
+            "y": 25
+            width: 150
+            height: 100
+            fill: "#D9D9D9"
+            cornerRadius:
+              topLeft: 36
+              topRight: 0
+              bottomRight: 16
+              bottomLeft: 0
+          - id: flipped-tip
+            type: rect
+            x: 175
+            "y": 60
+            width: 65
+            height: 30
+            fill: "#737373"
+      - id: group-flipped-magnitude
+        type: container
+        x: 1050
+        "y": 190
+        width: 220
+        height: 140
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -1.25
+        scaleY: 1.2
+        children:
+          - id: magnitude-body
+            type: rect
+            x: 16
+            "y": 20
+            width: 125
+            height: 85
+            fill: "#D9D9D9"
+            cornerRadius:
+              topLeft: 30
+              topRight: 0
+              bottomRight: 12
+              bottomLeft: 0
+          - id: magnitude-tip
+            type: rect
+            x: 145
+            "y": 52
+            width: 55
+            height: 25
+            fill: "#737373"
+      - id: outer-double-flip
+        type: container
+        x: 640
+        "y": 520
+        width: 300
+        height: 160
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -1
+        children:
+          - id: inner-double-flip
+            type: container
+            x: 20
+            "y": 20
+            width: 260
+            height: 120
+            scaleX: -1
+            children:
+              - id: double-body
+                type: rect
+                x: 15
+                "y": 15
+                width: 150
+                height: 90
+                fill: "#FFFFFF"
+                cornerRadius:
+                  topLeft: 34
+                  topRight: 0
+                  bottomRight: 14
+                  bottomLeft: 0
+              - id: double-tip
+                type: rect
+                x: 170
+                "y": 45
+                width: 70
+                height: 30
+                fill: "#737373"

--- a/vt/specs/particles/negative-scale.yaml
+++ b/vt/specs/particles/negative-scale.yaml
@@ -1,0 +1,110 @@
+---
+title: Negative Particle Scale
+description: Deterministic asymmetric burst fields verify full signed live scale on particle containers.
+specs:
+  - particle effect dimensions should remain local while negative scale mirrors the complete field
+  - equal seeds should produce reflected copies around their anchor-derived centers
+  - particle scale magnitude and sign should be applied exactly once
+skipInitialScreenshot: true
+steps:
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 32
+  - action: wait
+    ms: 50
+  - action: customEvent
+    name: "primeVtScreenshot"
+  - action: wait
+    ms: 50
+  - action: screenshot
+---
+states:
+  - elements:
+      - id: normal-frame
+        type: rect
+        x: 300
+        "y": 340
+        width: 320
+        height: 220
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: transparent
+        border:
+          width: 2
+          color: "#4D4D4D"
+      - id: normal-particles
+        type: particles
+        x: 300
+        "y": 340
+        width: 320
+        height: 220
+        anchorX: 0.5
+        anchorY: 0.5
+        seed: 8642
+        modules:
+          emission:
+            mode: burst
+            burstCount: 50
+            maxActive: 50
+            duration: 0.1
+            particleLifetime: 10
+            source:
+              kind: rect
+              data:
+                x: 24
+                "y": 28
+                width: 135
+                height: 70
+          appearance:
+            texture:
+              shape: rect
+              width: 12
+              height: 7
+              color: "#FFFFFF"
+            rotation:
+              mode: none
+      - id: flipped-frame
+        type: rect
+        x: 900
+        "y": 340
+        width: 320
+        height: 220
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: transparent
+        border:
+          width: 2
+          color: "#4D4D4D"
+      - id: flipped-particles
+        type: particles
+        x: 900
+        "y": 340
+        width: 320
+        height: 220
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -1
+        seed: 8642
+        modules:
+          emission:
+            mode: burst
+            burstCount: 50
+            maxActive: 50
+            duration: 0.1
+            particleLifetime: 10
+            source:
+              kind: rect
+              data:
+                x: 24
+                "y": 28
+                width: 135
+                height: 70
+          appearance:
+            texture:
+              shape: rect
+              width: 12
+              height: 7
+              color: "#FFFFFF"
+            rotation:
+              mode: none

--- a/vt/specs/rect/negative-scale.yaml
+++ b/vt/specs/rect/negative-scale.yaml
@@ -1,0 +1,127 @@
+---
+title: Negative Rect Scale
+description: Asymmetric corner geometry verifies signed scale without relying on color.
+specs:
+  - negative scale should mirror rect geometry while keeping drawable dimensions positive
+  - anchor-derived centers should stay fixed for horizontal, vertical, and two-axis reflections
+  - scale magnitude should remain baked exactly once
+  - zero scale should collapse the overlaid rect completely
+---
+states:
+  - elements:
+      - id: rect-normal
+        type: rect
+        x: 240
+        "y": 190
+        width: 220
+        height: 140
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#FFFFFF"
+        cornerRadius:
+          topLeft: 64
+          topRight: 8
+          bottomRight: 32
+          bottomLeft: 0
+      - id: rect-flip-x
+        type: rect
+        x: 640
+        "y": 190
+        width: 220
+        height: 140
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -1
+        fill: "#FFFFFF"
+        cornerRadius:
+          topLeft: 64
+          topRight: 8
+          bottomRight: 32
+          bottomLeft: 0
+      - id: rect-flip-y
+        type: rect
+        x: 1040
+        "y": 190
+        width: 220
+        height: 140
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleY: -1
+        fill: "#FFFFFF"
+        cornerRadius:
+          topLeft: 64
+          topRight: 8
+          bottomRight: 32
+          bottomLeft: 0
+      - id: rect-flip-both-magnitude
+        type: rect
+        x: 400
+        "y": 510
+        width: 160
+        height: 100
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -1.5
+        scaleY: -1.4
+        fill: "#D9D9D9"
+        cornerRadius:
+          topLeft: 48
+          topRight: 4
+          bottomRight: 24
+          bottomLeft: 0
+      - id: zero-scale-underlay
+        type: rect
+        x: 820
+        "y": 510
+        width: 180
+        height: 120
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#4D4D4D"
+      - id: zero-scale-overlay
+        type: rect
+        x: 820
+        "y": 510
+        width: 180
+        height: 120
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: 0
+        scaleY: 0
+        fill: "#FFFFFF"
+      - id: marker-normal
+        type: rect
+        x: 240
+        "y": 190
+        width: 8
+        height: 8
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#737373"
+      - id: marker-flip-x
+        type: rect
+        x: 640
+        "y": 190
+        width: 8
+        height: 8
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#737373"
+      - id: marker-flip-y
+        type: rect
+        x: 1040
+        "y": 190
+        width: 8
+        height: 8
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#737373"
+      - id: marker-both
+        type: rect
+        x: 400
+        "y": 510
+        width: 8
+        height: 8
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#737373"

--- a/vt/specs/recttransition/rect-negative-scale-restore.yaml
+++ b/vt/specs/recttransition/rect-negative-scale-restore.yaml
@@ -1,0 +1,77 @@
+---
+title: Rect Negative Scale Restoration
+description: A repeated render restores authored reflection after a transient scale tween ends positive.
+specs:
+  - the update tween should visibly end with the temporary positive scale
+  - the following unchanged render should restore the authored horizontal reflection
+  - the following render should restore the full 240 by 140 baked geometry
+  - the centered anchor should remain fixed through both representations
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 300
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: screenshot
+---
+states:
+  - elements:
+      - &guide
+        id: guide
+        type: rect
+        x: 640
+        "y": 360
+        width: 240
+        height: 140
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#262626"
+      - &panel
+        id: reflected-panel
+        type: rect
+        x: 640
+        "y": 360
+        width: 120
+        height: 140
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -2
+        fill: "#D9D9D9"
+        cornerRadius:
+          topLeft: 56
+          topRight: 4
+          bottomRight: 28
+          bottomLeft: 0
+      - &anchor
+        id: anchor
+        type: rect
+        x: 640
+        "y": 360
+        width: 8
+        height: 8
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#737373"
+  - elements:
+      - *guide
+      - *panel
+      - *anchor
+    animations:
+      - id: transient-positive-scale
+        targetId: reflected-panel
+        type: update
+        tween:
+          scaleX:
+            initialValue: -2
+            keyframes:
+              - duration: 300
+                value: 1
+                easing: linear
+  - elements:
+      - *guide
+      - *panel
+      - *anchor

--- a/vt/specs/sprite/negative-scale.yaml
+++ b/vt/specs/sprite/negative-scale.yaml
@@ -1,0 +1,79 @@
+---
+title: Negative Sprite Scale
+description: Uses an intentionally asymmetric asset to make every reflection visually unambiguous (asset-based guideline exception).
+specs:
+  - negative scale should mirror sprite texture content around its anchor
+  - horizontal, vertical, and two-axis signs should compose independently
+  - updates between negative and positive signs should not retain a stale reflection
+steps:
+  - action: keypress
+    key: "n"
+  - action: screenshot
+  - action: keypress
+    key: b
+  - action: screenshot
+---
+states:
+  - elements:
+      - id: sprite-left
+        type: sprite
+        src: sprite-mask-asym-incoming
+        x: 320
+        "y": 230
+        width: 400
+        height: 225
+        anchorX: 0.5
+        anchorY: 0.5
+      - id: sprite-right
+        type: sprite
+        src: sprite-mask-asym-incoming
+        x: 960
+        "y": 230
+        width: 400
+        height: 225
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -1
+      - id: sprite-bottom
+        type: sprite
+        src: sprite-mask-asym-incoming
+        x: 640
+        "y": 540
+        width: 320
+        height: 180
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleY: -1
+  - elements:
+      - id: sprite-left
+        type: sprite
+        src: sprite-mask-asym-incoming
+        x: 320
+        "y": 230
+        width: 400
+        height: 225
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: 1
+      - id: sprite-right
+        type: sprite
+        src: sprite-mask-asym-incoming
+        x: 960
+        "y": 230
+        width: 400
+        height: 225
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -1
+        scaleY: -1
+      - id: sprite-bottom
+        type: sprite
+        src: sprite-mask-asym-incoming
+        x: 640
+        "y": 540
+        width: 320
+        height: 180
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -1.25
+        scaleY: 1

--- a/vt/specs/spritetransition/sprite-negative-scale-auto.yaml
+++ b/vt/specs/spritetransition/sprite-negative-scale-auto.yaml
@@ -1,0 +1,78 @@
+---
+title: Sprite Negative Scale Auto Transition
+description: An asymmetric texture verifies that auto scale targets retain authored dimensions and signs.
+specs:
+  - the mirrored sprite should grow from 160 by 90 to 320 by 270
+  - the halfway frame should remain centered and measure approximately 240 by 180
+  - the final frame should preserve the authored negative horizontal sign
+  - auto scale should not settle at the texture's 1280 by 720 native size
+steps:
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - elements:
+      - &horizontal-guide
+        id: horizontal-guide
+        type: rect
+        x: 430
+        "y": 359
+        width: 420
+        height: 2
+        fill: "#FFFFFF"
+      - &vertical-guide
+        id: vertical-guide
+        type: rect
+        x: 639
+        "y": 190
+        width: 2
+        height: 340
+        fill: "#FFFFFF"
+      - id: mirrored-sprite
+        type: sprite
+        src: sprite-mask-asym-incoming
+        x: 640
+        "y": 360
+        width: 320
+        height: 180
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -0.5
+        scaleY: 0.5
+  - elements:
+      - *horizontal-guide
+      - *vertical-guide
+      - id: mirrored-sprite
+        type: sprite
+        src: sprite-mask-asym-incoming
+        x: 640
+        "y": 360
+        width: 320
+        height: 180
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -1
+        scaleY: 1.5
+    animations:
+      - id: signed-auto-scale
+        targetId: mirrored-sprite
+        type: update
+        tween:
+          scaleX:
+            auto:
+              duration: 1000
+              easing: linear
+          scaleY:
+            auto:
+              duration: 1000
+              easing: linear

--- a/vt/specs/textbasic/negative-scale.yaml
+++ b/vt/specs/textbasic/negative-scale.yaml
@@ -1,0 +1,62 @@
+---
+title: Negative Text Scale
+description: Text content is the subject of this test, making glyph direction a direct reflection oracle.
+specs:
+  - negative horizontal scale should mirror the complete text layout
+  - negative vertical scale should reflect glyphs around the anchor-derived center
+  - two negative axes and non-unit magnitude should compose without corrupting layout
+---
+states:
+  - elements:
+      - id: text-normal
+        type: text
+        content: "LEFT  →  RIGHT"
+        x: 320
+        "y": 170
+        width: 360
+        anchorX: 0.5
+        anchorY: 0.5
+        textStyle:
+          fontSize: 42
+          align: center
+          fill: "#FFFFFF"
+      - id: text-flip-x
+        type: text
+        content: "LEFT  →  RIGHT"
+        x: 960
+        "y": 170
+        width: 360
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -1
+        textStyle:
+          fontSize: 42
+          align: center
+          fill: "#FFFFFF"
+      - id: text-flip-y
+        type: text
+        content: "TOP  ↑  BOTTOM"
+        x: 320
+        "y": 480
+        width: 400
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleY: -1
+        textStyle:
+          fontSize: 40
+          align: center
+          fill: "#D9D9D9"
+      - id: text-flip-both
+        type: text
+        content: "DOUBLE  ↗  FLIP"
+        x: 930
+        "y": 480
+        width: 320
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -1.2
+        scaleY: -1.35
+        textStyle:
+          fontSize: 36
+          align: center
+          fill: "#D9D9D9"

--- a/vt/specs/textrevealing/negative-scale.yaml
+++ b/vt/specs/textrevealing/negative-scale.yaml
@@ -1,0 +1,151 @@
+---
+title: Text Revealing Negative Scale
+description: Asymmetric instant text verifies full scale magnitude, reflection, and centered anchors.
+specs:
+  - positive non-unit scale should enlarge text-revealing content exactly once
+  - negative scale should mirror the entire revealed layout around its anchor
+  - horizontal and vertical reflection signs should compose independently
+  - every anchor marker should remain fixed at the center of its scaled layout
+---
+states:
+  - elements:
+      - id: top-left-guide
+        type: rect
+        x: 310
+        "y": 205
+        width: 360
+        height: 120
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#262626"
+      - id: top-right-guide
+        type: rect
+        x: 970
+        "y": 205
+        width: 360
+        height: 120
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#262626"
+      - id: bottom-left-guide
+        type: rect
+        x: 310
+        "y": 515
+        width: 270
+        height: 120
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#262626"
+      - id: bottom-right-guide
+        type: rect
+        x: 970
+        "y": 515
+        width: 270
+        height: 120
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#262626"
+      - id: positive-scale
+        type: text-revealing
+        x: 310
+        "y": 205
+        width: 180
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: 2
+        scaleY: 1.5
+        revealEffect: none
+        content:
+          - text: "LEFT  →  RIGHT\nTOP  /  bottom"
+            textStyle:
+              fontFamily: Arial
+              fontSize: 24
+              lineHeight: 1.2
+              fill: "#FFFFFF"
+      - id: negative-x
+        type: text-revealing
+        x: 970
+        "y": 205
+        width: 180
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -2
+        scaleY: 1.5
+        revealEffect: none
+        content:
+          - text: "LEFT  →  RIGHT\nTOP  /  bottom"
+            textStyle:
+              fontFamily: Arial
+              fontSize: 24
+              lineHeight: 1.2
+              fill: "#FFFFFF"
+      - id: negative-y
+        type: text-revealing
+        x: 310
+        "y": 515
+        width: 180
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: 1.5
+        scaleY: -1.5
+        revealEffect: none
+        content:
+          - text: "LEFT  →  RIGHT\nTOP  /  bottom"
+            textStyle:
+              fontFamily: Arial
+              fontSize: 24
+              lineHeight: 1.2
+              fill: "#FFFFFF"
+      - id: negative-both
+        type: text-revealing
+        x: 970
+        "y": 515
+        width: 180
+        anchorX: 0.5
+        anchorY: 0.5
+        scaleX: -1.5
+        scaleY: -1.5
+        revealEffect: none
+        content:
+          - text: "LEFT  →  RIGHT\nTOP  /  bottom"
+            textStyle:
+              fontFamily: Arial
+              fontSize: 24
+              lineHeight: 1.2
+              fill: "#FFFFFF"
+      - id: top-left-anchor
+        type: rect
+        x: 310
+        "y": 205
+        width: 8
+        height: 8
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#737373"
+      - id: top-right-anchor
+        type: rect
+        x: 970
+        "y": 205
+        width: 8
+        height: 8
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#737373"
+      - id: bottom-left-anchor
+        type: rect
+        x: 310
+        "y": 515
+        width: 8
+        height: 8
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#737373"
+      - id: bottom-right-anchor
+        type: rect
+        x: 970
+        "y": 515
+        width: 8
+        height: 8
+        anchorX: 0.5
+        anchorY: 0.5
+        fill: "#737373"


### PR DESCRIPTION
## Summary

- support signed scaleX and scaleY values across Route Graphics elements
- preserve anchor/origin behavior while mirroring rendered content and composing nested container signs
- keep particle scaling live while baking scale magnitude into regular element geometry
- allow zero scale to collapse an axis and reject non-finite scale values
- document signed scales in public types and element schemas
- add broad unit, integration, and visual regression coverage

## Verification

- 1,594 unit/integration tests passed across 118 files
- 865 visual screenshots matched across 243 VT scenarios
- 7 new negative-scale references matched with 0 differences
- build passed
- lint/formatting passed
- git diff --check passed