### PR TITLE
fix(elements): render scaled text magnitudes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/elements/addTextRichContent.spec.js
+++ b/spec/elements/addTextRichContent.spec.js
@@ -29,6 +29,40 @@ const createSharedParams = () => ({
 });
 
 describe("text rich content", () => {
+  it("renders rich text with the full authored scale and unscaled layout box", () => {
+    const parent = new Container();
+    const element = parseText({
+      state: {
+        id: "scaled-rich-text",
+        type: "text",
+        x: 200,
+        y: 100,
+        width: 160,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        scaleX: -2,
+        scaleY: 1.5,
+        content: [{ text: "Scaled" }, { text: " rich text" }],
+      },
+    });
+
+    addText({
+      ...createSharedParams(),
+      parent,
+      element,
+      zIndex: 0,
+    });
+
+    const text = parent.getChildByLabel("scaled-rich-text");
+
+    expect(element.width).toBe(320);
+    expect(text.scale.x).toBe(-2);
+    expect(text.scale.y).toBe(1.5);
+    expect(text.hitArea.width).toBe(160);
+    expect(text.pivot.x * text.scale.x).toBeCloseTo(element.originX);
+    expect(text.pivot.y * text.scale.y).toBeCloseTo(element.originY);
+  });
+
   it("resyncs an existing split-text container after source layout updates", () => {
     const parent = new Container();
     const shared = createSharedParams();

--- a/spec/elements/negativeScaleParsing.spec.js
+++ b/spec/elements/negativeScaleParsing.spec.js
@@ -37,12 +37,15 @@ describe("negative scale parsing", () => {
     });
   });
 
-  it("preserves the established output shape for positive baked scales", () => {
+  it("retains explicit positive baked scales for animation targets", () => {
     const result = parseCommonObject(commonState({ scaleX: 1.5, scaleY: 2 }));
 
-    expect(result).toMatchObject({ width: 120, height: 100 });
-    expect(result).not.toHaveProperty("scaleX");
-    expect(result).not.toHaveProperty("scaleY");
+    expect(result).toMatchObject({
+      width: 120,
+      height: 100,
+      scaleX: 1.5,
+      scaleY: 2,
+    });
   });
 
   it("keeps a zero scale instead of treating it as an omitted value", () => {
@@ -214,8 +217,8 @@ describe("negative scale parsing", () => {
       originX: -100,
       originY: 50,
       scaleX: -2,
+      scaleY: 3,
     });
-    expect(result).not.toHaveProperty("scaleY");
     expect(result.children[0]).toMatchObject({
       width: 60,
       height: 60,

--- a/spec/elements/textHoverLayout.spec.js
+++ b/spec/elements/textHoverLayout.spec.js
@@ -1,6 +1,9 @@
 import { Container } from "pixi.js";
 import { describe, expect, it, vi } from "vitest";
-import { addText } from "../../src/plugins/elements/text/addText.js";
+import {
+  addText,
+  getTextAnimationTargetState,
+} from "../../src/plugins/elements/text/addText.js";
 import { parseText } from "../../src/plugins/elements/text/parseText.js";
 import { getTextLayoutPosition } from "../../src/plugins/elements/text/textLayout.js";
 import { updateText } from "../../src/plugins/elements/text/updateText.js";
@@ -31,6 +34,44 @@ const getWorldPivotPosition = (displayObject) =>
   getWorldPosition(displayObject, displayObject.pivot);
 
 describe("text hover layout", () => {
+  it("renders the full authored scale magnitude around the text anchor", () => {
+    const parent = new Container();
+    const element = parseText({
+      state: {
+        id: "scaled-text",
+        type: "text",
+        x: 240,
+        y: 120,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        scaleX: -2,
+        scaleY: 1.5,
+        content: "Scaled text",
+        textStyle: { fontFamily: "Arial", fontSize: 24 },
+      },
+    });
+
+    addText({
+      ...createSharedParams(),
+      parent,
+      zIndex: 0,
+      element,
+    });
+
+    const text = parent.getChildByLabel("scaled-text");
+
+    expect(text.scale.x).toBe(-2);
+    expect(text.scale.y).toBe(1.5);
+    expect(Math.abs(text.width - element.width)).toBeLessThan(1);
+    expect(Math.abs(text.height - element.height)).toBeLessThan(1);
+    expect(text.pivot.x * text.scale.x).toBeCloseTo(element.originX);
+    expect(text.pivot.y * text.scale.y).toBeCloseTo(element.originY);
+    expect(getTextAnimationTargetState(element)).toMatchObject({
+      scaleX: -2,
+      scaleY: 1.5,
+    });
+  });
+
   it("applies degree rotation around an explicit text origin", () => {
     const parent = new Container();
     const element = parseText({

--- a/spec/parser/parseCommonObject.test.yaml
+++ b/spec/parser/parseCommonObject.test.yaml
@@ -39,6 +39,8 @@ out:
   "y": 218
   originX: 363
   originY: 22
+  scaleX: 1.5
+  scaleY: 1.5
   rotation: 0
   alpha: 1
   hover:

--- a/spec/parser/parseContainer.test.yaml
+++ b/spec/parser/parseContainer.test.yaml
@@ -906,6 +906,8 @@ out:
       "y": 0
       originX: 50
       originY: 100
+      scaleX: 1
+      scaleY: 1
       scroll: false
       rotation: 0
       gapX: 0
@@ -1454,6 +1456,8 @@ out:
   "y": 0
   originX: 0
   originY: 0
+  scaleX: 2
+  scaleY: 2
   scroll: false
   rotation: 0
   alpha: 1
@@ -1524,6 +1528,8 @@ out:
   "y": 0
   originX: 0
   originY: 0
+  scaleX: 2
+  scaleY: 2
   scroll: false
   rotation: 0
   alpha: 1

--- a/spec/parser/parseSlider.test.yaml
+++ b/spec/parser/parseSlider.test.yaml
@@ -50,6 +50,8 @@ out:
   "y": 200
   originX: 48
   originY: 40
+  scaleX: 1.2
+  scaleY: 0.8
   rotation: 0
   alpha: 0.8
   barSrc: file:slider-bar

--- a/spec/parser/parseSprite.test.yaml
+++ b/spec/parser/parseSprite.test.yaml
@@ -51,6 +51,8 @@ out:
   "y": 200
   originX: 48
   originY: 40
+  scaleX: 1.2
+  scaleY: 0.8
   alpha: 0.8
   rotation: 45
   blur:
@@ -125,6 +127,8 @@ out:
   "y": 200
   originX: 48
   originY: 40
+  scaleX: 1.2
+  scaleY: 0.8
   alpha: 1
   rotation: 0
   src: ""

--- a/src/plugins/elements/text/addText.js
+++ b/src/plugins/elements/text/addText.js
@@ -21,6 +21,12 @@ import { getElementTransformTargetState } from "../util/transform.js";
 
 export const getTextAnimationTargetState = (textComputedNode) => ({
   ...getElementTransformTargetState(textComputedNode),
+  ...(textComputedNode.scaleX !== undefined && {
+    scaleX: textComputedNode.scaleX,
+  }),
+  ...(textComputedNode.scaleY !== undefined && {
+    scaleY: textComputedNode.scaleY,
+  }),
   alpha: textComputedNode.alpha,
 });
 

--- a/src/plugins/elements/text/parseText.js
+++ b/src/plugins/elements/text/parseText.js
@@ -106,6 +106,14 @@ export const parseText = ({ state }) => {
         value: typeof state.width === "number",
         enumerable: false,
       },
+      __layoutWidth: {
+        value: layoutWidth,
+        enumerable: false,
+      },
+      __layoutHeight: {
+        value: roundedHeight,
+        enumerable: false,
+      },
       ...(typeof state.originX === "number" && {
         __explicitOriginX: {
           value: true,
@@ -170,6 +178,14 @@ export const parseText = ({ state }) => {
     },
     __fixedWidth: {
       value: typeof state.width === "number",
+      enumerable: false,
+    },
+    __layoutWidth: {
+      value: layoutWidth,
+      enumerable: false,
+    },
+    __layoutHeight: {
+      value: roundedHeight,
       enumerable: false,
     },
     ...(typeof state.originX === "number" && {

--- a/src/plugins/elements/text/richTextDisplay.js
+++ b/src/plugins/elements/text/richTextDisplay.js
@@ -77,7 +77,8 @@ export const renderRichTextDisplayObject = (
     container.alpha = element.alpha ?? 1;
   }
 
-  const layoutWidth = element.width ?? element.measuredWidth ?? 0;
+  const layoutWidth =
+    element.__layoutWidth ?? element.width ?? element.measuredWidth ?? 0;
 
   for (let chunkIndex = 0; chunkIndex < element.content.length; chunkIndex++) {
     const chunk = element.content[chunkIndex];
@@ -119,12 +120,15 @@ export const renderRichTextDisplayObject = (
   }
 
   const hitAreaWidth = Math.max(0, layoutWidth);
-  const hitAreaHeight = Math.max(0, element.height ?? 0);
+  const hitAreaHeight = Math.max(
+    0,
+    element.__layoutHeight ?? element.height ?? 0,
+  );
   container.hitArea = new Rectangle(0, 0, hitAreaWidth, hitAreaHeight);
   if (preserveTransform) {
     applyElementPivot(container, element);
   } else {
-    applyElementTransform(container, element);
+    applyElementTransform(container, element, { scaleMode: "full" });
   }
   setElementHitTestBounds(container, (displayObject) =>
     getRichTextHitBounds(displayObject, hitAreaWidth, hitAreaHeight),

--- a/src/plugins/elements/text/textLayout.js
+++ b/src/plugins/elements/text/textLayout.js
@@ -17,6 +17,9 @@ const getAnchorRatio = (size, origin) => {
 
 const getTextAlign = (style) => style?.align ?? DEFAULT_TEXT_STYLE.align;
 
+const getAuthoredLayoutWidth = (textComputedNode) =>
+  textComputedNode.__layoutWidth ?? textComputedNode.width;
+
 const getLayoutWidth = (textElement) => {
   const layoutState = textElement[TEXT_LAYOUT_STATE];
 
@@ -53,9 +56,15 @@ const getRuntimeTextLayout = (textElement, style) => {
     return measureTextLayout(textElement.text, style);
   }
 
+  const scaleX = Math.abs(textElement.scale?.x);
+  const scaleY = Math.abs(textElement.scale?.y);
+  if (!(scaleX > 0) || !(scaleY > 0)) {
+    return measureTextLayout(textElement.text, style);
+  }
+
   return {
-    width: textElement.width,
-    height: textElement.height,
+    width: Math.abs(textElement.width) / scaleX,
+    height: Math.abs(textElement.height) / scaleY,
   };
 };
 
@@ -93,7 +102,9 @@ const setTextLayoutState = (textElement, textComputedNode, measurements) => {
 
   textElement[TEXT_LAYOUT_STATE] = {
     fixedWidth,
-    layoutWidth: fixedWidth ? textComputedNode.width : measuredWidth,
+    layoutWidth: fixedWidth
+      ? getAuthoredLayoutWidth(textComputedNode)
+      : measuredWidth,
     measuredWidth,
     measuredHeight,
   };
@@ -144,6 +155,7 @@ const applyTextElementTransform = (
   applyElementTransform(textElement, transformedElement, {
     localOriginX: originX - offsetX,
     localOriginY: originY,
+    scaleMode: "full",
   });
 
   textElement[TEXT_TRANSFORM_STATE] = {
@@ -194,8 +206,9 @@ export const syncTextAnchorRatios = (textElement, textComputedNode) => {
     textComputedNode.textStyle,
   );
   const width =
-    textComputedNode.__fixedWidth && typeof textComputedNode.width === "number"
-      ? textComputedNode.width
+    textComputedNode.__fixedWidth &&
+    typeof getAuthoredLayoutWidth(textComputedNode) === "number"
+      ? getAuthoredLayoutWidth(textComputedNode)
       : measurements.width;
   const height = measurements.height;
   const anchorXRatio =
@@ -315,8 +328,8 @@ export const positionTextInLayoutBox = (textElement, textComputedNode) => {
   applyTextElementTransform(textElement, textComputedNode, {
     layoutWidth:
       textComputedNode.__fixedWidth &&
-      typeof textComputedNode.width === "number"
-        ? textComputedNode.width
+      typeof getAuthoredLayoutWidth(textComputedNode) === "number"
+        ? getAuthoredLayoutWidth(textComputedNode)
         : measuredWidth,
     measuredWidth,
     measuredHeight: getMeasuredHeight(textElement),

--- a/src/plugins/elements/util/parseCommonObject.js
+++ b/src/plugins/elements/util/parseCommonObject.js
@@ -60,8 +60,8 @@ export const parseCommonObject = (state, { scaleMode = "baked" } = {}) => {
   const {
     x: adjustedPositionX,
     y: adjustedPositionY,
-    originX: originX,
-    originY: originY,
+    originX,
+    originY,
   } = calculatePositionAfterAnchor({
     positionX: state.x,
     positionY: state.y,
@@ -75,9 +75,9 @@ export const parseCommonObject = (state, { scaleMode = "baked" } = {}) => {
   const transformOriginY =
     typeof state.originY === "number" ? state.originY : originY;
 
-  // Round all pixel calculations
-  const includeScaleX = scaleMode === "live" || scaleX <= 0;
-  const includeScaleY = scaleMode === "live" || scaleY <= 0;
+  // Round all pixel calculations. Preserve every explicitly authored scale so
+  // update animations can resolve positive, negative, and collapsed targets.
+  // Baked renderers still apply only its sign to the display transform.
   let computedObj = {
     id: state.id,
     type: state.type,
@@ -89,8 +89,8 @@ export const parseCommonObject = (state, { scaleMode = "baked" } = {}) => {
     originY: Math.round(transformOriginY),
     alpha: state.alpha ?? 1,
     rotation: state.rotation ?? 0,
-    ...(state.scaleX !== undefined && includeScaleX ? { scaleX } : {}),
-    ...(state.scaleY !== undefined && includeScaleY ? { scaleY } : {}),
+    ...(state.scaleX !== undefined ? { scaleX } : {}),
+    ...(state.scaleY !== undefined ? { scaleY } : {}),
   };
 
   if (state.hover) {


### PR DESCRIPTION
## Summary

- render plain and rich text with the full authored scale magnitude while keeping local layout and hit bounds unscaled
- preserve explicitly authored positive scales in computed nodes so auto-update tweens can resolve their target state
- add regression coverage for scaled text geometry, origins, animation targets, and parser output
- bump the patch release from `1.40.0` to `1.40.1`

## Context

Follow-up to #331 and its review. The asynchronous video texture sizing fix from the same review is already present on `main` via #331; this PR resolves the remaining text-rendering and positive-scale target findings.

## Validation

- `bun run lint`
- `bun run build`
- `bun run test -- --reporter=dot` (120 files, 1,615 tests)
- pre-commit oxlint and Prettier hooks
- pre-push full test suite
