### PR TITLE
feat(animations): support keyframe start values

### DIFF
--- a/docs/animation-implementation-plan.md
+++ b/docs/animation-implementation-plan.md
@@ -1,6 +1,6 @@
 # Animation Implementation Plan
 
-Last updated: 2026-07-31
+Last updated: 2026-08-06
 
 ## Purpose
 
@@ -99,6 +99,22 @@ See `docs/shader-interface.md` for the full contract.
 
 These are animation-lifecycle improvements, not missing shader-effect
 capabilities.
+
+### Implement Keyframe Start Values
+
+Status: accepted design; not implemented.
+
+Add optional keyframe-level `startValue` support across the compact visual,
+shader-parameter, and audio keyframe interfaces. Preserve the preceding value
+during `delay`, apply `startValue` when the interpolation duration begins, and
+resolve relative frames sequentially from the preceding endpoint through the
+explicit start to the endpoint.
+
+The schemas, normalizers, compilers, evaluators, public types, hosted docs, and
+conformance tests must ship together so no interface accepts the field with
+partial behavior. See `docs/keyframe-start-value-design.md` for the normative
+formulas, boundary rules, compatibility constraints, and implementation
+coverage.
 
 ### Tighten Update Lifecycle Semantics
 

--- a/docs/animation-implementation-plan.md
+++ b/docs/animation-implementation-plan.md
@@ -100,18 +100,18 @@ See `docs/shader-interface.md` for the full contract.
 These are animation-lifecycle improvements, not missing shader-effect
 capabilities.
 
-### Implement Keyframe Start Values
+### Keyframe Start Values
 
-Status: accepted design; not implemented.
+Status: implemented.
 
-Add optional keyframe-level `startValue` support across the compact visual,
-shader-parameter, and audio keyframe interfaces. Preserve the preceding value
-during `delay`, apply `startValue` when the interpolation duration begins, and
-resolve relative frames sequentially from the preceding endpoint through the
-explicit start to the endpoint.
+Optional keyframe-level `startValue` is supported across the compact visual,
+shader-parameter, and audio keyframe interfaces. The runtime preserves the
+preceding value during `delay`, applies `startValue` when the interpolation
+duration begins, and resolves relative frames sequentially from the preceding
+endpoint through the explicit start to the endpoint.
 
 The schemas, normalizers, compilers, evaluators, public types, hosted docs, and
-conformance tests must ship together so no interface accepts the field with
+conformance tests shipped together so no interface accepts the field with
 partial behavior. See `docs/keyframe-start-value-design.md` for the normative
 formulas, boundary rules, compatibility constraints, and implementation
 coverage.

--- a/docs/animation-model.md
+++ b/docs/animation-model.md
@@ -185,11 +185,6 @@ The missing side is treated as transparent.
 
 ## Tween Payload
 
-> **Accepted future extension:** `docs/keyframe-start-value-design.md` defines
-> optional keyframe-level `startValue` semantics for an explicit segment start.
-> It is not implemented; the current schema and runtime continue to accept only
-> the endpoint-style keyframes described below.
-
 The existing keyframe format stays the standard:
 
 ```yaml
@@ -200,6 +195,7 @@ x:
       value: 180
       easing: "easeOutQuad"
     - delay: 300
+      startValue: 200
       duration: 150
       value: 220
       easing: "easeInQuad"
@@ -225,6 +221,16 @@ current live value; a later delay creates a gap between segments. Total track
 duration is the sum of every `delay + duration`. Delays scale with
 `playback.speed` and repeat with the rest of a loop. Omitting `delay`, or
 setting it to `0`, starts the segment immediately.
+
+Each manual keyframe may also define `startValue`. The preceding endpoint is
+still held throughout `delay`; at the end of that delay the value jumps to
+`startValue` and interpolation begins from there. For an absolute keyframe,
+the segment runs from `startValue` to `value`. With `relative: true`, both are
+sequential deltas: the start is the preceding endpoint plus `startValue`, and
+the endpoint is that resolved start plus `value`. Omitting `startValue`
+preserves normal endpoint chaining. See
+[`keyframe-start-value-design.md`](./keyframe-start-value-design.md) for exact
+boundary, zero-duration, repeat, and reverse semantics.
 
 The same payload is reused in two places:
 

--- a/docs/animation-model.md
+++ b/docs/animation-model.md
@@ -1,11 +1,12 @@
 # Animation Model
 
-Last updated: 2026-08-01
+Last updated: 2026-08-06
 
 See also:
 
 - `docs/animation-type-semantics.md`
 - `docs/animation-implementation-plan.md`
+- `docs/keyframe-start-value-design.md`
 - `docs/portable-gsap-timelines.md`
 - `docs/shader-interface.md`
 
@@ -183,6 +184,11 @@ Use it for:
 The missing side is treated as transparent.
 
 ## Tween Payload
+
+> **Accepted future extension:** `docs/keyframe-start-value-design.md` defines
+> optional keyframe-level `startValue` semantics for an explicit segment start.
+> It is not implemented; the current schema and runtime continue to accept only
+> the endpoint-style keyframes described below.
 
 The existing keyframe format stays the standard:
 

--- a/docs/audio-effects.md
+++ b/docs/audio-effects.md
@@ -2,14 +2,13 @@
 
 Last updated: 2026-08-06
 
-> **Design proposal:** [`Inline Audio Transition Interface`](./inline-audio-transitions.md)
-> defines a proposed inline replacement for separately authored
-> `audio-transition` records. It is not implemented. The interface documented
-> below remains the current runtime contract.
+[`Inline Audio Transition Interface`](./inline-audio-transitions.md) defines
+the canonical co-located interface. The separately authored
+`audio-transition` records documented below remain supported for compatibility.
 
-> **Accepted future extension:** [`Keyframe Start Value Design`](./keyframe-start-value-design.md)
-> defines optional keyframe-level `startValue` semantics for both canonical
-> inline transitions and the legacy interface below. It is not implemented.
+Both canonical inline transitions and the legacy interface below support the
+optional keyframe-level `startValue` semantics defined in
+[`Keyframe Start Value Design`](./keyframe-start-value-design.md).
 
 This document defines the channel-based audio interface for Route Graphics
 render state.
@@ -338,18 +337,21 @@ Phase fields:
 
 Keyframe fields:
 
-| Field      | Type    | Default  | Description                                              |
-| ---------- | ------- | -------- | -------------------------------------------------------- |
-| `value`    | number  | required | Absolute target, or a delta when `relative` is `true`    |
-| `duration` | number  | required | Milliseconds to reach this keyframe from the prior value |
-| `easing`   | string  | `linear` | Animation easing applied to the segment reaching it      |
-| `relative` | boolean | `false`  | Resolve `value` relative to the prior keyframe value     |
+| Field        | Type    | Default  | Description                                               |
+| ------------ | ------- | -------- | --------------------------------------------------------- |
+| `value`      | number  | required | Absolute target, or delta from the resolved segment start |
+| `startValue` | number  | previous | Explicit segment start, or delta when relative            |
+| `duration`   | number  | required | Milliseconds to reach the endpoint                        |
+| `delay`      | number  | `0`      | Milliseconds to hold the preceding endpoint               |
+| `easing`     | string  | `linear` | Animation easing applied to the segment                   |
+| `relative`   | boolean | `false`  | Resolve start and endpoint sequentially as deltas         |
 
 The first keyframe starts at `initialValue` when provided; otherwise it starts
-at the current audible value. Each later keyframe starts where the previous one
-ended. When a relative keyframe exceeds a property's range, its clamped audible
-endpoint is the baseline for the next relative keyframe. Total phase duration
-is the sum of its keyframe durations.
+at the current audible value. A keyframe with `startValue` holds the preceding
+endpoint during `delay`, then jumps to its resolved start before ramping. For a
+relative keyframe, the start is resolved and clamped before `value` is added;
+the clamped endpoint is the baseline for the next keyframe. Total phase
+duration is the sum of every `delay + duration`.
 
 Audio keyframes support the same easing names as visual animation keyframes.
 Resolved volume, pan, and playback-rate values are constrained to their valid

--- a/docs/audio-effects.md
+++ b/docs/audio-effects.md
@@ -1,11 +1,15 @@
 # Audio Channel Design
 
-Last updated: 2026-07-15
+Last updated: 2026-08-06
 
 > **Design proposal:** [`Inline Audio Transition Interface`](./inline-audio-transitions.md)
 > defines a proposed inline replacement for separately authored
 > `audio-transition` records. It is not implemented. The interface documented
 > below remains the current runtime contract.
+
+> **Accepted future extension:** [`Keyframe Start Value Design`](./keyframe-start-value-design.md)
+> defines optional keyframe-level `startValue` semantics for both canonical
+> inline transitions and the legacy interface below. It is not implemented.
 
 This document defines the channel-based audio interface for Route Graphics
 render state.

--- a/docs/inline-audio-transitions.md
+++ b/docs/inline-audio-transitions.md
@@ -11,10 +11,8 @@ This document defines the canonical inline transition interface on `sound` and
 accepted as a legacy compatibility interface documented in
 [`audio-effects.md`](./audio-effects.md).
 
-> **Accepted future extension:** [`Keyframe Start Value Design`](./keyframe-start-value-design.md)
-> defines optional keyframe-level `startValue` semantics shared with compact
-> visual tweens. It is not implemented; the current audio schema and runtime
-> continue to accept only the endpoint-style keyframes described below.
+Keyframes share the optional `startValue` segment-start semantics defined in
+[`Keyframe Start Value Design`](./keyframe-start-value-design.md).
 
 ## Goals
 
@@ -100,6 +98,7 @@ type InlineAudioTransitionTrack = {
 
 type InlineAudioTransitionKeyframe = {
   value: number;
+  startValue?: number;
   duration: number; // milliseconds
   delay?: number; // milliseconds; defaults to 0
   easing?: string; // defaults to linear
@@ -190,19 +189,20 @@ current audible value.
 
 ### Keyframe
 
-| Field      | Type    | Required | Default  | Description                                      |
-| ---------- | ------- | -------- | -------- | ------------------------------------------------ |
-| `value`    | number  | yes      | none     | Absolute endpoint, or delta when relative        |
-| `duration` | number  | yes      | none     | Ramp duration in milliseconds                    |
-| `delay`    | number  | no       | `0`      | Hold preceding value before this ramp            |
-| `easing`   | string  | no       | `linear` | Easing for the segment reaching this keyframe    |
-| `relative` | boolean | no       | `false`  | Resolve value relative to the preceding endpoint |
+| Field        | Type    | Required | Default  | Description                                         |
+| ------------ | ------- | -------- | -------- | --------------------------------------------------- |
+| `value`      | number  | yes      | none     | Absolute endpoint, or delta from the resolved start |
+| `startValue` | number  | no       | previous | Explicit segment start, or delta when relative      |
+| `duration`   | number  | yes      | none     | Ramp duration in milliseconds                       |
+| `delay`      | number  | no       | `0`      | Hold preceding value before this ramp               |
+| `easing`     | string  | no       | `linear` | Easing for the segment reaching this keyframe       |
+| `relative`   | boolean | no       | `false`  | Resolve start and endpoint sequentially as deltas   |
 
-`duration` and `delay` must be finite non-negative numbers, and `value` must be
-finite. Absolute values use the same ranges as their target fields. A relative
-value is a signed delta and is not itself restricted to the target field's
-range. Its resolved endpoint is clamped to that range before becoming the
-baseline for the following keyframe.
+`duration` and `delay` must be finite non-negative numbers, and `value` and any
+`startValue` must be finite. Absolute values use the same ranges as their
+target fields. Relative values are signed deltas. A relative start is resolved
+and clamped first; that audible start is then the base for the endpoint delta.
+The resolved endpoint becomes the baseline for the following keyframe.
 
 For `enter` and `update`, the last keyframe must be absolute and equal the value
 declared on the next audio node. This keeps the final audible value consistent
@@ -235,6 +235,11 @@ sum(keyframe.delay + keyframe.duration)
 
 Repeated keyframe delays allow holds between later ramp segments without a
 second step or offset vocabulary.
+
+When `startValue` is present, the preceding endpoint remains audible for the
+whole delay. The parameter jumps to the resolved start at the delay boundary
+and ramps from there. For a zero-duration keyframe, terminal `value` wins at
+that shared boundary.
 
 `sound.startDelayMs` remains separate: it delays when the source begins
 playback. `transition.*.*.keyframes[].delay` delays one automation segment

--- a/docs/inline-audio-transitions.md
+++ b/docs/inline-audio-transitions.md
@@ -2,7 +2,7 @@
 
 Status: implemented
 
-Last updated: 2026-08-02
+Last updated: 2026-08-06
 
 ## Purpose
 
@@ -10,6 +10,11 @@ This document defines the canonical inline transition interface on `sound` and
 `audio-channel` nodes. Separately authored `audio-transition` records remain
 accepted as a legacy compatibility interface documented in
 [`audio-effects.md`](./audio-effects.md).
+
+> **Accepted future extension:** [`Keyframe Start Value Design`](./keyframe-start-value-design.md)
+> defines optional keyframe-level `startValue` semantics shared with compact
+> visual tweens. It is not implemented; the current audio schema and runtime
+> continue to accept only the endpoint-style keyframes described below.
 
 ## Goals
 

--- a/docs/keyframe-start-value-design.md
+++ b/docs/keyframe-start-value-design.md
@@ -1,6 +1,6 @@
 # Keyframe Start Value Design
 
-Status: accepted design; not implemented
+Status: implemented
 
 Last updated: 2026-08-06
 
@@ -191,20 +191,21 @@ The portable `gsap` frontend does not add `startValue` to its multi-property
 `keyframes` frames. It already expresses this operation explicitly through a
 `fromTo` action or a `set` followed by `to`.
 
-## Implementation Requirements
+## Implementation Coverage
 
-Shipping this field requires one coordinated change across the public
-interfaces that use endpoint-style keyframes:
+The field ships as one coordinated change across the public interfaces that
+use endpoint-style keyframes:
 
-- add `startValue` to the visual animation, shader, and audio schemas with the
+- `startValue` is present in the visual animation, shader, and audio schemas with the
   same type and absolute-value range rules as `value`
-- validate and normalize `startValue` without changing omitted-field output
-- compile each segment from resolved `S` to resolved `E`
-- preserve delay holds and exact boundary ownership
-- apply relative scalar and vector addition in the order specified above
-- update public JSDoc types and hosted interface documentation
-- add conformance coverage for absolute, relative, delayed, vector, clamped,
+- runtime normalizers validate and preserve it without changing omitted-field output
+- compilers build each segment from resolved `S` to resolved `E`
+- delay holds and exact boundary ownership are preserved
+- relative scalar and vector addition follows the order specified above
+- public JSDoc types and hosted interface documentation expose it
+- conformance coverage includes absolute, relative, delayed, vector, clamped,
   zero-duration, repeated, yoyo, and interrupted segments
 
-Until those changes land together, schemas and runtimes must continue to reject
-`startValue` rather than accepting it with partial behavior.
+The schemas, runtime normalizers, visual and transition compilers, Web Audio
+automation scheduler, public types, documentation, and conformance tests all
+recognize the field together.

--- a/docs/keyframe-start-value-design.md
+++ b/docs/keyframe-start-value-design.md
@@ -1,0 +1,210 @@
+# Keyframe Start Value Design
+
+Status: accepted design; not implemented
+
+Last updated: 2026-08-06
+
+Related documents:
+
+- `docs/animation-model.md`
+- `docs/animation-implementation-plan.md`
+- `docs/inline-audio-transitions.md`
+- `docs/portable-gsap-timelines.md`
+
+## Decision
+
+Manual keyframes gain an optional `startValue` field. It explicitly sets the
+value at which that keyframe's interpolation segment begins.
+
+```yaml
+x:
+  initialValue: 10
+  keyframes:
+    - duration: 400
+      value: 100
+    - delay: 200
+      startValue: 0
+      duration: 300
+      value: 50
+```
+
+This track:
+
+1. interpolates from `10` to `100` over `400` milliseconds
+2. holds `100` for `200` milliseconds
+3. jumps to `0` when the second segment begins
+4. interpolates from `0` to `50` over `300` milliseconds
+
+The field is named `startValue`, not `initialValue`, `from`, or `fromValue`:
+
+- track-level `initialValue` remains the value before the entire track
+- keyframe-level `startValue` is the value at the start of one segment
+- keyframe-level `value` remains the value at the end of that segment
+- `from` and `fromValue` do not make the track-versus-segment scope as explicit
+
+`startValue` is optional. Omitting it preserves the current chained-keyframe
+behavior exactly.
+
+## Motivation
+
+Today, every keyframe describes an endpoint. A segment begins at the previous
+endpoint and reaches `value` over `duration`. An author who needs a deliberate
+jump immediately before an interpolation must insert a zero-duration
+keyframe:
+
+```yaml
+keyframes:
+  - value: 100
+    duration: 400
+  - value: 0
+    duration: 0
+  - value: 50
+    duration: 300
+```
+
+Zero-duration keyframes remain useful as explicit set operations, but they are
+awkward when the set exists only to establish the next segment's starting
+value. `startValue` expresses that segment as one authored unit.
+
+## Timing Semantics
+
+Each keyframe still occupies:
+
+```text
+delay + duration
+```
+
+For a keyframe beginning at cursor time `T`:
+
+1. The value preceding the keyframe is held from `T` through its `delay`.
+2. `startValue`, when present, takes effect at `T + delay`.
+3. Interpolation begins at that same time and runs for `duration`.
+4. The keyframe reaches `value` at `T + delay + duration`.
+
+Therefore, `startValue` does not change the value held during `delay`:
+
+```yaml
+- delay: 500
+  startValue: 20
+  value: 80
+  duration: 300
+```
+
+If the preceding endpoint is `100`, the runtime holds `100` for `500`
+milliseconds, jumps to `20`, and then interpolates to `80`.
+
+At an exact boundary, the segment beginning at that boundary owns the sampled
+value. This makes the `startValue` jump observable when `duration` is positive.
+If `duration` is zero, terminal `value` wins at the shared start/end boundary;
+`startValue` has no observable duration.
+
+## Absolute Resolution
+
+Let:
+
+- `B` be the resolved value held immediately before the segment
+- `S` be the resolved interpolation start
+- `E` be the resolved interpolation endpoint
+
+For an absolute keyframe (`relative` omitted or `false`):
+
+```text
+S = startValue, when provided; otherwise B
+E = value
+```
+
+The easing function interpolates from `S` to `E`.
+
+The first keyframe uses the track's `initialValue` as `B` when one is provided.
+Otherwise, `B` is captured from the current renderer-owned value according to
+the existing track semantics.
+
+## Relative Resolution
+
+`startValue` also supports `relative: true`. Relative operations resolve in
+sequence so that `value` remains the delta traversed during the segment:
+
+```text
+S = B + startValue, when startValue is provided; otherwise B
+E = S + value
+```
+
+For example:
+
+```yaml
+- delay: 200
+  startValue: -20
+  value: 50
+  relative: true
+  duration: 300
+```
+
+If `B` is `100`, the runtime holds `100` during the delay, jumps to `80`, and
+interpolates to `130`. The following keyframe uses `130` as its preceding
+endpoint.
+
+Addition is ordinary numeric addition for scalar values and component-wise
+addition for compatible numeric vectors. The existing shape-validation rules
+continue to apply. Types that do not currently support relative keyframes,
+such as colors, do not gain relative support through `startValue`.
+
+An absolute `startValue` follows the same authored range rules as an absolute
+`value`. With `relative: true`, `startValue` is a signed delta and is resolved
+before range constraints are applied, just like a relative endpoint delta.
+
+When a channel constrains resolved values, it applies its existing constraint
+rules to `S` before using `S` as the base for the endpoint delta, and then to
+`E`. This is especially important for audio properties: the audible, clamped
+start becomes the base for the relative movement that follows.
+
+## Chaining And Playback
+
+The resolved endpoint `E` becomes `B` for the following keyframe. The optional
+start value does not become the chain baseline after its segment has finished.
+
+Repeats reapply the same start-value discontinuity on every iteration. During
+yoyo or reverse evaluation, the segment interpolates from `E` back to `S`; when
+evaluation crosses into the preceding segment, the preceding segment resumes
+ownership. If `S` differs from the preceding endpoint `B`, that boundary is
+intentionally discontinuous in both directions.
+
+An interruption during a keyframe's delay observes the held preceding value,
+because `startValue` has not taken effect yet. An interruption during its
+duration observes the interpolated value under the existing continuity rules.
+
+## Compatibility
+
+This is an additive authoring change:
+
+- existing keyframes without `startValue` retain their current output
+- `value`, `duration`, `delay`, `easing`, and `relative` retain their meanings
+- track-level `initialValue` retains its current meaning
+- zero-duration keyframes remain valid explicit set operations
+- total track duration remains the sum of every `delay + duration`
+
+`startValue` applies to compact manual keyframe interfaces that already expose
+the endpoint-style `value` field, including numeric visual tweens, shader
+parameters, and audio property automation. Absolute color start values may use
+the field, but color keyframes remain non-relative.
+
+The portable `gsap` frontend does not add `startValue` to its multi-property
+`keyframes` frames. It already expresses this operation explicitly through a
+`fromTo` action or a `set` followed by `to`.
+
+## Implementation Requirements
+
+Shipping this field requires one coordinated change across the public
+interfaces that use endpoint-style keyframes:
+
+- add `startValue` to the visual animation, shader, and audio schemas with the
+  same type and absolute-value range rules as `value`
+- validate and normalize `startValue` without changing omitted-field output
+- compile each segment from resolved `S` to resolved `E`
+- preserve delay holds and exact boundary ownership
+- apply relative scalar and vector addition in the order specified above
+- update public JSDoc types and hosted interface documentation
+- add conformance coverage for absolute, relative, delayed, vector, clamped,
+  zero-duration, repeated, yoyo, and interrupted segments
+
+Until those changes land together, schemas and runtimes must continue to reject
+`startValue` rather than accepting it with partial behavior.

--- a/docs/shader-interface.md
+++ b/docs/shader-interface.md
@@ -319,6 +319,12 @@ finite, non-negative `delay` holds the preceding scalar, vector, or matrix
 value before interpolation. It contributes to total duration and repeats in a
 loop.
 
+An optional `startValue` supplies an explicit scalar, vector, or matrix value
+at which a segment begins after its delay. With `relative: true`, it is added
+component by component to the preceding endpoint, then `value` is added to
+that resolved start. `startValue` and `value` must both match the targeted
+parameter's shape.
+
 Only one active animation may write the same
 `targetId + filterId + parameter` channel in one state.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.39.1",
+  "version": "1.41.0",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/audio/audioStage.spec.js
+++ b/spec/audio/audioStage.spec.js
@@ -1027,6 +1027,179 @@ describe("AudioStage graph rendering", () => {
     expect(gain.linearRampToValueAtTime.mock.calls.length).toBeGreaterThan(2);
   });
 
+  it("holds through delay, jumps to startValue, and ramps to the endpoint", async () => {
+    const { stage } = await setupAudioStage();
+
+    stage.renderGraph({
+      nextAudio: [
+        {
+          id: "bgm",
+          type: "sound",
+          src: "theme",
+          volume: 50,
+        },
+      ],
+      nextAudioEffects: [
+        {
+          id: "bgm-enter",
+          type: "audio-transition",
+          targetId: "bgm",
+          properties: {
+            volume: {
+              enter: {
+                initialValue: 100,
+                keyframes: [
+                  {
+                    delay: 200,
+                    startValue: 20,
+                    value: 50,
+                    duration: 300,
+                    easing: "linear",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const gain = findCurrentSound(stage, "bgm").gainNode.gain;
+    expect(gain.linearRampToValueAtTime).toHaveBeenNthCalledWith(1, 1, 10.2);
+    expect(gain.setValueAtTime).toHaveBeenCalledWith(0.2, 10.2);
+    expect(gain.linearRampToValueAtTime).toHaveBeenNthCalledWith(2, 0.5, 10.5);
+  });
+
+  it("clamps a relative start before resolving its relative endpoint", async () => {
+    const { stage } = await setupAudioStage();
+
+    stage.renderGraph({
+      nextAudio: [{ id: "bgm", type: "sound", src: "theme", pan: 0.8 }],
+      nextAudioEffects: [
+        {
+          id: "bgm-enter",
+          type: "audio-transition",
+          targetId: "bgm",
+          properties: {
+            pan: {
+              enter: {
+                initialValue: 0.8,
+                keyframes: [
+                  {
+                    startValue: 0.5,
+                    value: -0.2,
+                    relative: true,
+                    duration: 100,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const pan = findCurrentSound(stage, "bgm").pannerNode.pan;
+    expect(pan.setValueAtTime).toHaveBeenCalledWith(1, 10);
+    expect(pan.linearRampToValueAtTime).toHaveBeenCalledWith(0.8, 10.1);
+  });
+
+  it("tracks the held value before startValue and the ramp after it", async () => {
+    const { stage, context } = await setupAudioStage({
+      contextOptions: {
+        reflectScheduledAudioParamValue: false,
+        supportCancelAndHold: false,
+      },
+    });
+    const initialAudio = [{ id: "bgm", type: "sound", src: "theme", pan: 1 }];
+
+    stage.renderGraph({
+      nextAudio: initialAudio,
+      nextAudioEffects: [
+        {
+          id: "bgm-enter",
+          type: "audio-transition",
+          targetId: "bgm",
+          properties: {
+            pan: {
+              enter: {
+                initialValue: -1,
+                keyframes: [
+                  {
+                    delay: 500,
+                    startValue: 0.5,
+                    value: 1,
+                    duration: 500,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    context.currentTime = 10.25;
+    stage.renderGraph({
+      prevAudio: initialAudio,
+      nextAudio: [{ id: "bgm", type: "sound", src: "theme", pan: 0 }],
+      nextAudioEffects: [
+        {
+          id: "bgm-update",
+          type: "audio-transition",
+          targetId: "bgm",
+          properties: {
+            pan: { update: keyframePhase(0, 100) },
+          },
+        },
+      ],
+    });
+    let pan = findCurrentSound(stage, "bgm").pannerNode.pan;
+    expect(pan.setValueAtTime).toHaveBeenLastCalledWith(-1, 10.25);
+
+    stage.renderGraph({
+      prevAudio: [{ id: "bgm", type: "sound", src: "theme", pan: 0 }],
+      nextAudio: [{ id: "bgm", type: "sound", src: "theme", pan: 1 }],
+      nextAudioEffects: [
+        {
+          id: "bgm-enter-again",
+          type: "audio-transition",
+          targetId: "bgm",
+          properties: {
+            pan: {
+              update: {
+                initialValue: -1,
+                keyframes: [
+                  {
+                    delay: 500,
+                    startValue: 0.5,
+                    value: 1,
+                    duration: 500,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+    });
+    context.currentTime = 11;
+    stage.renderGraph({
+      prevAudio: [{ id: "bgm", type: "sound", src: "theme", pan: 1 }],
+      nextAudio: [{ id: "bgm", type: "sound", src: "theme", pan: 0 }],
+      nextAudioEffects: [
+        {
+          id: "bgm-update-after-start",
+          type: "audio-transition",
+          targetId: "bgm",
+          properties: { pan: { update: keyframePhase(0, 100) } },
+        },
+      ],
+    });
+    pan = findCurrentSound(stage, "bgm").pannerNode.pan;
+    expect(pan.setValueAtTime).toHaveBeenLastCalledWith(0.75, 11);
+  });
+
   it("accumulates relative keyframes from clamped audible endpoints", async () => {
     const { stage } = await setupAudioStage();
 

--- a/spec/audio/normalizeAudio.spec.js
+++ b/spec/audio/normalizeAudio.spec.js
@@ -82,7 +82,13 @@ describe("inline audio transition normalization", () => {
             volume: {
               initialValue: 0,
               keyframes: [
-                { value: 120, duration: 25, relative: true, delay: 10 },
+                {
+                  startValue: -20,
+                  value: 120,
+                  duration: 25,
+                  relative: true,
+                  delay: 10,
+                },
                 { value: 80, duration: 25 },
               ],
             },
@@ -230,6 +236,11 @@ describe("inline audio transition normalization", () => {
       "an out-of-range absolute volume",
       { enter: { volume: track(101) } },
       "must be less than or equal to 100",
+    ],
+    [
+      "an out-of-range absolute volume start",
+      { enter: { volume: track(80, { startValue: 101 }) } },
+      "startValue must be less than or equal to 100",
     ],
     [
       "a relative final enter keyframe",

--- a/src/AudioStage.js
+++ b/src/AudioStage.js
@@ -211,6 +211,20 @@ const buildAudioTimeline = ({
         easing: "linear",
       });
     }
+
+    if (keyframe.startValue !== undefined) {
+      const startAuthoredValue = keyframe.relative
+        ? authoredValue + keyframe.startValue
+        : keyframe.startValue;
+      const startValue = normalizeTransitionValue(startAuthoredValue);
+      authoredValue = denormalizeParamValue(startValue);
+      timeline.push({
+        time: elapsedMs,
+        value: startValue,
+        easing: "linear",
+      });
+    }
+
     elapsedMs += Math.max(0, toFiniteParamValue(keyframe.duration, 0));
     const nextAuthoredValue = keyframe.relative
       ? authoredValue + keyframe.value

--- a/src/plugins/animations/replace/runReplaceAnimation.js
+++ b/src/plugins/animations/replace/runReplaceAnimation.js
@@ -1843,7 +1843,10 @@ const createCompositorOverlay = ({
       }
       const parameterValues = [
         ...(config.initialValue === undefined ? [] : [config.initialValue]),
-        ...config.keyframes.map((keyframe) => keyframe.value),
+        ...config.keyframes.flatMap((keyframe) => [
+          ...(keyframe.startValue === undefined ? [] : [keyframe.startValue]),
+          keyframe.value,
+        ]),
       ];
       for (const value of parameterValues) {
         validateShaderEffectParameterValue(compositorEffect, parameter, value);

--- a/src/plugins/animations/timeline/compileLegacyTransition.js
+++ b/src/plugins/animations/timeline/compileLegacyTransition.js
@@ -3,6 +3,24 @@ import { compilePortableGsapAnimation } from "./compilePortableGsap.js";
 const toPortableFrameValue = (frame) =>
   frame.relative ? { by: frame.value } : frame.value;
 
+const toPortableFrameStartValue = (frame) =>
+  frame.relative ? { by: frame.startValue } : frame.startValue;
+
+const toPortableFrameStep = (target, property, frame) => ({
+  kind: frame.startValue === undefined ? "to" : "fromTo",
+  targets: target,
+  overwrite: "none",
+  ...(frame.startValue === undefined
+    ? { values: { [property]: toPortableFrameValue(frame) } }
+    : {
+        from: { [property]: toPortableFrameStartValue(frame) },
+        to: { [property]: toPortableFrameValue(frame) },
+      }),
+  duration: frame.duration,
+  ...(frame.delay === undefined ? {} : { delay: frame.delay }),
+  ...(frame.easing === undefined ? {} : { easing: frame.easing }),
+});
+
 const addInitialTrackDelay = (config, delay = 0) => {
   if (delay === 0) return config;
 
@@ -25,17 +43,26 @@ const addLegacyTrack = (steps, { target, property, config }) => {
     });
   }
   if (config.keyframes.length > 0) {
-    children.push({
-      kind: "keyframes",
-      targets: target,
-      overwrite: "none",
-      frames: config.keyframes.map((frame) => ({
-        values: { [property]: toPortableFrameValue(frame) },
-        duration: frame.duration,
-        ...(frame.delay === undefined ? {} : { delay: frame.delay }),
-        ...(frame.easing === undefined ? {} : { easing: frame.easing }),
-      })),
-    });
+    if (config.keyframes.some((frame) => frame.startValue !== undefined)) {
+      children.push({
+        kind: "sequence",
+        steps: config.keyframes.map((frame) =>
+          toPortableFrameStep(target, property, frame),
+        ),
+      });
+    } else {
+      children.push({
+        kind: "keyframes",
+        targets: target,
+        overwrite: "none",
+        frames: config.keyframes.map((frame) => ({
+          values: { [property]: toPortableFrameValue(frame) },
+          duration: frame.duration,
+          ...(frame.delay === undefined ? {} : { delay: frame.delay }),
+          ...(frame.easing === undefined ? {} : { easing: frame.easing }),
+        })),
+      });
+    }
   }
   if (children.length === 1) steps.push(children[0]);
   else if (children.length > 1)

--- a/src/plugins/animations/timeline/compileLegacyTransition.test.js
+++ b/src/plugins/animations/timeline/compileLegacyTransition.test.js
@@ -15,7 +15,12 @@ const bindVirtualTransition = (program) => {
       { values: { "transition.mask.progress": 0 } },
       { values: { "transition.mask.progress": 0 } },
     ],
-    compositor: { values: { "transition.compositor.progress": 0 } },
+    compositor: {
+      values: {
+        "transition.compositor.progress": 0,
+        "transition.compositor.parameter.tint": [0.1, 0.2, 0.3],
+      },
+    },
   };
   return bindTimelineProgram(program, {
     capabilities: new Set(program.requirements),
@@ -221,5 +226,80 @@ describe("legacy transition compiler", () => {
     expect(sample(300)).toBeCloseTo(0.5);
     expect(animation.mask[0].progress.keyframes[0].delay).toBe(50);
     evaluator.destroy();
+  });
+
+  it("honors explicit starts in transition surfaces and shader parameters", () => {
+    const [animation] = normalizeAnimations([
+      {
+        id: "explicit-transition-starts",
+        targetId: "scene",
+        type: "transition",
+        prev: {
+          tween: {
+            x: {
+              initialValue: 100,
+              keyframes: [
+                {
+                  delay: 50,
+                  startValue: 20,
+                  value: 60,
+                  duration: 100,
+                  easing: "linear",
+                },
+              ],
+            },
+          },
+        },
+        compositor: {
+          type: "shader",
+          source: {
+            webgl: { fragment: "void main(){}" },
+            webgpu: {
+              source:
+                "@vertex fn mainVertex() -> @builtin(position) vec4<f32> { return vec4<f32>(); } @fragment fn mainFragment() -> @location(0) vec4<f32> { return vec4<f32>(); }",
+            },
+          },
+          parameters: { tint: [0.1, 0.2, 0.3] },
+          tween: {
+            progress: {
+              initialValue: 0,
+              keyframes: [{ value: 1, duration: 150 }],
+            },
+            tint: {
+              initialValue: [0.1, 0.2, 0.3],
+              keyframes: [
+                {
+                  startValue: [0.1, 0.1, 0.1],
+                  value: [0.2, 0.3, 0.4],
+                  relative: true,
+                  duration: 100,
+                  easing: "linear",
+                },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+    const program = compileLegacyTransitionAnimation(animation);
+    const instance = bindVirtualTransition(program);
+    const sample = (time, channel) =>
+      evaluateTimelineInstance(instance, time).values.find(
+        (entry) => entry.channel === channel,
+      )?.value;
+
+    expect(sample(49, "transform.x")).toBe(100);
+    expect(sample(50, "transform.x")).toBe(20);
+    expect(sample(100, "transform.x")).toBe(40);
+    expect(sample(150, "transform.x")).toBe(60);
+    const expectTint = (time, expected) => {
+      const actual = sample(time, "transition.compositor.parameter.tint");
+      expected.forEach((value, index) =>
+        expect(actual[index]).toBeCloseTo(value),
+      );
+    };
+    expectTint(0, [0.2, 0.3, 0.4]);
+    expectTint(50, [0.3, 0.45, 0.6]);
+    expectTint(100, [0.4, 0.6, 0.8]);
   });
 });

--- a/src/plugins/animations/timeline/compileLegacyTween.js
+++ b/src/plugins/animations/timeline/compileLegacyTween.js
@@ -38,6 +38,14 @@ const addRelativeValue = (property, expression) => ({
     : expression,
 });
 
+const resolveFrameStart = (property, frame, currentExpression) => {
+  if (frame.startValue === undefined) return currentExpression;
+  const authored = constant(frame.startValue);
+  return frame.relative
+    ? addRelativeValue(property, authored)
+    : toSubjectCoordinate(property, authored);
+};
+
 const toIterations = (playback = {}) => {
   if (playback.loop === true || playback.repeat === "infinite") return null;
   return (playback.repeat ?? 0) + 1;
@@ -167,6 +175,11 @@ export const compileLegacyTweenAnimation = (
           frame.delay ?? 0,
           `${propertyPath}.keyframes[${index}].delay`,
         );
+        const startExpression = resolveFrameStart(
+          property,
+          frame,
+          currentExpression,
+        );
         const authored = constant(frame.value);
         const nextExpression = frame.relative
           ? addRelativeValue(property, authored)
@@ -183,7 +196,7 @@ export const compileLegacyTweenAnimation = (
           duration: frame.duration,
           sampler: {
             kind: "interpolate",
-            from: currentExpression,
+            from: startExpression,
             to: nextExpression,
             easing: getEasingId(frame.easing),
           },

--- a/src/plugins/animations/timeline/compileLegacyTween.test.js
+++ b/src/plugins/animations/timeline/compileLegacyTween.test.js
@@ -45,6 +45,171 @@ describe("legacy tween TimelineProgram compiler", () => {
     expect(sample(200)).toBe(30);
   });
 
+  it("jumps to delayed absolute starts and resolves relative starts in order", () => {
+    const program = compile({
+      id: "segment-starts",
+      targetId: "hero",
+      type: "update",
+      tween: {
+        x: {
+          initialValue: 10,
+          keyframes: [
+            { value: 100, duration: 100, easing: "linear" },
+            {
+              startValue: -20,
+              value: 50,
+              relative: true,
+              delay: 50,
+              duration: 100,
+              easing: "linear",
+            },
+          ],
+        },
+      },
+    });
+    const target = { x: 0 };
+    const instance = bindTimelineProgram(program, {
+      capabilities: new Set(program.requirements),
+      targetRegistry: { hero: { handle: target, identity: "hero" } },
+      channelRegistry: {
+        "transform.x": {
+          get: (handle) => handle.x,
+          apply: (handle, value) => {
+            handle.x = value;
+          },
+        },
+      },
+    });
+    const sample = (time) =>
+      evaluateTimelineInstance(instance, time).values[0].value;
+
+    expect(sample(149)).toBe(100);
+    expect(sample(150)).toBe(80);
+    expect(sample(200)).toBe(105);
+    expect(sample(250)).toBe(130);
+  });
+
+  it("gives zero-duration endpoints ownership and reapplies starts on repeat/yoyo", () => {
+    const zero = compile({
+      id: "zero-start",
+      targetId: "hero",
+      type: "update",
+      tween: {
+        x: {
+          initialValue: 10,
+          keyframes: [{ startValue: 0, value: 50, duration: 0 }],
+        },
+      },
+    });
+    const repeated = compile({
+      id: "repeat-start",
+      targetId: "hero",
+      type: "update",
+      playback: { repeat: 1, yoyo: true },
+      tween: {
+        x: {
+          initialValue: 10,
+          keyframes: [
+            {
+              startValue: 20,
+              value: 80,
+              duration: 100,
+              easing: "linear",
+            },
+          ],
+        },
+      },
+    });
+    const forwardRepeated = compile({
+      id: "forward-repeat-start",
+      targetId: "hero",
+      type: "update",
+      playback: { repeat: 1 },
+      tween: {
+        x: {
+          initialValue: 10,
+          keyframes: [
+            {
+              startValue: 20,
+              value: 80,
+              duration: 100,
+              easing: "linear",
+            },
+          ],
+        },
+      },
+    });
+    const bind = (program) =>
+      bindTimelineProgram(program, {
+        capabilities: new Set(program.requirements),
+        targetRegistry: { hero: { handle: { x: 0 }, identity: "hero" } },
+        channelRegistry: {
+          "transform.x": {
+            get: (handle) => handle.x,
+            apply: (handle, value) => {
+              handle.x = value;
+            },
+          },
+        },
+      });
+    const sample = (instance, time) =>
+      evaluateTimelineInstance(instance, time).values[0].value;
+
+    expect(sample(bind(zero), 0)).toBe(50);
+    const repeatedInstance = bind(repeated);
+    expect(sample(repeatedInstance, 0)).toBe(20);
+    expect(sample(repeatedInstance, 50)).toBe(50);
+    expect(sample(repeatedInstance, 100)).toBe(80);
+    expect(sample(repeatedInstance, 150)).toBe(50);
+    expect(sample(repeatedInstance, 200)).toBe(20);
+    const forwardRepeatedInstance = bind(forwardRepeated);
+    expect(sample(forwardRepeatedInstance, 99)).toBeCloseTo(79.4);
+    expect(sample(forwardRepeatedInstance, 100)).toBe(20);
+  });
+
+  it("interpolates absolute color start values", () => {
+    const program = compile({
+      id: "color-start",
+      targetId: "hero",
+      type: "update",
+      tween: {
+        border: {
+          color: {
+            initialValue: "#00ff00",
+            keyframes: [
+              {
+                startValue: "#ff0000",
+                value: "#0000ff",
+                duration: 100,
+                easing: "linear",
+              },
+            ],
+          },
+        },
+      },
+    });
+    const target = { color: [0, 1, 0, 1] };
+    const instance = bindTimelineProgram(program, {
+      capabilities: new Set(program.requirements),
+      targetRegistry: { hero: { handle: target, identity: "hero" } },
+      channelRegistry: {
+        "geometry.rect.border.color": {
+          valueType: "colorSrgb",
+          get: (handle) => handle.color,
+          apply: (handle, value) => {
+            handle.color = value;
+          },
+        },
+      },
+    });
+    const sample = (time) =>
+      evaluateTimelineInstance(instance, time).values[0].value;
+
+    expect(sample(0)).toEqual([1, 0, 0, 1]);
+    expect(sample(50)).toEqual([0.5, 0, 0.5, 1]);
+    expect(sample(100)).toEqual([0, 0, 1, 1]);
+  });
+
   it("accumulates consecutive subject-relative keyframes from the live position", () => {
     const program = compile({
       id: "relative-translate-chain",

--- a/src/plugins/animations/tween/docs/README.md
+++ b/src/plugins/animations/tween/docs/README.md
@@ -43,6 +43,12 @@ from the previous value. The first authored keyframe controls the segment from
 the current value to that keyframe. `auto.easing` controls the single segment
 from the current value to the next state value.
 
+Manual keyframes may define `startValue` to jump to an explicit segment start
+after any `delay`, then interpolate to `value`. With `relative: true`,
+`startValue` is added to the preceding endpoint and `value` is then added to
+that resolved start. Omitting `startValue` preserves ordinary endpoint
+chaining.
+
 Use `update` only when the same target stays mounted before and after the
 change. Do not use it for first-enter or final-exit. Those are `transition`
 cases.

--- a/src/plugins/elements/util/shaderFilterEffect.js
+++ b/src/plugins/elements/util/shaderFilterEffect.js
@@ -793,7 +793,10 @@ export const validateShaderFilterAnimationTarget = (
   for (const [parameter, config] of Object.entries(tween ?? {})) {
     const values = [
       ...(config.initialValue === undefined ? [] : [config.initialValue]),
-      ...config.keyframes.map((keyframe) => keyframe.value),
+      ...config.keyframes.flatMap((keyframe) => [
+        ...(keyframe.startValue === undefined ? [] : [keyframe.startValue]),
+        keyframe.value,
+      ]),
     ];
 
     for (const value of values) {

--- a/src/plugins/elements/util/shaderFilterEffect.test.js
+++ b/src/plugins/elements/util/shaderFilterEffect.test.js
@@ -731,6 +731,18 @@ describe("shader filter resources", () => {
       validateShaderFilterAnimationTarget(
         displayObject,
         "grade",
+        "bad-start-shape",
+        {
+          amount: {
+            keyframes: [{ startValue: [1, 2], duration: 100, value: 1 }],
+          },
+        },
+      ),
+    ).toThrow(/parameter "amount" must be a finite number/);
+    expect(() =>
+      validateShaderFilterAnimationTarget(
+        displayObject,
+        "grade",
         "unknown-parameter",
         {
           missing: {

--- a/src/plugins/elements/util/shaderStateValidation.js
+++ b/src/plugins/elements/util/shaderStateValidation.js
@@ -5,7 +5,10 @@ import {
 
 const getTweenValues = (config) => [
   ...(config.initialValue === undefined ? [] : [config.initialValue]),
-  ...config.keyframes.map((keyframe) => keyframe.value),
+  ...config.keyframes.flatMap((keyframe) => [
+    ...(keyframe.startValue === undefined ? [] : [keyframe.startValue]),
+    keyframe.value,
+  ]),
 ];
 
 const isFiniteNumber = (value) =>

--- a/src/plugins/elements/util/shaderStateValidation.test.js
+++ b/src/plugins/elements/util/shaderStateValidation.test.js
@@ -289,6 +289,25 @@ describe("shader state validation", () => {
     ).toThrow(
       'Animation "bad-second-keyframe" parameter "amount" on shader filter "grade" on element "card" must be a finite number.',
     );
+
+    expect(() =>
+      validate([
+        {
+          id: "bad-start",
+          targetId: "card",
+          type: "update",
+          filterTweens: {
+            grade: {
+              amount: {
+                keyframes: [{ startValue: [1, 2], duration: 100, value: 1 }],
+              },
+            },
+          },
+        },
+      ]),
+    ).toThrow(
+      'Animation "bad-start" parameter "amount" on shader filter "grade" on element "card" must be a finite number.',
+    );
   });
 
   it.each([

--- a/src/schemas/animations/animation.yaml
+++ b/src/schemas/animations/animation.yaml
@@ -13,6 +13,9 @@ $defs:
       - value
       - duration
     properties:
+      startValue:
+        type: number
+        description: Optional explicit value at which this keyframe segment begins.
       value:
         type: number
         description: The target value for this keyframe.
@@ -77,6 +80,9 @@ $defs:
       - value
       - duration
     properties:
+      startValue:
+        type: string
+        description: Optional explicit color at which this keyframe segment begins.
       value:
         type: string
         description: Target color value.

--- a/src/schemas/audio/audio-transition.yaml
+++ b/src/schemas/audio/audio-transition.yaml
@@ -70,6 +70,9 @@ definitions:
       - value
       - duration
     properties:
+      startValue:
+        type: number
+        description: Absolute segment start, or delta from the preceding value when relative is true
       value:
         type: number
         description: Absolute target value, or delta when relative is true
@@ -97,6 +100,9 @@ definitions:
               const: false
         then:
           properties:
+            startValue:
+              minimum: 0
+              maximum: 100
             value:
               minimum: 0
               maximum: 100
@@ -109,6 +115,9 @@ definitions:
               const: false
         then:
           properties:
+            startValue:
+              minimum: -1
+              maximum: 1
             value:
               minimum: -1
               maximum: 1
@@ -121,6 +130,8 @@ definitions:
               const: false
         then:
           properties:
+            startValue:
+              minimum: 0
             value:
               minimum: 0
   volumePhase:

--- a/src/schemas/shader-config.yaml
+++ b/src/schemas/shader-config.yaml
@@ -135,6 +135,11 @@ definitions:
     required: [value, duration]
     additionalProperties: false
     properties:
+      startValue:
+        description: Optional explicit value at which this keyframe segment begins.
+        oneOf:
+          - type: number
+          - $ref: "#/definitions/numericArray"
       value:
         oneOf:
           - type: number
@@ -169,6 +174,8 @@ definitions:
     allOf:
       - $ref: "#/definitions/shaderTweenKeyframe"
       - properties:
+          startValue:
+            type: number
           value:
             type: number
   shaderProgressProperty:

--- a/src/types.js
+++ b/src/types.js
@@ -54,9 +54,19 @@
  */
 
 /**
+ * @typedef {Object} AnimationKeyframe
+ * @property {number | number[] | string} value - Segment endpoint, or delta when relative is true
+ * @property {number | number[] | string} [startValue] - Explicit segment start, absolute or a delta when relative is true
+ * @property {number} duration - Segment duration in milliseconds
+ * @property {number} [delay=0] - Time to hold the preceding endpoint before the segment
+ * @property {string} [easing="linear"] - Animation easing name
+ * @property {boolean} [relative=false] - Whether numeric start and endpoint values are relative
+ */
+
+/**
  * @typedef {Object} ShaderTweenProperty
  * @property {number | number[]} [initialValue] - Optional override; otherwise inferred from the current parameter value
- * @property {Array<{value: number | number[], duration: number, easing?: string, relative?: boolean}>} keyframes - Parameter keyframes
+ * @property {Array<{value: number | number[], startValue?: number | number[], duration: number, delay?: number, easing?: string, relative?: boolean}>} keyframes - Parameter keyframes
  */
 
 /**
@@ -759,6 +769,7 @@
 /**
  * @typedef {Object} InlineAudioTransitionKeyframe
  * @property {number} value - Absolute target value, or delta when relative is true
+ * @property {number} [startValue] - Explicit segment start, absolute or a delta when relative is true
  * @property {number} duration - Ramp duration in milliseconds
  * @property {number} [delay=0] - Time to hold the preceding value before the ramp
  * @property {string} [easing="linear"] - Animation easing name
@@ -788,6 +799,7 @@
 /**
  * @typedef {Object} AudioTransitionKeyframe
  * @property {number} value - Absolute target value, or delta when relative is true
+ * @property {number} [startValue] - Explicit segment start, absolute or a delta when relative is true
  * @property {number} duration - Duration to reach this value in milliseconds
  * @property {number} [delay=0] - Time to hold the preceding value before the ramp
  * @property {string} [easing="linear"] - Animation easing name

--- a/src/util/animationTimeline.js
+++ b/src/util/animationTimeline.js
@@ -154,7 +154,10 @@ export const buildTimeline = (keyframesInput) => {
   let latestValue;
 
   keyframesInput.forEach(
-    ({ value, delay = 0, duration, easing = "linear", relative }, index) => {
+    (
+      { value, startValue, delay = 0, duration, easing = "linear", relative },
+      index,
+    ) => {
       if (index === 0) {
         latestValue = value;
         timeline.push({ time: accumulatedTime, value, easing: "linear" });
@@ -167,6 +170,17 @@ export const buildTimeline = (keyframesInput) => {
 
       if (delay > 0) {
         accumulatedTime += delay;
+        timeline.push({
+          time: accumulatedTime,
+          value: latestValue,
+          easing: "linear",
+        });
+      }
+
+      if (startValue !== undefined) {
+        latestValue = relative
+          ? addTweenValues(latestValue, startValue)
+          : startValue;
         timeline.push({
           time: accumulatedTime,
           value: latestValue,

--- a/src/util/animationTimeline.test.js
+++ b/src/util/animationTimeline.test.js
@@ -41,4 +41,49 @@ describe("animationTimeline numeric arrays", () => {
     expect(getValueAtTime(timeline, 100)).toEqual([2, 1.5]);
     expect(getValueAtTime(timeline, 150)).toEqual([3, 1]);
   });
+
+  it("holds the preceding endpoint until a delayed absolute start value", () => {
+    const timeline = buildTimeline([
+      { value: 10 },
+      { value: 100, duration: 100, easing: "linear" },
+      {
+        startValue: 0,
+        value: 50,
+        delay: 50,
+        duration: 100,
+        easing: "linear",
+      },
+    ]);
+
+    expect(getValueAtTime(timeline, 149)).toBe(100);
+    expect(getValueAtTime(timeline, 150)).toBe(0);
+    expect(getValueAtTime(timeline, 200)).toBe(25);
+    expect(getValueAtTime(timeline, 250)).toBe(50);
+  });
+
+  it("resolves relative vector starts before relative endpoints", () => {
+    const timeline = buildTimeline([
+      { value: [10, 20] },
+      {
+        startValue: [-2, 5],
+        value: [4, -1],
+        duration: 100,
+        easing: "linear",
+        relative: true,
+      },
+    ]);
+
+    expect(getValueAtTime(timeline, 0)).toEqual([8, 25]);
+    expect(getValueAtTime(timeline, 50)).toEqual([10, 24.5]);
+    expect(getValueAtTime(timeline, 100)).toEqual([12, 24]);
+  });
+
+  it("uses the terminal value for a zero-duration explicit-start segment", () => {
+    const timeline = buildTimeline([
+      { value: 10 },
+      { startValue: 0, value: 50, duration: 0 },
+    ]);
+
+    expect(getValueAtTime(timeline, 0)).toBe(50);
+  });
 });

--- a/src/util/normalizeAnimations.js
+++ b/src/util/normalizeAnimations.js
@@ -261,6 +261,9 @@ const normalizeKeyframes = (
     const keyframePath = `${path}.keyframes[${index}]`;
     assertPlainObject(keyframe, keyframePath);
     assertValue(keyframe.value, `${keyframePath}.value`);
+    if (keyframe.startValue !== undefined) {
+      assertValue(keyframe.startValue, `${keyframePath}.startValue`);
+    }
     assertNonNegativeSafeIntegerMilliseconds(
       keyframe.duration,
       `${keyframePath}.duration`,
@@ -295,6 +298,9 @@ const normalizeKeyframes = (
 
     return {
       value: normalizeValue(keyframe.value),
+      ...(keyframe.startValue === undefined
+        ? {}
+        : { startValue: normalizeValue(keyframe.startValue) }),
       duration: keyframe.duration,
       easing: keyframe.easing ?? "linear",
       ...(keyframe.delay > 0 ? { delay: keyframe.delay } : {}),

--- a/src/util/normalizeAnimations.test.js
+++ b/src/util/normalizeAnimations.test.js
@@ -1363,3 +1363,75 @@ describe("normalizeAnimations rect style support", () => {
     ).toThrow(/second transition for target "panel"/);
   });
 });
+
+describe("normalizeAnimations keyframe start values", () => {
+  it("preserves scalar, shader-vector, and color start values", () => {
+    const [animation] = normalizeAnimations([
+      {
+        id: "explicit-starts",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          x: {
+            keyframes: [{ startValue: 10, value: 20, duration: 100 }],
+          },
+          filters: {
+            grade: {
+              tint: {
+                keyframes: [
+                  {
+                    startValue: [0.1, 0.2, 0.3],
+                    value: [0.4, 0.5, 0.6],
+                    duration: 100,
+                  },
+                ],
+              },
+            },
+          },
+          border: {
+            color: {
+              keyframes: [
+                {
+                  startValue: "#ff0000",
+                  value: "#0000ff",
+                  duration: 100,
+                },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(animation.tween.x.keyframes[0].startValue).toBe(10);
+    expect(animation.filterTweens.grade.tint.keyframes[0].startValue).toEqual([
+      0.1, 0.2, 0.3,
+    ]);
+    expect(
+      animation.tween["rect.border.color"].keyframes[0].startValue,
+    ).toEqual([1, 0, 0, 1]);
+  });
+
+  it("validates start values through the same channel rules as endpoints", () => {
+    expect(() =>
+      normalizeAnimations([
+        {
+          id: "invalid-start",
+          targetId: "panel",
+          type: "update",
+          tween: {
+            filters: {
+              grade: {
+                tint: {
+                  keyframes: [
+                    { startValue: [1], value: [1, 1], duration: 100 },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      ]),
+    ).toThrow(/startValue must be a finite number or a numeric array/);
+  });
+});

--- a/src/util/normalizeAudio.js
+++ b/src/util/normalizeAudio.js
@@ -30,6 +30,7 @@ const AUDIO_EASINGS = new Set(SUPPORTED_EASING_NAMES);
 const AUDIO_TRANSITION_PHASE_KEYS = new Set(["initialValue", "keyframes"]);
 const AUDIO_TRANSITION_KEYFRAME_KEYS = new Set([
   "value",
+  "startValue",
   "duration",
   "delay",
   "easing",
@@ -452,6 +453,16 @@ const validateTransitionPhase = (
         ? undefined
         : AUDIO_TRANSITION_PROPERTY_RANGES[propertyName],
     );
+
+    if (keyframe.startValue !== undefined) {
+      assertFiniteNumber(
+        keyframe.startValue,
+        `${keyframePath}.startValue`,
+        keyframe.relative
+          ? undefined
+          : AUDIO_TRANSITION_PROPERTY_RANGES[propertyName],
+      );
+    }
 
     if (keyframe.duration === undefined) {
       throw new Error(`Input error: ${keyframePath}.duration is required.`);


### PR DESCRIPTION
## Summary

- implement optional keyframe-level `startValue` across compact visual, shader, color, and audio tracks
- preserve preceding values during delay, then resolve each segment from explicit start to endpoint
- support absolute and relative scalar/vector resolution, clamped audio starts, colors, zero-duration boundaries, repeats, yoyo, and interruption sampling
- keep the portable GSAP authoring contract unchanged while compiling compact transition tracks through `fromTo`
- update schemas, runtime normalization, public JSDoc, hosted interface docs, and the accepted design status
- bump the feature version from `1.40.1` on `main` to `1.41.0`

## Coverage

- visual and shader normalization plus parameter-shape validation
- update and transition timeline compilation
- Web Audio scheduling and tracked interruption values
- absolute, relative, delayed, vector, color, clamped, zero-duration, repeat, yoyo, and interruption tests

## Validation

- `bun run lint`
- `bun run build`
- focused Vitest suite: 9 files and 296 tests passed
- package version verified as `1.41.0`
- local full pre-push suite: 1,549 passed; 27 environment-dependent Unicode 17, text-metric, and PNG-size assertions failed outside this change
