### PR TITLE
feat(rect): support interaction visual states

### DIFF
--- a/docs/rect-interaction-visual-states-implementation-plan.md
+++ b/docs/rect-interaction-visual-states-implementation-plan.md
@@ -1,0 +1,466 @@
+# Rect Interaction Visual States Implementation Plan
+
+Last updated: 2026-08-08
+
+## Goal
+
+Make `rect.hover`, `rect.click`, and `rect.rightClick` support native visual
+states in Route Graphics while preserving their existing event metadata.
+
+The first supported appearance fields are:
+
+- `fill`
+- `alpha`
+
+Route Graphics owns pointer-state tracking and browser-visible state changes.
+An embedding layer such as Route Engine may resolve higher-level resource IDs
+and compatibility aliases before passing the renderer-ready shape to Route
+Graphics.
+
+## End State
+
+Route Graphics accepts this low-level rect shape:
+
+```yaml
+- id: menu-button
+  type: rect
+  width: 320
+  height: 72
+  fill: "#202020"
+  alpha: 0.8
+  hover:
+    fill: "#303030"
+    alpha: 0.9
+    cursor: pointer
+    soundSrc: hover.mp3
+    soundVolume: 70
+    payload:
+      source: menu-button
+  click:
+    fill: "#101010"
+    alpha: 0.7
+    soundSrc: press.mp3
+    soundVolume: 80
+    payload:
+      action: select
+  rightClick:
+    fill: "#401010"
+    alpha: 0.75
+    soundSrc: context.mp3
+    soundVolume: 60
+    payload:
+      action: context-menu
+```
+
+The interaction objects remain a single object containing both appearance and
+event metadata. No new `visualStates` wrapper is introduced.
+
+Renderer boundary rules:
+
+- `fill` uses the same complete fill grammar as top-level rect `fill`, including
+  solid and gradient fills.
+- `alpha` is a finite number from `0` through `1`.
+- `alpha` is the only opacity field accepted by Route Graphics.
+- Route Graphics does not accept `opacity`, `colorId`, or other embedding-layer
+  aliases.
+- `payload`, sound, and cursor behavior remain unchanged.
+- Unknown direct fields in an interaction object remain validation errors.
+- Arbitrary keys inside `payload` remain data and are never interpreted as
+  appearance fields.
+
+## Existing Behavior
+
+Route Graphics already has the main interaction primitives:
+
+- `createHoverStateController`
+- `createPressStateController`
+- `createRightPressStateController`
+- inherited hover, press, and right-press propagation from containers
+- native visual states for sprites and text
+
+Rects currently support only event metadata in `hover`, `click`, and
+`rightClick`. Their interaction binder emits events, plays sounds, changes the
+hover cursor, and handles drag/scroll, but it does not apply visual state.
+Strict rect validation therefore rejects nested `fill` and `alpha`.
+
+The rect style runtime already owns the animated base fill. Top-level `alpha`
+is still animated directly on the Pixi display object. Supporting interaction
+appearance correctly requires separating the current base/animated appearance
+from the effective appearance shown after interaction overrides.
+
+## Visual State Semantics
+
+### State lifecycle
+
+- Hover becomes active on direct `pointerover` or inherited container hover.
+- Hover becomes inactive on direct `pointerout` after all inherited hover
+  sources are inactive.
+- Primary press becomes active on a primary `pointerdown` or inherited
+  container press.
+- Primary press becomes inactive on primary `pointerup` or
+  `pointerupoutside` after all inherited press sources are inactive.
+- Right press becomes active on `rightdown` or inherited container
+  right-press.
+- Right press becomes inactive on `rightup`, `rightupoutside`, or
+  `rightclick` after all inherited right-press sources are inactive.
+- Interaction state is cleared when the corresponding config is removed, the
+  element is rebound, or the element is destroyed.
+
+Existing event timing does not change:
+
+- hover payload and sound occur on `pointerover`
+- click payload and sound occur on a valid primary `pointerup`
+- right-click payload and sound occur on `rightclick`
+- `pointerupoutside` and `rightupoutside` clear appearance without emitting a
+  successful click event
+
+### Priority and partial overrides
+
+Appearance resolves independently for each supported field with this priority:
+
+1. active `rightClick`
+2. active `click`
+3. active `hover`
+4. current base/animated value
+
+Only a defined field overrides the lower layer. For example:
+
+```yaml
+fill: "#202020"
+alpha: 0.8
+hover:
+  fill: "#303030"
+click:
+  alpha: 0.6
+```
+
+While hovered and pressed, the effective appearance is:
+
+```yaml
+fill: "#303030" # inherited from the active hover layer
+alpha: 0.6 # overridden by the active click layer
+```
+
+This per-field cascade avoids requiring authors to repeat an entire appearance
+in every state.
+
+### Animation composition
+
+Interaction appearance is an overlay on the current animated base, not a
+replacement for animation state.
+
+Required behavior:
+
+- Base fill and alpha animations continue advancing while an interaction
+  override covers the same field.
+- Leaving the interaction reveals the latest animated value, not a snapshot
+  taken when the pointer entered.
+- An active state that does not define a field never interrupts that field's
+  animation.
+- Animation completion, cancellation, looping, seeking, and target-state
+  settlement update the base channel first and then recompute the effective
+  appearance.
+- Legacy tween animations and portable GSAP timelines have identical
+  composition behavior.
+
+Snapshot-and-restore is explicitly not acceptable because it restores stale
+values when animations or render-state updates occur during interaction.
+
+### Render-state updates
+
+- Updating base `fill` or `alpha` while an override is active updates the base
+  immediately but keeps the overriding value visible.
+- Updating an active interaction's visual config recomputes the effective
+  appearance immediately without requiring pointer exit/re-entry.
+- Removing the currently winning field falls through to the next active layer
+  or the latest base value.
+- Rebinding interactions must not duplicate listeners, sounds, or events.
+- Existing container inheritance remains active across child updates and child
+  insertion while a container state is already active.
+
+## Proposed Runtime Architecture
+
+### 1. Add a rect appearance runtime
+
+Add a small runtime next to `rectStyleRuntime.js`, tentatively
+`rectAppearanceRuntime.js`. It owns:
+
+- current base alpha
+- references to the current base fill/style runtime
+- current `hover`, `click`, and `rightClick` appearance configs
+- direct and inherited active-state results
+- per-field cascade resolution
+- application of the effective fill and alpha
+- batching so one animation frame causes at most one redraw/recompute
+
+Keep base state and effective rendered state separate. Do not write interaction
+values into the authored/computed element object or the rect style animation
+state.
+
+The appearance runtime should expose focused operations such as:
+
+- install/sync for add and update paths
+- set hover/press/right-press activity
+- set base alpha from static reconciliation or animation
+- notify that base fill changed
+- compute effective appearance
+- begin/end animation frame batching
+- destroy/cleanup
+
+The final names may follow nearby runtime conventions, but the ownership split
+must remain explicit.
+
+### 2. Reuse the existing interaction controllers
+
+Extend `rectInteractions.js` to use the same hover, press, and right-press
+controllers used by text and sprites.
+
+The binder should:
+
+- create controllers whenever the corresponding interaction exists, including
+  metadata-only interactions
+- send state changes to the rect appearance runtime
+- add `pointerdown`, `pointerupoutside`, `rightdown`, `rightup`, and
+  `rightupoutside` handling required for pressed visuals
+- preserve primary-button filtering
+- preserve hover cursor, sound, payload, drag, and scroll behavior
+- clear inherited controller targets and any direct press state during cleanup
+- avoid treating payload contents as configuration
+
+Container inheritance must work without a rect-specific parallel propagation
+system.
+
+### 3. Compose drawing through the runtime
+
+Update `addRect.js`, `updateRect.js`, `rectStyleRuntime.js`, and, if useful,
+`rectDrawing.js` so all redraws use effective appearance:
+
+- the style runtime remains the canonical animated base for fill and other rect
+  style properties
+- fill animation changes notify the appearance runtime
+- the appearance runtime selects the effective fill before drawing
+- alpha reconciliation updates base alpha, then writes effective alpha to Pixi
+- interaction-only redraws do not overwrite base style state
+- structured fill resources are released through the existing rect fill
+  lifecycle when effective fills change or the rect is destroyed
+
+Avoid duplicating full draw logic inside pointer listeners.
+
+### 4. Route alpha animation through the base channel
+
+Top-level rect `alpha` animations currently target the Pixi display object's
+effective `alpha`. Introduce a rect-specific animation adapter so alpha samples
+update appearance-runtime base alpha instead.
+
+The integration must cover:
+
+- legacy tween preparation and application
+- portable timeline channel `appearance.alpha`
+- automatic target-state resolution
+- initial-value reads
+- target-state settlement
+- batching with existing rect style animation hooks
+
+Non-rect elements must retain their existing direct Pixi alpha behavior. Keep
+the adaptation scoped by the presence of the rect appearance runtime rather
+than changing the public animation property.
+
+Before implementation, add a focused runtime test proving the adapter sees the
+base alpha while an interaction override is active. This closes the easiest
+place for a false-positive implementation that looks correct only when no
+animation is running.
+
+## Validation, Schema, and Types
+
+Update the raw and computed rect contracts together:
+
+- `src/plugins/elements/rect/rectConfig.js`
+- `src/schemas/elements/rect.element.yaml`
+- `src/schemas/elements/rect.computed.yaml`
+- `src/types.js`
+
+Define one reusable rect interaction appearance shape where practical. The
+allowed direct fields are:
+
+| Interaction  | Appearance      | Metadata                                       |
+| ------------ | --------------- | ---------------------------------------------- |
+| `hover`      | `fill`, `alpha` | `cursor`, `soundSrc`, `soundVolume`, `payload` |
+| `click`      | `fill`, `alpha` | `soundSrc`, `soundVolume`, `payload`           |
+| `rightClick` | `fill`, `alpha` | `soundSrc`, `soundVolume`, `payload`           |
+
+Validation requirements:
+
+- reuse the existing fill validator rather than creating a reduced interaction
+  fill grammar
+- reject non-finite alpha and values outside `0..1`
+- reject `opacity` with a path-specific unsupported-field error
+- keep metadata validation unchanged
+- keep arbitrary nested payload data valid, including payload keys named
+  `fill`, `alpha`, or `opacity`
+- ensure parser output preserves all supported appearance and metadata fields
+  without mutation
+
+## Test Plan
+
+### Parser and validation
+
+Extend `spec/parser/parseRect.test.yaml` and
+`spec/elements/rectConfig.spec.js` to cover:
+
+- `fill` and `alpha` in all three interaction objects
+- solid, linear-gradient, and radial-gradient interaction fills
+- boundary alpha values `0` and `1`
+- invalid alpha type, non-finite values, and range errors
+- unsupported `opacity`
+- unsupported direct fields
+- payload objects containing appearance-like keys that remain byte-for-byte
+  unchanged
+- raw and computed schema parity
+
+### Pointer and event semantics
+
+Extend `spec/elements/eventSemantics.spec.js` or add a focused rect visual-state
+spec covering:
+
+- hover enter/exit and cursor restoration
+- primary press/release and `pointerupoutside`
+- non-primary pointer events do not activate click visuals
+- right press/release, `rightupoutside`, and `rightclick`
+- event payload and sound timing remains unchanged
+- metadata-only interactions still work
+- cleanup and rebind do not duplicate listeners
+
+### Appearance cascade
+
+Add focused runtime tests for:
+
+- base -> hover -> press -> hover -> base
+- right-press priority over primary press and hover
+- per-field fallthrough when higher states define only fill or only alpha
+- explicit `alpha: 0` and transparent fill
+- full structured fill replacement and restoration
+- direct plus inherited state from one or more containers
+- nested container inheritance
+- removal and replacement of an active interaction during update
+- child update/add while a parent interaction is already active
+- delete/destroy cleanup
+
+### Animation coexistence
+
+Cover both legacy tweens and portable timelines:
+
+- fill animation while hover fill is active
+- alpha animation while hover alpha is active
+- animation starts before interaction
+- animation starts during interaction
+- interaction begins during animation
+- release reveals the latest sampled base value
+- loop, seek, cancellation, natural completion, and target-state settlement
+- an interaction that omits the animated field does not affect it
+- base render-state update animations and interaction-config updates while
+  active
+
+Unit tests should inspect both base runtime state and effective Pixi output so
+they cannot pass by asserting only one side of the composition.
+
+### Browser and VT coverage
+
+Add an isolated rect-interaction VT/browser fixture. It should exercise only
+this feature and provide deterministic checkpoints for:
+
+1. base appearance
+2. hover appearance
+3. primary pressed appearance
+4. return to hover after release
+5. return to base after pointer exit
+6. right-pressed appearance and restoration
+7. animated base fill/alpha progressing underneath an active override
+8. release revealing the progressed base value
+
+Pointer-driven screenshots must use the real browser input path. Do not model
+hover or press by replacing the authored rect state between screenshots.
+
+Follow `docs/vt-guidelines.md`: keep the fixture minimal, make each state
+visually distinguishable, generate the reference, inspect it in a browser, and
+run the report before accepting it.
+
+## Documentation
+
+Update `playground/pages/docs/nodes/rect.md` with:
+
+- the combined appearance/metadata interaction shape
+- the canonical use of `alpha`
+- state lifecycle and priority
+- partial override behavior
+- an explicit statement that `opacity` and resource IDs belong to embedding
+  layers, not Route Graphics
+- a static example and an animation-coexistence example
+
+Update any generated/public API documentation or type examples that list rect
+interaction fields.
+
+## Implementation Order
+
+1. Add failing parser, validation, and static pointer-state tests that define
+   the contract.
+2. Add the rect appearance runtime and static fill/alpha composition.
+3. Integrate the existing hover/press/right-press controllers and cleanup.
+4. Wire add/update/destroy reconciliation and container inheritance.
+5. Route alpha animation through the base appearance channel and add legacy
+   tween tests.
+6. Add portable timeline, seeking, cancellation, and settlement coverage.
+7. Add the isolated browser/VT fixture and inspect the recorded checkpoints.
+8. Update docs, schemas, and types; run the complete validation suite.
+
+This ordering deliberately proves static interaction semantics before changing
+animation routing, while still treating animation-safe restoration as part of
+the same feature rather than optional follow-up work.
+
+## Verification Commands
+
+Use the repository's current scripts rather than introducing a separate test
+harness:
+
+```sh
+bun run test
+bun run build
+bun run vt:generate
+bun run vt:report
+```
+
+During implementation, run the focused Vitest files first, followed by the full
+suite. The final handoff requires both the relevant automated state-transition
+coverage and a browser-visible reproduction of the actual pointer path.
+
+## Out of Scope
+
+The first implementation does not add interaction overrides for:
+
+- border
+- corner radius
+- blur or shader filters
+- geometry or transforms
+- drag/scroll appearance
+- `opacity` as a Route Graphics alias
+- resource resolution such as `colorId`
+- changes to sprite or text interaction contracts
+
+These can be added later using the same partial cascade only after their
+composition with animations and hit testing is defined.
+
+## Completion Criteria
+
+The feature is complete when:
+
+- rect `hover`, `click`, and `rightClick` accept and visibly apply `fill` and
+  `alpha`
+- direct and inherited state lifecycles match existing sprite/text semantics
+- per-field priority and restoration are deterministic
+- event metadata and payloads retain their current behavior
+- base animations continue beneath interaction overrides and restore at their
+  latest sampled values
+- add, update, settlement, cancellation, and destroy paths leave no stale
+  listeners or appearance state
+- raw schema, computed schema, runtime validation, types, and docs agree
+- focused tests, the full automated suite, and isolated browser/VT checks pass
+  with reviewed visual output

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/playground/pages/docs/nodes/rect.md
+++ b/playground/pages/docs/nodes/rect.md
@@ -16,33 +16,33 @@ Try it in the [Playground](/playground/?template=basic-shapes).
 
 ## Field Reference
 
-| Field          | Type             | Required | Default     | Notes                                   |
-| -------------- | ---------------- | -------- | ----------- | --------------------------------------- |
-| `id`           | string           | Yes      | -           | Element id.                             |
-| `type`         | string           | Yes      | -           | Must be `rect`.                         |
-| `width`        | number           | Yes      | -           | Render width.                           |
-| `height`       | number           | Yes      | -           | Render height.                          |
-| `x`            | number           | No       | `0`         | Position before anchor transform.       |
-| `y`            | number           | No       | `0`         | Position before anchor transform.       |
-| `anchorX`      | number           | No       | `0`         | Anchor offset ratio.                    |
-| `anchorY`      | number           | No       | `0`         | Anchor offset ratio.                    |
-| `originX`      | number           | No       | anchor      | Transform origin X in pixels.           |
-| `originY`      | number           | No       | anchor      | Transform origin Y in pixels.           |
-| `alpha`        | number           | No       | `1`         | Opacity `0..1`.                         |
-| `fill`         | string \| object | No       | transparent | Fill color or structured gradient fill. |
-| `border`       | object           | No       | -           | Border config.                          |
-| `cornerRadius` | number \| object | No       | `0`         | Uniform or per-corner radii.            |
-| `rotation`     | number           | No       | `0`         | Degrees.                                |
-| `scaleX`       | number           | No       | `1`         | Horizontal geometry scale.              |
-| `scaleY`       | number           | No       | `1`         | Vertical geometry scale.                |
-| `blur`         | object           | No       | -           | Directional Gaussian blur.              |
-| `filters`      | array            | No       | `[]`        | Ordered custom shader filters.          |
-| `hover`        | object           | No       | -           | Hover event config.                     |
-| `click`        | object           | No       | -           | Click event config.                     |
-| `rightClick`   | object           | No       | -           | Right click event config.               |
-| `drag`         | object           | No       | -           | `start`/`move`/`end` payload hooks.     |
-| `scrollUp`     | object           | No       | -           | Wheel-up payload hook.                  |
-| `scrollDown`   | object           | No       | -           | Wheel-down payload hook.                |
+| Field          | Type             | Required | Default     | Notes                                    |
+| -------------- | ---------------- | -------- | ----------- | ---------------------------------------- |
+| `id`           | string           | Yes      | -           | Element id.                              |
+| `type`         | string           | Yes      | -           | Must be `rect`.                          |
+| `width`        | number           | Yes      | -           | Render width.                            |
+| `height`       | number           | Yes      | -           | Render height.                           |
+| `x`            | number           | No       | `0`         | Position before anchor transform.        |
+| `y`            | number           | No       | `0`         | Position before anchor transform.        |
+| `anchorX`      | number           | No       | `0`         | Anchor offset ratio.                     |
+| `anchorY`      | number           | No       | `0`         | Anchor offset ratio.                     |
+| `originX`      | number           | No       | anchor      | Transform origin X in pixels.            |
+| `originY`      | number           | No       | anchor      | Transform origin Y in pixels.            |
+| `alpha`        | number           | No       | `1`         | Opacity `0..1`.                          |
+| `fill`         | string \| object | No       | transparent | Fill color or structured gradient fill.  |
+| `border`       | object           | No       | -           | Border config.                           |
+| `cornerRadius` | number \| object | No       | `0`         | Uniform or per-corner radii.             |
+| `rotation`     | number           | No       | `0`         | Degrees.                                 |
+| `scaleX`       | number           | No       | `1`         | Horizontal geometry scale.               |
+| `scaleY`       | number           | No       | `1`         | Vertical geometry scale.                 |
+| `blur`         | object           | No       | -           | Directional Gaussian blur.               |
+| `filters`      | array            | No       | `[]`        | Ordered custom shader filters.           |
+| `hover`        | object           | No       | -           | Hover appearance and event config.       |
+| `click`        | object           | No       | -           | Primary-press appearance/event config.   |
+| `rightClick`   | object           | No       | -           | Secondary-press appearance/event config. |
+| `drag`         | object           | No       | -           | `start`/`move`/`end` payload hooks.      |
+| `scrollUp`     | object           | No       | -           | Wheel-up payload hook.                   |
+| `scrollDown`   | object           | No       | -           | Wheel-down payload hook.                 |
 
 `filters` runs after built-in rendering effects. See
 [Shaders](/docs/guides/shaders/) for source, uniform, texture, pipeline, and
@@ -133,6 +133,61 @@ Gradient notes:
 
 The public fill contract is renderer-independent. Renderer resources and
 sampling objects are managed internally.
+
+## Interaction Appearance
+
+`hover`, `click`, and `rightClick` can override `fill` and `alpha` while their
+pointer state is active. The same objects continue to carry event metadata.
+
+| Field         | `hover` | `click` | `rightClick` |
+| ------------- | ------- | ------- | ------------ |
+| `fill`        | Yes     | Yes     | Yes          |
+| `alpha`       | Yes     | Yes     | Yes          |
+| `soundSrc`    | Yes     | Yes     | Yes          |
+| `soundVolume` | Yes     | Yes     | Yes          |
+| `payload`     | Yes     | Yes     | Yes          |
+| `cursor`      | Yes     | No      | No           |
+
+```yaml
+fill: "#202020"
+alpha: 0.8
+hover:
+  fill: "#303030"
+  alpha: 0.9
+  cursor: pointer
+click:
+  fill: "#101010"
+  alpha: 0.7
+  payload:
+    action: select
+rightClick:
+  fill: "#401010"
+  alpha: 0.75
+```
+
+The visual lifecycle is:
+
+- hover appearance applies while the pointer is over the rect
+- click appearance applies while the primary pointer is held down
+- right-click appearance applies while the secondary pointer is held down
+- releasing outside clears pressed appearance without emitting a successful
+  click event
+
+When states overlap, each field resolves independently in this order:
+
+1. active `rightClick`
+2. active `click`
+3. active `hover`
+4. current base value
+
+This means a click state that defines only `alpha` keeps the active hover fill.
+Base fill and alpha animations continue underneath interaction overrides;
+releasing an override reveals the latest animated value.
+
+Route Graphics uses `alpha` as its canonical renderer field. It does not accept
+`opacity`, `colorId`, or other embedding-layer aliases in interaction objects.
+Embedding layers must resolve those values before rendering. Keys inside
+`payload` are arbitrary event data and are never interpreted as appearance.
 
 ## Rect Style Animation
 
@@ -246,16 +301,22 @@ elements:
       color: "0xffffff"
       alpha: 0.7
     hover:
+      fill: "0x303030"
+      alpha: 0.9
       cursor: pointer
       soundSrc: hover-sfx
       payload:
         action: panelHover
     click:
+      fill: "0x101010"
+      alpha: 0.7
       soundSrc: click-sfx
       soundVolume: 90
       payload:
         action: panelClick
     rightClick:
+      fill: "0x401010"
+      alpha: 0.75
       soundSrc: rightclick-sfx
       payload:
         action: panelContext

--- a/playground/pages/docs/nodes/rect.md
+++ b/playground/pages/docs/nodes/rect.md
@@ -322,6 +322,53 @@ elements:
         action: panelContext
 ```
 
+## Example: Interaction + Base Animation
+
+Render the first state, keep the pointer over the panel, and then render the
+second state. The blue hover appearance remains active while the base `fill`
+and `alpha` animate underneath it. Moving the pointer out reveals the latest
+animated base values rather than the values from when hover began.
+
+```yaml
+states:
+  - elements:
+      - id: animated-panel
+        type: rect
+        x: 160
+        y: 120
+        width: 400
+        height: 240
+        fill: "#374151"
+        alpha: 0.8
+        hover:
+          fill: "#2563eb"
+          alpha: 1
+          cursor: pointer
+  - elements:
+      - id: animated-panel
+        type: rect
+        x: 160
+        y: 120
+        width: 400
+        height: 240
+        fill: "#8b5cf6"
+        alpha: 0.3
+        hover:
+          fill: "#2563eb"
+          alpha: 1
+          cursor: pointer
+    animations:
+      - id: animate-panel-base
+        targetId: animated-panel
+        type: update
+        tween:
+          fill:
+            color:
+              auto: { duration: 1000, easing: linear }
+          alpha:
+            auto: { duration: 1000, easing: linear }
+```
+
 ## Example: Drag + Scroll
 
 ```yaml

--- a/spec/elements/eventSemantics.spec.js
+++ b/spec/elements/eventSemantics.spec.js
@@ -129,6 +129,14 @@ describe("event semantics", () => {
     expect(rect.cursor).toBe("auto");
     expect(rect._isDragging).toBe(false);
     expect(rect.hitArea).toBeNull();
+    expect(rect.listenerCount("pointerover")).toBe(0);
+    expect(rect.listenerCount("pointerdown")).toBe(0);
+    expect(rect.listenerCount("rightclick")).toBe(0);
+    expect(Symbol.for("routeGraphics.setInheritedHover") in rect).toBe(false);
+    expect(Symbol.for("routeGraphics.setInheritedPress") in rect).toBe(false);
+    expect(Symbol.for("routeGraphics.setInheritedRightPress") in rect).toBe(
+      false,
+    );
     expect(app.canvas.removeEventListener).toHaveBeenCalledWith(
       "wheel",
       expect.any(Function),
@@ -138,6 +146,72 @@ describe("event semantics", () => {
     rect.emit("pointerover");
     rect.emit("pointerup");
     expect(eventHandler).not.toHaveBeenCalled();
+  });
+
+  it("skips interaction bindings for decorative rects", () => {
+    const rect = new Graphics();
+    rect.label = "decorative";
+
+    bindRectInteractions({
+      app: { audioStage: { add: vi.fn() } },
+      rect,
+      eventHandler: vi.fn(),
+      element: { id: "decorative", width: 100, height: 60 },
+    });
+
+    expect(rect.eventNames()).toEqual([]);
+    expect(Symbol.for("routeGraphics.setInheritedHover") in rect).toBe(false);
+    expect(Symbol.for("routeGraphics.setInheritedPress") in rect).toBe(false);
+    expect(Symbol.for("routeGraphics.setInheritedRightPress") in rect).toBe(
+      false,
+    );
+  });
+
+  it("refreshes the cursor when an active hover config changes", () => {
+    const rect = new Graphics();
+    rect.label = "cursor-sync";
+    const app = { audioStage: { add: vi.fn() } };
+    const eventHandler = vi.fn();
+
+    bindRectInteractions({
+      app,
+      rect,
+      eventHandler,
+      element: {
+        id: "cursor-sync",
+        width: 100,
+        height: 60,
+        hover: { cursor: "pointer" },
+      },
+    });
+    rect.emit("pointerover");
+    expect(rect.cursor).toBe("pointer");
+
+    bindRectInteractions({
+      app,
+      rect,
+      eventHandler,
+      element: {
+        id: "cursor-sync",
+        width: 100,
+        height: 60,
+        hover: { cursor: "crosshair" },
+      },
+    });
+    expect(rect.cursor).toBe("crosshair");
+
+    bindRectInteractions({
+      app,
+      rect,
+      eventHandler,
+      element: {
+        id: "cursor-sync",
+        width: 100,
+        height: 60,
+        hover: {},
+      },
+    });
+    expect(rect.cursor).toBe("auto");
   });
 
   it("applies right-click sound volume consistently", () => {

--- a/spec/elements/rectConfig.spec.js
+++ b/spec/elements/rectConfig.spec.js
@@ -52,13 +52,27 @@ describe("rect runtime validation", () => {
             repeatEdgePixels: true,
           },
           hover: {
+            fill: "#eeeeee",
+            alpha: 0.9,
             cursor: "pointer",
             soundSrc: "hover.mp3",
             soundVolume: 40,
             payload: { action: "hover" },
           },
-          click: { payload: { action: "click" } },
+          click: {
+            fill: { type: "solid", color: "#dddddd" },
+            alpha: 0,
+            payload: { action: "click", opacity: 0.4 },
+          },
           rightClick: {
+            fill: {
+              type: "radial-gradient",
+              stops: [
+                { offset: 0, color: "#ffffff" },
+                { offset: 1, color: "#000000" },
+              ],
+            },
+            alpha: 1,
             soundSrc: "context.mp3",
             soundVolume: 25,
           },
@@ -144,6 +158,17 @@ describe("rect runtime validation", () => {
       "unknown hover property",
       { hover: { opacity: 0.5 } },
       "rect.hover.opacity",
+    ],
+    ["out-of-range hover alpha", { hover: { alpha: 1.1 } }, "rect.hover.alpha"],
+    [
+      "non-finite click alpha",
+      { click: { alpha: Number.NaN } },
+      "rect.click.alpha",
+    ],
+    [
+      "invalid right-click fill",
+      { rightClick: { fill: "not-a-real-color()" } },
+      "rect.rightClick.fill",
     ],
     ["non-object click", { click: true }, "rect.click"],
     [

--- a/spec/elements/rectInteractionVisualState.spec.js
+++ b/spec/elements/rectInteractionVisualState.spec.js
@@ -1,0 +1,551 @@
+import { Container } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
+import { createAnimationBus } from "../../src/plugins/animations/animationBus.js";
+import { addRect } from "../../src/plugins/elements/rect/addRect.js";
+import { deleteRect } from "../../src/plugins/elements/rect/deleteRect.js";
+import {
+  getRectBaseAlpha,
+  getRectEffectiveAppearance,
+} from "../../src/plugins/elements/rect/rectAppearanceRuntime.js";
+import { parseRect } from "../../src/plugins/elements/rect/parseRect.js";
+import { getRectStyleAnimationValue } from "../../src/plugins/elements/rect/rectStyleRuntime.js";
+import { updateRect } from "../../src/plugins/elements/rect/updateRect.js";
+import {
+  setTreeInheritedHover,
+  setTreeInheritedPress,
+  setTreeInheritedRightPress,
+} from "../../src/plugins/elements/util/hoverInheritance.js";
+import { normalizeAnimations } from "../../src/util/normalizeAnimations.js";
+
+const app = { audioStage: { add: vi.fn() } };
+const completionTracker = {
+  getVersion: () => 1,
+  track: vi.fn(),
+  complete: vi.fn(),
+};
+
+const createRect = (overrides = {}) =>
+  parseRect({
+    state: {
+      id: "panel",
+      type: "rect",
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+      fill: "#111111",
+      alpha: 0.8,
+      ...overrides,
+    },
+  });
+
+const mountRect = ({ element = createRect(), eventHandler = vi.fn() } = {}) => {
+  const parent = new Container();
+  const animationBus = createAnimationBus();
+  addRect({
+    app,
+    parent,
+    element,
+    animations: [],
+    animationBus,
+    completionTracker,
+    eventHandler,
+    zIndex: 0,
+  });
+  animationBus.flush();
+  return {
+    parent,
+    rect: parent.getChildByLabel(element.id),
+    animationBus,
+    eventHandler,
+  };
+};
+
+describe("rect interaction visual states", () => {
+  it("cascades partial hover, click, and right-click appearance by field", () => {
+    const element = createRect({
+      hover: { fill: "#222222", alpha: 0.9 },
+      click: { alpha: 0 },
+      rightClick: { fill: "#333333" },
+    });
+    const { rect } = mountRect({ element });
+
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#111111",
+      alpha: 0.8,
+    });
+
+    rect.emit("pointerover");
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#222222",
+      alpha: 0.9,
+    });
+    expect(rect.alpha).toBe(0.9);
+
+    rect.emit("pointerdown");
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#222222",
+      alpha: 0,
+    });
+
+    rect.emit("rightdown");
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#333333",
+      alpha: 0,
+    });
+
+    rect.emit("rightup");
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#222222",
+      alpha: 0,
+    });
+
+    rect.emit("pointerup");
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#222222",
+      alpha: 0.9,
+    });
+
+    rect.emit("pointerout");
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#111111",
+      alpha: 0.8,
+    });
+  });
+
+  it("fully replaces and restores structured and transparent fills", () => {
+    const element = createRect({
+      hover: {
+        fill: {
+          type: "linear-gradient",
+          stops: [
+            { offset: 0, color: "#ff0000" },
+            { offset: 1, color: "#0000ff" },
+          ],
+        },
+      },
+      click: { fill: "transparent", alpha: 0 },
+    });
+    const { rect } = mountRect({ element });
+
+    rect.emit("pointerover");
+    expect(getRectEffectiveAppearance(rect).fill).toEqual(element.hover.fill);
+    expect(rect._rtglFillResource).toBeDefined();
+
+    rect.emit("pointerdown");
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "transparent",
+      alpha: 0,
+    });
+    expect(rect._rtglFillResource).toBeUndefined();
+
+    rect.emit("pointerup");
+    expect(getRectEffectiveAppearance(rect).fill).toEqual(element.hover.fill);
+    expect(rect._rtglFillResource).toBeDefined();
+
+    rect.emit("pointerout");
+    expect(getRectEffectiveAppearance(rect).fill).toBe("#111111");
+    expect(rect._rtglFillResource).toBeUndefined();
+  });
+
+  it("clears pressed appearance outside without emitting a click", () => {
+    const eventHandler = vi.fn();
+    const { rect } = mountRect({
+      element: createRect({
+        click: { fill: "#222222", payload: { action: "click" } },
+        rightClick: { fill: "#333333", payload: { action: "context" } },
+      }),
+      eventHandler,
+    });
+
+    rect.emit("pointerdown", { button: 2 });
+    expect(getRectEffectiveAppearance(rect).fill).toBe("#111111");
+
+    rect.emit("pointerdown");
+    expect(getRectEffectiveAppearance(rect).fill).toBe("#222222");
+    rect.emit("pointerupoutside");
+    expect(getRectEffectiveAppearance(rect).fill).toBe("#111111");
+
+    rect.emit("rightdown");
+    expect(getRectEffectiveAppearance(rect).fill).toBe("#333333");
+    rect.emit("rightupoutside");
+    expect(getRectEffectiveAppearance(rect).fill).toBe("#111111");
+    expect(eventHandler).not.toHaveBeenCalled();
+  });
+
+  it("preserves active direct state and applies updated configs immediately", () => {
+    const prevElement = createRect({
+      hover: { fill: "#222222", alpha: 0.9 },
+    });
+    const nextElement = createRect({
+      fill: "#444444",
+      alpha: 0.6,
+      hover: { fill: "#555555", alpha: 0.7 },
+    });
+    const { parent, rect, animationBus } = mountRect({ element: prevElement });
+
+    rect.emit("pointerover");
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations: [],
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#555555",
+      alpha: 0.7,
+    });
+    rect.emit("pointerout");
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#444444",
+      alpha: 0.6,
+    });
+
+    const removedElement = createRect({ fill: "#666666", alpha: 0.4 });
+    rect.emit("pointerover");
+    updateRect({
+      app,
+      parent,
+      prevElement: nextElement,
+      nextElement: removedElement,
+      animations: [],
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#666666",
+      alpha: 0.4,
+    });
+  });
+
+  it("supports inherited hover, press, and right-press state", () => {
+    const root = new Container();
+    const { rect } = mountRect({
+      element: createRect({
+        hover: { fill: "#222222" },
+        click: { alpha: 0.5 },
+        rightClick: { fill: "#333333" },
+      }),
+    });
+    root.addChild(rect);
+
+    setTreeInheritedHover({ root, isHovered: true });
+    expect(getRectEffectiveAppearance(rect).fill).toBe("#222222");
+    setTreeInheritedPress({ root, isPressed: true });
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#222222",
+      alpha: 0.5,
+    });
+    setTreeInheritedRightPress({ root, isPressed: true });
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#333333",
+      alpha: 0.5,
+    });
+
+    setTreeInheritedRightPress({ root, isPressed: false });
+    setTreeInheritedPress({ root, isPressed: false });
+    setTreeInheritedHover({ root, isHovered: false });
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#111111",
+      alpha: 0.8,
+    });
+  });
+
+  it("retains inherited state until every nested source releases it", () => {
+    const outer = new Container();
+    const inner = new Container();
+    const { rect } = mountRect({
+      element: createRect({ hover: { fill: "#222222" } }),
+    });
+    outer.addChild(inner);
+    inner.addChild(rect);
+
+    setTreeInheritedHover({ root: outer, isHovered: true });
+    setTreeInheritedHover({ root: inner, isHovered: true });
+    setTreeInheritedHover({ root: outer, isHovered: false });
+    expect(getRectEffectiveAppearance(rect).fill).toBe("#222222");
+
+    setTreeInheritedHover({ root: inner, isHovered: false });
+    expect(getRectEffectiveAppearance(rect).fill).toBe("#111111");
+  });
+
+  it("cleans up appearance and interaction state when deleted", () => {
+    const element = createRect({ hover: { fill: "#222222", alpha: 0.4 } });
+    const { parent, rect, animationBus } = mountRect({ element });
+    rect.emit("pointerover");
+
+    deleteRect({
+      parent,
+      element,
+      animations: [],
+      animationBus,
+      completionTracker,
+    });
+
+    expect(rect.destroyed).toBe(true);
+    expect(getRectEffectiveAppearance(rect)).toBeNull();
+  });
+
+  it("keeps legacy alpha and fill tweens advancing under hover overrides", () => {
+    const prevElement = createRect({
+      alpha: 1,
+      fill: "#ff0000",
+      hover: { alpha: 0.9, fill: "#00ff00" },
+    });
+    const nextElement = createRect({
+      alpha: 0.2,
+      fill: "#0000ff",
+      hover: { alpha: 0.9, fill: "#00ff00" },
+    });
+    const { parent, rect, animationBus } = mountRect({ element: prevElement });
+    const animations = normalizeAnimations([
+      {
+        id: "animate-under-hover",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          alpha: { auto: { duration: 1000, easing: "linear" } },
+          fill: { color: { auto: { duration: 1000, easing: "linear" } } },
+        },
+      },
+    ]);
+
+    rect.emit("pointerover");
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations,
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+    animationBus.flush();
+    animationBus.tick(500);
+
+    expect(getRectBaseAlpha(rect)).toBeCloseTo(0.6);
+    expect(getRectStyleAnimationValue(rect, "rect.fill.color")).toEqual([
+      0.5, 0, 0.5, 1,
+    ]);
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#00ff00",
+      alpha: 0.9,
+    });
+
+    rect.emit("pointerout");
+    expect(rect.alpha).toBeCloseTo(0.6);
+    expect(getRectEffectiveAppearance(rect).fill).toEqual([0.5, 0, 0.5, 1]);
+
+    rect.emit("pointerover");
+    animationBus.tick(500);
+    expect(getRectBaseAlpha(rect)).toBeCloseTo(0.2);
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#00ff00",
+      alpha: 0.9,
+    });
+    rect.emit("pointerout");
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#0000ff",
+      alpha: 0.2,
+    });
+  });
+
+  it("does not redraw geometry after an update alpha initial value is applied", () => {
+    const prevElement = createRect({ alpha: 1 });
+    const nextElement = createRect({ alpha: 1 });
+    const { parent, rect, animationBus } = mountRect({ element: prevElement });
+    const animations = normalizeAnimations([
+      {
+        id: "initial-alpha-without-redraw",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          alpha: {
+            initialValue: 0.3,
+            keyframes: [
+              { duration: 1000, value: 0.7, easing: "linear" },
+              { duration: 1000, value: 1, easing: "linear" },
+            ],
+          },
+        },
+      },
+    ]);
+    const clearSpy = vi.spyOn(rect, "clear");
+
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations,
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+    animationBus.flush();
+
+    expect(getRectBaseAlpha(rect)).toBe(0.3);
+    expect(rect.alpha).toBe(0.3);
+    expect(clearSpy).not.toHaveBeenCalled();
+
+    animationBus.tick(800);
+    expect(getRectBaseAlpha(rect)).toBeCloseTo(0.62);
+    expect(rect.alpha).toBeCloseTo(0.62);
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it("settles animated base values on cancellation without exposing them early", () => {
+    const prevElement = createRect({
+      alpha: 1,
+      fill: "#ff0000",
+      hover: { alpha: 0.9, fill: "#00ff00" },
+    });
+    const nextElement = createRect({
+      alpha: 0.2,
+      fill: "#0000ff",
+      hover: { alpha: 0.9, fill: "#00ff00" },
+    });
+    const { parent, rect, animationBus } = mountRect({ element: prevElement });
+    const animations = normalizeAnimations([
+      {
+        id: "cancel-under-hover",
+        targetId: "panel",
+        type: "update",
+        tween: {
+          alpha: { auto: { duration: 1000, easing: "linear" } },
+          fill: { color: { auto: { duration: 1000, easing: "linear" } } },
+        },
+      },
+    ]);
+
+    rect.emit("pointerover");
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations,
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+    animationBus.flush();
+    animationBus.tick(250);
+    animationBus.cancelAllExcept(new Set());
+
+    expect(getRectBaseAlpha(rect)).toBe(0.2);
+    expect(getRectStyleAnimationValue(rect, "rect.fill.color")).toEqual([
+      0, 0, 1, 1,
+    ]);
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: "#00ff00",
+      alpha: 0.9,
+    });
+    rect.emit("pointerout");
+    expect(getRectEffectiveAppearance(rect)).toEqual({
+      fill: [0, 0, 1, 1],
+      alpha: 0.2,
+    });
+  });
+
+  it("keeps looping base animations isolated under interaction appearance", () => {
+    const prevElement = createRect({ alpha: 1, hover: { alpha: 0.95 } });
+    const nextElement = createRect({ alpha: 0.2, hover: { alpha: 0.95 } });
+    const { parent, rect, animationBus } = mountRect({ element: prevElement });
+    const animations = normalizeAnimations([
+      {
+        id: "loop-under-hover",
+        targetId: "panel",
+        type: "update",
+        playback: { loop: true },
+        tween: {
+          alpha: {
+            initialValue: 1,
+            keyframes: [{ duration: 1000, value: 0.2, easing: "linear" }],
+          },
+        },
+      },
+    ]);
+
+    rect.emit("pointerover");
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations,
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+    animationBus.flush();
+    animationBus.tick(250);
+    expect(getRectBaseAlpha(rect)).toBeCloseTo(0.8);
+    expect(rect.alpha).toBe(0.95);
+
+    animationBus.tick(1000);
+    expect(getRectBaseAlpha(rect)).toBeCloseTo(0.8);
+    expect(rect.alpha).toBe(0.95);
+
+    animationBus.cancelAllExcept(new Set());
+    rect.emit("pointerout");
+    expect(rect.alpha).toBe(0.2);
+  });
+
+  it("routes portable timeline alpha through the animated base channel", () => {
+    const prevElement = createRect({ alpha: 1, hover: { alpha: 0.95 } });
+    const nextElement = createRect({ alpha: 0.4, hover: { alpha: 0.95 } });
+    const { parent, rect, animationBus } = mountRect({ element: prevElement });
+    const animations = normalizeAnimations([
+      {
+        id: "portable-alpha-under-hover",
+        targetId: "panel",
+        type: "update",
+        gsap: {
+          profile: "portable-v1",
+          steps: [
+            {
+              kind: "to",
+              values: { alpha: 0.4 },
+              duration: 1000,
+              easing: "linear",
+            },
+          ],
+        },
+      },
+    ]);
+
+    rect.emit("pointerover");
+    updateRect({
+      app,
+      parent,
+      prevElement,
+      nextElement,
+      animations,
+      animationBus,
+      completionTracker,
+      eventHandler: vi.fn(),
+      zIndex: 0,
+    });
+    animationBus.flush();
+    expect(animationBus.seek("portable-alpha-under-hover", 500)).toBe(true);
+
+    expect(rect.alpha).toBe(0.95);
+    expect(getRectBaseAlpha(rect)).toBeCloseTo(0.7);
+    rect.emit("pointerout");
+    expect(rect.alpha).toBeCloseTo(0.7);
+  });
+});

--- a/spec/elements/rectInteractionVisualState.spec.js
+++ b/spec/elements/rectInteractionVisualState.spec.js
@@ -226,6 +226,56 @@ describe("rect interaction visual states", () => {
     });
   });
 
+  it.each([
+    {
+      name: "replaces",
+      nextOverrides: { hover: { fill: "#555555", alpha: 0.7 } },
+      expected: { fill: "#555555", alpha: 0.7 },
+    },
+    {
+      name: "removes",
+      nextOverrides: {},
+      expected: { fill: "#111111", alpha: 0.8 },
+    },
+  ])(
+    "$name active interaction appearance before an unrelated tween completes",
+    ({ nextOverrides, expected }) => {
+      const prevElement = createRect({
+        hover: { fill: "#222222", alpha: 0.9 },
+      });
+      const nextElement = createRect({ x: 100, ...nextOverrides });
+      const { parent, rect, animationBus } = mountRect({
+        element: prevElement,
+      });
+      const animations = normalizeAnimations([
+        {
+          id: "move-panel",
+          targetId: "panel",
+          type: "update",
+          tween: {
+            x: { auto: { duration: 1000, easing: "linear" } },
+          },
+        },
+      ]);
+
+      rect.emit("pointerover");
+      updateRect({
+        app,
+        parent,
+        prevElement,
+        nextElement,
+        animations,
+        animationBus,
+        completionTracker,
+        eventHandler: vi.fn(),
+        zIndex: 0,
+      });
+
+      expect(getRectEffectiveAppearance(rect)).toEqual(expected);
+      expect(rect.x).toBe(prevElement.x);
+    },
+  );
+
   it("supports inherited hover, press, and right-press state", () => {
     const root = new Container();
     const { rect } = mountRect({

--- a/spec/elements/rectInteractionVisualState.spec.js
+++ b/spec/elements/rectInteractionVisualState.spec.js
@@ -412,7 +412,7 @@ describe("rect interaction visual states", () => {
 
   it("does not redraw geometry after an update alpha initial value is applied", () => {
     const prevElement = createRect({ alpha: 1 });
-    const nextElement = createRect({ alpha: 1 });
+    const nextElement = createRect({ alpha: 1, x: 100 });
     const { parent, rect, animationBus } = mountRect({ element: prevElement });
     const animations = normalizeAnimations([
       {

--- a/spec/elements/renderElements.unchangedUpdate.spec.js
+++ b/spec/elements/renderElements.unchangedUpdate.spec.js
@@ -54,8 +54,9 @@ describe("renderElements unchanged update hooks", () => {
 
   it("updates an unchanged shader-filtered element to reset stale progress", () => {
     const parent = new Container();
-    const child = new Container();
+    const child = new Graphics();
     child.label = "shader-rect";
+    child.rect(0, 0, 100, 100).fill("#ffffff");
     parent.addChild(child);
     installShaderProgressProperty(child);
     child.uProgress = 1;

--- a/spec/parser/parseRect.test.yaml
+++ b/spec/parser/parseRect.test.yaml
@@ -74,6 +74,53 @@ out:
   rotation: 90
   alpha: 1
 ---
+case: Test parsing rect interaction appearance and metadata
+in:
+  - state:
+      id: rect-interactions
+      type: rect
+      width: 80
+      height: 100
+      fill: red
+      hover:
+        fill: yellow
+        alpha: 0.9
+        cursor: pointer
+        payload:
+          fill: payload-fill
+          opacity: 0.5
+      click:
+        fill: blue
+        alpha: 0.7
+      rightClick:
+        fill: green
+        alpha: 0
+out:
+  id: rect-interactions
+  type: rect
+  width: 80
+  height: 100
+  x: 0
+  "y": 0
+  originX: 0
+  originY: 0
+  fill: red
+  hover:
+    fill: yellow
+    alpha: 0.9
+    cursor: pointer
+    payload:
+      fill: payload-fill
+      opacity: 0.5
+  click:
+    fill: blue
+    alpha: 0.7
+  rightClick:
+    fill: green
+    alpha: 0
+  rotation: 0
+  alpha: 1
+---
 case: Test parsing rect with explicit origin independent of anchor
 in:
   - state:

--- a/src/plugins/animations/animationPropertyUtils.js
+++ b/src/plugins/animations/animationPropertyUtils.js
@@ -3,13 +3,18 @@ import {
   radiansToDegrees,
   refreshElementPivot,
 } from "../elements/util/transform.js";
+import { RECT_APPEARANCE_STATE_KEY } from "../elements/rect/rectAppearanceRuntime.js";
 
 export const isTranslateAnimationProperty = (property) =>
   property === "translateX" || property === "translateY";
 
-const getMappedPath = (propertyPathMap, path) => {
+const getMappedPath = (object, propertyPathMap, path) => {
   if (typeof path !== "string") {
     return path;
+  }
+
+  if (path === "alpha" && object?.[RECT_APPEARANCE_STATE_KEY]) {
+    return [RECT_APPEARANCE_STATE_KEY, "baseAlpha"];
   }
 
   if (path.startsWith("rect.")) {
@@ -25,7 +30,7 @@ export const getAnimationProperty = (
   propertyPathMap,
   defaultValue,
 ) => {
-  const mappedPath = getMappedPath(propertyPathMap, path);
+  const mappedPath = getMappedPath(object, propertyPathMap, path);
 
   if (typeof mappedPath === "string") {
     const result = object[mappedPath];
@@ -46,7 +51,7 @@ export const getAnimationProperty = (
 };
 
 export const setAnimationProperty = (object, path, propertyPathMap, value) => {
-  const mappedPath = getMappedPath(propertyPathMap, path);
+  const mappedPath = getMappedPath(object, propertyPathMap, path);
   const nextValue = path === "rotation" ? degreesToRadians(value) : value;
 
   if (typeof mappedPath === "string") {

--- a/src/plugins/elements/rect/addRect.js
+++ b/src/plugins/elements/rect/addRect.js
@@ -15,8 +15,11 @@ import {
   hasShaderProgressUpdateAnimation,
   syncShaderFilters,
 } from "../util/shaderFilterEffect.js";
-import { drawRectVisual } from "./rectDrawing.js";
 import { bindRectInteractions } from "./rectInteractions.js";
+import {
+  installRectAppearanceRuntime,
+  notifyRectBaseStyleChange,
+} from "./rectAppearanceRuntime.js";
 import {
   getRectStyleTargetState,
   installRectStyleRuntime,
@@ -54,10 +57,7 @@ export const addRect = ({
     rect,
     element,
     (property, runtime) => {
-      drawRectVisual(rect, runtime.state, {
-        ...runtime.element,
-        ...runtime.state,
-      });
+      notifyRectBaseStyleChange(rect);
       const dimensionChanged =
         property === "rect.width" ||
         property === "rect.height" ||
@@ -74,6 +74,7 @@ export const addRect = ({
       }
     },
   );
+  installRectAppearanceRuntime(rect, element, styleRuntime);
   const targetState = getElementTransformTargetState(element, { alpha });
 
   if (scaleX !== undefined) {
@@ -85,8 +86,6 @@ export const addRect = ({
   }
 
   const drawRect = () => {
-    drawRectVisual(rect, styleRuntime.state, element);
-    rect.alpha = alpha;
     // Rect computed nodes already bake scale into width/height for layout.
     // Reset the live transform so update tweens do not double-apply scale.
     rect.scale.x = 1;

--- a/src/plugins/elements/rect/deleteRect.js
+++ b/src/plugins/elements/rect/deleteRect.js
@@ -1,6 +1,7 @@
 import { dispatchLiveAnimations } from "../../animations/planAnimations.js";
 import { destroyRectFillResource } from "./rectFill.js";
 import { cleanupRectInteractions } from "./rectInteractions.js";
+import { destroyRectAppearanceRuntime } from "./rectAppearanceRuntime.js";
 
 /**
  * Delete rectangle element (synchronous)
@@ -17,6 +18,8 @@ export const deleteRect = ({
 
   if (!rect) return;
 
+  cleanupRectInteractions(rect);
+
   const dispatched = dispatchLiveAnimations({
     animations,
     targetId: element.id,
@@ -26,7 +29,7 @@ export const deleteRect = ({
     targetState: null,
     onComplete: () => {
       if (rect && !rect.destroyed) {
-        cleanupRectInteractions(rect);
+        destroyRectAppearanceRuntime(rect);
         destroyRectFillResource(rect);
         rect.destroy();
       }
@@ -35,7 +38,7 @@ export const deleteRect = ({
 
   if (!dispatched) {
     // No animation, destroy immediately
-    cleanupRectInteractions(rect);
+    destroyRectAppearanceRuntime(rect);
     destroyRectFillResource(rect);
     rect.destroy();
   }

--- a/src/plugins/elements/rect/rectAppearanceRuntime.js
+++ b/src/plugins/elements/rect/rectAppearanceRuntime.js
@@ -8,9 +8,9 @@ const getInteractionField = (runtime, field) => {
   for (const interaction of INTERACTION_PRIORITY) {
     if (
       runtime.active[interaction] &&
-      runtime.element?.[interaction]?.[field] !== undefined
+      runtime.interactionElement?.[interaction]?.[field] !== undefined
     ) {
-      return runtime.element[interaction][field];
+      return runtime.interactionElement[interaction][field];
     }
   }
 
@@ -48,6 +48,7 @@ export const installRectAppearanceRuntime = (
     const target = {
       displayObject,
       element,
+      interactionElement: element,
       styleRuntime,
       _baseAlpha: element.alpha ?? 1,
       active: {
@@ -57,8 +58,13 @@ export const installRectAppearanceRuntime = (
       },
       sync(nextElement, nextStyleRuntime) {
         this.element = nextElement;
+        this.interactionElement = nextElement;
         this.styleRuntime = nextStyleRuntime;
         this._baseAlpha = nextElement.alpha ?? 1;
+        applyAppearance(displayObject, runtime);
+      },
+      syncInteractions(nextElement) {
+        this.interactionElement = nextElement;
         applyAppearance(displayObject, runtime);
       },
       setInteractionActive(interaction, isActive) {
@@ -97,6 +103,7 @@ export const installRectAppearanceRuntime = (
     applyAppearance(displayObject, runtime);
   } else {
     runtime.element = element;
+    runtime.interactionElement = element;
     runtime.styleRuntime = styleRuntime;
   }
 
@@ -114,6 +121,10 @@ export const syncRectAppearanceRuntime = (
   }
   runtime.sync(element, styleRuntime);
   return runtime;
+};
+
+export const syncRectInteractionAppearance = (displayObject, element) => {
+  displayObject?.[RECT_APPEARANCE_STATE_KEY]?.syncInteractions(element);
 };
 
 export const notifyRectBaseStyleChange = (displayObject) => {

--- a/src/plugins/elements/rect/rectAppearanceRuntime.js
+++ b/src/plugins/elements/rect/rectAppearanceRuntime.js
@@ -1,0 +1,149 @@
+import { drawRectVisual } from "./rectDrawing.js";
+
+export const RECT_APPEARANCE_STATE_KEY = "_routeGraphicsRectAppearance";
+
+const INTERACTION_PRIORITY = ["rightClick", "click", "hover"];
+
+const getInteractionField = (runtime, field) => {
+  for (const interaction of INTERACTION_PRIORITY) {
+    if (
+      runtime.active[interaction] &&
+      runtime.element?.[interaction]?.[field] !== undefined
+    ) {
+      return runtime.element[interaction][field];
+    }
+  }
+
+  return field === "fill"
+    ? runtime.styleRuntime.state.fill
+    : runtime._baseAlpha;
+};
+
+const applyAlpha = (displayObject, runtime) => {
+  displayObject.alpha = getInteractionField(runtime, "alpha");
+};
+
+const applyAppearance = (displayObject, runtime) => {
+  const style = runtime.styleRuntime.state;
+  const effectiveStyle = {
+    ...style,
+    fill: getInteractionField(runtime, "fill"),
+  };
+
+  drawRectVisual(displayObject, effectiveStyle, {
+    ...runtime.element,
+    ...effectiveStyle,
+  });
+  applyAlpha(displayObject, runtime);
+};
+
+export const installRectAppearanceRuntime = (
+  displayObject,
+  element,
+  styleRuntime,
+) => {
+  let runtime = displayObject[RECT_APPEARANCE_STATE_KEY];
+
+  if (!runtime) {
+    const target = {
+      displayObject,
+      element,
+      styleRuntime,
+      _baseAlpha: element.alpha ?? 1,
+      active: {
+        hover: false,
+        click: false,
+        rightClick: false,
+      },
+      sync(nextElement, nextStyleRuntime) {
+        this.element = nextElement;
+        this.styleRuntime = nextStyleRuntime;
+        this._baseAlpha = nextElement.alpha ?? 1;
+        applyAppearance(displayObject, runtime);
+      },
+      setInteractionActive(interaction, isActive) {
+        if (this.active[interaction] === isActive) return;
+        this.active[interaction] = isActive;
+        applyAppearance(displayObject, runtime);
+      },
+      notifyBaseStyleChange() {
+        applyAppearance(displayObject, runtime);
+      },
+      apply() {
+        applyAppearance(displayObject, runtime);
+      },
+      destroy() {
+        if (displayObject[RECT_APPEARANCE_STATE_KEY] === runtime) {
+          delete displayObject[RECT_APPEARANCE_STATE_KEY];
+        }
+      },
+    };
+
+    runtime = new Proxy(target, {
+      get(current, property, receiver) {
+        if (property === "baseAlpha") return current._baseAlpha;
+        return Reflect.get(current, property, receiver);
+      },
+      set(current, property, value, receiver) {
+        if (property === "baseAlpha") {
+          current._baseAlpha = value;
+          applyAlpha(displayObject, runtime);
+          return true;
+        }
+        return Reflect.set(current, property, value, receiver);
+      },
+    });
+    displayObject[RECT_APPEARANCE_STATE_KEY] = runtime;
+    applyAppearance(displayObject, runtime);
+  } else {
+    runtime.element = element;
+    runtime.styleRuntime = styleRuntime;
+  }
+
+  return runtime;
+};
+
+export const syncRectAppearanceRuntime = (
+  displayObject,
+  element,
+  styleRuntime,
+) => {
+  const runtime = displayObject?.[RECT_APPEARANCE_STATE_KEY];
+  if (!runtime) {
+    return installRectAppearanceRuntime(displayObject, element, styleRuntime);
+  }
+  runtime.sync(element, styleRuntime);
+  return runtime;
+};
+
+export const notifyRectBaseStyleChange = (displayObject) => {
+  displayObject?.[RECT_APPEARANCE_STATE_KEY]?.notifyBaseStyleChange();
+};
+
+export const setRectInteractionActive = (
+  displayObject,
+  interaction,
+  isActive,
+) => {
+  displayObject?.[RECT_APPEARANCE_STATE_KEY]?.setInteractionActive(
+    interaction,
+    isActive,
+  );
+};
+
+export const getRectBaseAlpha = (displayObject) =>
+  displayObject?.[RECT_APPEARANCE_STATE_KEY]?.baseAlpha;
+
+export const getRectEffectiveAppearance = (displayObject) => {
+  const runtime = displayObject?.[RECT_APPEARANCE_STATE_KEY];
+  if (!runtime) return null;
+
+  return {
+    fill: getInteractionField(runtime, "fill"),
+    alpha: getInteractionField(runtime, "alpha"),
+  };
+};
+
+export const destroyRectAppearanceRuntime = (displayObject) => {
+  displayObject?.[RECT_APPEARANCE_STATE_KEY]?.destroy();
+};

--- a/src/plugins/elements/rect/rectConfig.js
+++ b/src/plugins/elements/rect/rectConfig.js
@@ -325,6 +325,8 @@ const validatePointerEvent = (event, path, { cursor = false } = {}) => {
   assertKnownFields(
     event,
     new Set([
+      "fill",
+      "alpha",
       "soundSrc",
       "soundVolume",
       "payload",
@@ -332,6 +334,12 @@ const validatePointerEvent = (event, path, { cursor = false } = {}) => {
     ]),
     path,
   );
+  if (event.fill !== undefined) {
+    validateRectFill(event.fill, `${path}.fill`);
+  }
+  if (event.alpha !== undefined) {
+    assertRange(event.alpha, `${path}.alpha`, 0, 1);
+  }
   validateSoundFields(event, path, { cursor });
 };
 

--- a/src/plugins/elements/rect/rectInteractions.js
+++ b/src/plugins/elements/rect/rectInteractions.js
@@ -27,6 +27,16 @@ const LISTENER_EVENTS = [
 const getPayload = (config) =>
   config?.payload && typeof config.payload === "object" ? config.payload : {};
 
+const hasInteractionConfig = (element) =>
+  Boolean(
+    element.hover ||
+    element.click ||
+    element.rightClick ||
+    element.scrollUp ||
+    element.scrollDown ||
+    element.drag,
+  );
+
 const emit = (eventHandler, eventName, rect, config, eventData = {}) => {
   eventHandler?.(eventName, {
     _event: {
@@ -182,8 +192,11 @@ const syncBinding = (binding, { app, element, eventHandler }) => {
 
   if (!element.hover) {
     binding.hoverController.setDirectHover(false);
-    binding.rect.cursor = "auto";
   }
+  binding.rect.cursor =
+    element.hover && binding.hoverController.isHovering()
+      ? (element.hover.cursor ?? "auto")
+      : "auto";
   if (!element.click) {
     binding.pressController.setDirectPress(false);
   }
@@ -197,18 +210,7 @@ const syncBinding = (binding, { app, element, eventHandler }) => {
   syncAppearanceState(binding);
 
   binding.rect._cleanupScrollInteraction?.();
-  const hasInteraction = Boolean(
-    element.hover ||
-    element.click ||
-    element.rightClick ||
-    element.scrollUp ||
-    element.scrollDown ||
-    element.drag,
-  );
-  binding.rect.eventMode = hasInteraction ? "static" : "auto";
-  if (!hasInteraction) {
-    binding.rect.hitArea = null;
-  }
+  binding.rect.eventMode = "static";
 
   if (element.scrollUp || element.scrollDown) {
     setupScrollInteraction({
@@ -244,6 +246,13 @@ export const cleanupRectInteractions = (rect) => {
 
 export const bindRectInteractions = ({ app, rect, element, eventHandler }) => {
   let binding = rect[RECT_INTERACTION_BINDING];
+  if (!hasInteractionConfig(element)) {
+    if (binding) {
+      cleanupRectInteractions(rect);
+    }
+    return;
+  }
+
   if (!binding) {
     binding = createBinding({ app, rect, element, eventHandler });
     rect[RECT_INTERACTION_BINDING] = binding;

--- a/src/plugins/elements/rect/rectInteractions.js
+++ b/src/plugins/elements/rect/rectInteractions.js
@@ -1,6 +1,14 @@
 import { normalizeVolume } from "../../../util/normalizeVolume.js";
 import { isPrimaryPointerEvent } from "../util/isPrimaryPointerEvent.js";
+import {
+  createHoverStateController,
+  createPressStateController,
+  createRightPressStateController,
+} from "../util/hoverInheritance.js";
 import { setupScrollInteraction } from "../util/setupScrollInteraction.js";
+import { setRectInteractionActive } from "./rectAppearanceRuntime.js";
+
+const RECT_INTERACTION_BINDING = Symbol("routeGraphicsRectInteractions");
 
 const LISTENER_EVENTS = [
   "pointerover",
@@ -11,6 +19,9 @@ const LISTENER_EVENTS = [
   "pointerdown",
   "globalpointermove",
   "pointerupoutside",
+  "rightdown",
+  "rightup",
+  "rightupoutside",
 ];
 
 const getPayload = (config) =>
@@ -36,11 +47,195 @@ const playSound = (app, eventName, config) => {
   });
 };
 
+const syncAppearanceState = (binding) => {
+  setRectInteractionActive(
+    binding.rect,
+    "hover",
+    binding.hoverController.isHovering(),
+  );
+  setRectInteractionActive(
+    binding.rect,
+    "click",
+    binding.pressController.isPressed(),
+  );
+  setRectInteractionActive(
+    binding.rect,
+    "rightClick",
+    binding.rightPressController.isPressed(),
+  );
+};
+
+const createBinding = ({ app, rect, element, eventHandler }) => {
+  const binding = {
+    app,
+    rect,
+    element,
+    eventHandler,
+    hoverController: null,
+    pressController: null,
+    rightPressController: null,
+  };
+
+  binding.hoverController = createHoverStateController({
+    displayObject: rect,
+    onHoverChange: (isActive) =>
+      setRectInteractionActive(rect, "hover", isActive),
+  });
+  binding.pressController = createPressStateController({
+    displayObject: rect,
+    onPressChange: (isActive) =>
+      setRectInteractionActive(rect, "click", isActive),
+  });
+  binding.rightPressController = createRightPressStateController({
+    displayObject: rect,
+    onPressChange: (isActive) =>
+      setRectInteractionActive(rect, "rightClick", isActive),
+  });
+
+  rect.on("pointerover", () => {
+    const hover = binding.element.hover;
+    if (!hover) return;
+
+    binding.hoverController.setDirectHover(true);
+    emit(binding.eventHandler, "hover", rect, hover);
+    if (hover.cursor) rect.cursor = hover.cursor;
+    playSound(binding.app, "hover", hover);
+  });
+
+  rect.on("pointerout", () => {
+    binding.hoverController.setDirectHover(false);
+    rect.cursor = "auto";
+  });
+
+  rect.on("pointerdown", (event) => {
+    if (!isPrimaryPointerEvent(event)) return;
+
+    if (binding.element.click) {
+      binding.pressController.setDirectPress(true);
+    }
+
+    const start = binding.element.drag?.start;
+    if (binding.element.drag) {
+      rect._isDragging = true;
+      if (start) emit(binding.eventHandler, "dragStart", rect, start);
+    }
+  });
+
+  const releasePrimary = (event, { outside = false } = {}) => {
+    if (!isPrimaryPointerEvent(event)) return;
+
+    binding.pressController.setDirectPress(false);
+
+    const click = binding.element.click;
+    if (!outside && click) {
+      emit(binding.eventHandler, "click", rect, click);
+      playSound(binding.app, "click", click);
+    }
+
+    if (rect._isDragging) {
+      rect._isDragging = false;
+      const end = binding.element.drag?.end;
+      if (end) emit(binding.eventHandler, "dragEnd", rect, end);
+    }
+  };
+
+  rect.on("pointerup", (event) => releasePrimary(event));
+  rect.on("pointerupoutside", (event) =>
+    releasePrimary(event, { outside: true }),
+  );
+
+  rect.on("globalpointermove", (event) => {
+    const move = binding.element.drag?.move;
+    if (!move || !rect._isDragging) return;
+    emit(binding.eventHandler, "dragMove", rect, move, {
+      x: event.global.x,
+      y: event.global.y,
+    });
+  });
+
+  rect.on("rightdown", () => {
+    if (binding.element.rightClick) {
+      binding.rightPressController.setDirectPress(true);
+    }
+  });
+
+  const releaseRight = () => {
+    binding.rightPressController.setDirectPress(false);
+  };
+  rect.on("rightup", releaseRight);
+  rect.on("rightupoutside", releaseRight);
+  rect.on("rightclick", () => {
+    releaseRight();
+    const rightClick = binding.element.rightClick;
+    if (!rightClick) return;
+    emit(binding.eventHandler, "rightClick", rect, rightClick);
+    playSound(binding.app, "rightClick", rightClick);
+  });
+
+  return binding;
+};
+
+const syncBinding = (binding, { app, element, eventHandler }) => {
+  binding.app = app;
+  binding.element = element;
+  binding.eventHandler = eventHandler;
+
+  if (!element.hover) {
+    binding.hoverController.setDirectHover(false);
+    binding.rect.cursor = "auto";
+  }
+  if (!element.click) {
+    binding.pressController.setDirectPress(false);
+  }
+  if (!element.rightClick) {
+    binding.rightPressController.setDirectPress(false);
+  }
+  if (!element.drag) {
+    binding.rect._isDragging = false;
+  }
+
+  syncAppearanceState(binding);
+
+  binding.rect._cleanupScrollInteraction?.();
+  const hasInteraction = Boolean(
+    element.hover ||
+    element.click ||
+    element.rightClick ||
+    element.scrollUp ||
+    element.scrollDown ||
+    element.drag,
+  );
+  binding.rect.eventMode = hasInteraction ? "static" : "auto";
+  if (!hasInteraction) {
+    binding.rect.hitArea = null;
+  }
+
+  if (element.scrollUp || element.scrollDown) {
+    setupScrollInteraction({
+      canvas: app.canvas,
+      displayObject: binding.rect,
+      width: element.width,
+      height: element.height,
+      scrollUpEvent: element.scrollUp,
+      scrollDownEvent: element.scrollDown,
+      eventHandler,
+    });
+  }
+};
+
 export const cleanupRectInteractions = (rect) => {
   rect._cleanupScrollInteraction?.();
+  const binding = rect[RECT_INTERACTION_BINDING];
+  binding?.hoverController.destroy();
+  binding?.pressController.destroy();
+  binding?.rightPressController.destroy();
   for (const eventName of LISTENER_EVENTS) {
     rect.removeAllListeners(eventName);
   }
+  delete rect[RECT_INTERACTION_BINDING];
+  setRectInteractionActive(rect, "hover", false);
+  setRectInteractionActive(rect, "click", false);
+  setRectInteractionActive(rect, "rightClick", false);
   rect.eventMode = "auto";
   rect.cursor = "auto";
   rect.hitArea = null;
@@ -48,83 +243,11 @@ export const cleanupRectInteractions = (rect) => {
 };
 
 export const bindRectInteractions = ({ app, rect, element, eventHandler }) => {
-  cleanupRectInteractions(rect);
-
-  const hover = element.hover;
-  const click = element.click;
-  const rightClick = element.rightClick;
-  const scrollUp = element.scrollUp;
-  const scrollDown = element.scrollDown;
-  const drag = element.drag;
-  const hasInteraction = Boolean(
-    hover || click || rightClick || scrollUp || scrollDown || drag,
-  );
-
-  if (!hasInteraction) {
-    return;
+  let binding = rect[RECT_INTERACTION_BINDING];
+  if (!binding) {
+    binding = createBinding({ app, rect, element, eventHandler });
+    rect[RECT_INTERACTION_BINDING] = binding;
   }
 
-  rect.eventMode = "static";
-
-  if (hover) {
-    rect.on("pointerover", () => {
-      emit(eventHandler, "hover", rect, hover);
-      if (hover.cursor) rect.cursor = hover.cursor;
-      playSound(app, "hover", hover);
-    });
-    rect.on("pointerout", () => {
-      rect.cursor = "auto";
-    });
-  }
-
-  if (click) {
-    rect.on("pointerup", (event) => {
-      if (!isPrimaryPointerEvent(event)) return;
-      emit(eventHandler, "click", rect, click);
-      playSound(app, "click", click);
-    });
-  }
-
-  if (rightClick) {
-    rect.on("rightclick", () => {
-      emit(eventHandler, "rightClick", rect, rightClick);
-      playSound(app, "rightClick", rightClick);
-    });
-  }
-
-  if (scrollUp || scrollDown) {
-    setupScrollInteraction({
-      canvas: app.canvas,
-      displayObject: rect,
-      width: element.width,
-      height: element.height,
-      scrollUpEvent: scrollUp,
-      scrollDownEvent: scrollDown,
-      eventHandler,
-    });
-  }
-
-  if (drag) {
-    const { start, end, move } = drag;
-    const endDrag = (event) => {
-      if (!isPrimaryPointerEvent(event) || !rect._isDragging) return;
-      rect._isDragging = false;
-      if (end) emit(eventHandler, "dragEnd", rect, end);
-    };
-
-    rect.on("pointerdown", (event) => {
-      if (!isPrimaryPointerEvent(event)) return;
-      rect._isDragging = true;
-      if (start) emit(eventHandler, "dragStart", rect, start);
-    });
-    rect.on("pointerup", endDrag);
-    rect.on("pointerupoutside", endDrag);
-    rect.on("globalpointermove", (event) => {
-      if (!move || !rect._isDragging) return;
-      emit(eventHandler, "dragMove", rect, move, {
-        x: event.global.x,
-        y: event.global.y,
-      });
-    });
-  }
+  syncBinding(binding, { app, element, eventHandler });
 };

--- a/src/plugins/elements/rect/updateRect.js
+++ b/src/plugins/elements/rect/updateRect.js
@@ -21,8 +21,12 @@ import {
   syncShaderFilters,
 } from "../util/shaderFilterEffect.js";
 import { setElementRenderState } from "../elementRenderState.js";
-import { drawRectVisual } from "./rectDrawing.js";
 import { bindRectInteractions } from "./rectInteractions.js";
+import {
+  installRectAppearanceRuntime,
+  notifyRectBaseStyleChange,
+  syncRectAppearanceRuntime,
+} from "./rectAppearanceRuntime.js";
 import {
   RECT_STYLE_STATE_KEY,
   getRectStyleTargetState,
@@ -116,10 +120,7 @@ export const updateRect = ({
     rectElement,
     prevElement,
     (property, runtime) => {
-      drawRectVisual(rectElement, runtime.state, {
-        ...runtime.element,
-        ...runtime.state,
-      });
+      notifyRectBaseStyleChange(rectElement);
       const dimensionChanged =
         property === "rect.width" ||
         property === "rect.height" ||
@@ -136,6 +137,7 @@ export const updateRect = ({
       }
     },
   );
+  installRectAppearanceRuntime(rectElement, prevElement, rectStyleRuntime);
   const rectStyleStartState = getRectStyleTargetState(prevElement, {
     liveScaleX,
     liveScaleY,
@@ -203,8 +205,7 @@ export const updateRect = ({
   const updateElement = () => {
     if (!isDeepEqual(prevElement, nextElement)) {
       const styleRuntime = syncRectStyleRuntime(rectElement, nextElement);
-      drawRectVisual(rectElement, styleRuntime.state, nextElement);
-      rectElement.alpha = alpha;
+      syncRectAppearanceRuntime(rectElement, nextElement, styleRuntime);
       // Rect computed nodes already bake scale into width/height for layout.
       // Reset the live transform so update tweens do not double-apply scale.
       rectElement.scale.x = 1;

--- a/src/plugins/elements/rect/updateRect.js
+++ b/src/plugins/elements/rect/updateRect.js
@@ -26,6 +26,7 @@ import {
   installRectAppearanceRuntime,
   notifyRectBaseStyleChange,
   syncRectAppearanceRuntime,
+  syncRectInteractionAppearance,
 } from "./rectAppearanceRuntime.js";
 import {
   RECT_STYLE_STATE_KEY,
@@ -257,6 +258,15 @@ export const updateRect = ({
     // No animations, update immediately
     updateElement();
   } else {
+    if (!isDeepEqual(prevElement, nextElement)) {
+      syncRectInteractionAppearance(rectElement, nextElement);
+      bindRectInteractions({
+        app,
+        rect: rectElement,
+        element: nextElement,
+        eventHandler,
+      });
+    }
     deferRenderStateCommit?.();
   }
 };

--- a/src/plugins/elements/rect/updateRect.js
+++ b/src/plugins/elements/rect/updateRect.js
@@ -35,6 +35,15 @@ import {
   syncRectStyleRuntime,
 } from "./rectStyleRuntime.js";
 
+const getRectInteractionConfig = (element) => ({
+  hover: element.hover,
+  click: element.click,
+  rightClick: element.rightClick,
+  drag: element.drag,
+  scrollUp: element.scrollUp,
+  scrollDown: element.scrollDown,
+});
+
 export const shouldRestoreStaticRectTransform = ({ parent, nextElement }) => {
   const rectElement = parent.children.find(
     (child) => child.label === nextElement.id,
@@ -77,6 +86,11 @@ export const updateRect = ({
   );
 
   if (!rectElement) return;
+
+  const interactionsChanged = !isDeepEqual(
+    getRectInteractionConfig(prevElement),
+    getRectInteractionConfig(nextElement),
+  );
 
   rectElement.zIndex = zIndex;
 
@@ -258,7 +272,7 @@ export const updateRect = ({
     // No animations, update immediately
     updateElement();
   } else {
-    if (!isDeepEqual(prevElement, nextElement)) {
+    if (interactionsChanged) {
       syncRectInteractionAppearance(rectElement, nextElement);
       bindRectInteractions({
         app,

--- a/src/schemas/elements/rect.computed.yaml
+++ b/src/schemas/elements/rect.computed.yaml
@@ -210,6 +210,12 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      fill:
+        "$ref": "#/$def/fill"
+      alpha:
+        type: number
+        minimum: 0
+        maximum: 1
       soundSrc:
         type: string
         description: source of sound to be played when hovering over the sprite
@@ -229,6 +235,12 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      fill:
+        "$ref": "#/$def/fill"
+      alpha:
+        type: number
+        minimum: 0
+        maximum: 1
       soundSrc:
         type: string
         description: source of sound to be played when the sprite is clicked
@@ -268,6 +280,12 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      fill:
+        "$ref": "#/$def/fill"
+      alpha:
+        type: number
+        minimum: 0
+        maximum: 1
       soundSrc:
         type: string
         description: source of sound to be played when the rect is right-clicked

--- a/src/schemas/elements/rect.element.yaml
+++ b/src/schemas/elements/rect.element.yaml
@@ -251,6 +251,14 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      fill:
+        "$ref": "#/$def/fill"
+        description: Fill while the rect is hovered
+      alpha:
+        type: number
+        minimum: 0
+        maximum: 1
+        description: Alpha while the rect is hovered
       soundSrc:
         type: string
         description: source of sound to be played when hovering over the sprite
@@ -270,6 +278,14 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      fill:
+        "$ref": "#/$def/fill"
+        description: Fill while the rect is pressed with the primary pointer
+      alpha:
+        type: number
+        minimum: 0
+        maximum: 1
+        description: Alpha while the rect is pressed with the primary pointer
       soundSrc:
         type: string
         description: source of sound to be played when the sprite is clicked
@@ -312,6 +328,14 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      fill:
+        "$ref": "#/$def/fill"
+        description: Fill while the rect is pressed with the secondary pointer
+      alpha:
+        type: number
+        minimum: 0
+        maximum: 1
+        description: Alpha while the rect is pressed with the secondary pointer
       soundSrc:
         type: string
         description: source of sound to be played when the rect is right-clicked

--- a/src/types.js
+++ b/src/types.js
@@ -508,6 +508,20 @@
  */
 
 /**
+ * @typedef {Object} RectInteractionAppearance
+ * @property {RectFill} [fill] - Fill override while the interaction is active
+ * @property {number} [alpha] - Alpha override from 0 to 1 while the interaction is active
+ */
+
+/**
+ * @typedef {(HoverProps & RectInteractionAppearance)} RectHover
+ */
+
+/**
+ * @typedef {(ClickProps & RectInteractionAppearance)} RectClick
+ */
+
+/**
  * @typedef {Object} RectComputedProps
  * @property {'rect'} type
  * @property {RectFill} [fill] - Optional fill. When omitted, the rect renders transparent.
@@ -517,14 +531,14 @@
  * @property {number} border.alpha
  * @property {{topLeft: number, topRight: number, bottomRight: number, bottomLeft: number}} [cornerRadius]
  * @property {BlurConfig} [blur]
+ * @property {RectHover} [hover]
+ * @property {RectClick} [click]
+ * @property {RectClick} [rightClick]
  * @property {string} cursor - Cursor style (e.g., "pointer")
  * @property {string} pointerDown - Event name for pointer down
  * @property {string} pointerUp - Event name for pointer up
  * @property {string} pointerMove - Event name for pointer move
  * @property {number} rotation - Rotation in degrees
- * @property {HoverProps} hover
- * @property {ClickProps} click
- * @property {ClickProps} rightClick
  * @property {ScrollProps} [scrollUp]
  * @property {ScrollProps} [scrollDown]
  * @typedef {(ComputedNode & RectComputedProps)} RectComputedNode

--- a/src/types.js
+++ b/src/types.js
@@ -514,11 +514,23 @@
  */
 
 /**
- * @typedef {(HoverProps & RectInteractionAppearance)} RectHover
+ * @typedef {Object} RectInteractionMetadata
+ * @property {string} [soundSrc]
+ * @property {number} [soundVolume]
+ * @property {Object} [payload]
  */
 
 /**
- * @typedef {(ClickProps & RectInteractionAppearance)} RectClick
+ * @typedef {Object} RectHoverMetadata
+ * @property {string} [cursor]
+ */
+
+/**
+ * @typedef {(RectInteractionAppearance & RectInteractionMetadata & RectHoverMetadata)} RectHover
+ */
+
+/**
+ * @typedef {(RectInteractionAppearance & RectInteractionMetadata)} RectClick
  */
 
 /**

--- a/vt/reference/rectevent/interaction-visual-states-01.webp
+++ b/vt/reference/rectevent/interaction-visual-states-01.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fd2b9cdb5f3e3d3f2d992089df8789128d76cc54b293fa315f8a4bb5e49f317
+size 2132

--- a/vt/reference/rectevent/interaction-visual-states-02.webp
+++ b/vt/reference/rectevent/interaction-visual-states-02.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fd2b9cdb5f3e3d3f2d992089df8789128d76cc54b293fa315f8a4bb5e49f317
+size 2132

--- a/vt/reference/rectevent/interaction-visual-states-03.webp
+++ b/vt/reference/rectevent/interaction-visual-states-03.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89146eb3217234f7156bde2fc6d57f1465e2df3d6cb1c77783ad8c68accbe7c3
+size 2494

--- a/vt/reference/rectevent/interaction-visual-states-04.webp
+++ b/vt/reference/rectevent/interaction-visual-states-04.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68569e9be1f98a5a634550990f880033bee2bdb73a15725971f90f4b1d5c3004
+size 2528

--- a/vt/reference/rectevent/interaction-visual-states-05.webp
+++ b/vt/reference/rectevent/interaction-visual-states-05.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89146eb3217234f7156bde2fc6d57f1465e2df3d6cb1c77783ad8c68accbe7c3
+size 2494

--- a/vt/reference/rectevent/interaction-visual-states-06.webp
+++ b/vt/reference/rectevent/interaction-visual-states-06.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02e3cf550029ea6d1cde0095908732d879c8f355975c34e761793760778b9d48
+size 2300

--- a/vt/reference/rectevent/interaction-visual-states-07.webp
+++ b/vt/reference/rectevent/interaction-visual-states-07.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89146eb3217234f7156bde2fc6d57f1465e2df3d6cb1c77783ad8c68accbe7c3
+size 2494

--- a/vt/reference/rectevent/interaction-visual-states-08.webp
+++ b/vt/reference/rectevent/interaction-visual-states-08.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89146eb3217234f7156bde2fc6d57f1465e2df3d6cb1c77783ad8c68accbe7c3
+size 2494

--- a/vt/reference/rectevent/interaction-visual-states-09.webp
+++ b/vt/reference/rectevent/interaction-visual-states-09.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a88fdd1dbe0ad12c55ed24dc9364848f7fd52f0b9bf6fe174071c1fcfc30b263
+size 2216

--- a/vt/reference/rectevent/interaction-visual-states-10.webp
+++ b/vt/reference/rectevent/interaction-visual-states-10.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cf1d30fb0cc366c958e4bcaf6e746b2086b124bd59e098382f75cf9b1a7418d
+size 2112

--- a/vt/specs/rectevent/interaction-visual-states.yaml
+++ b/vt/specs/rectevent/interaction-visual-states.yaml
@@ -1,0 +1,94 @@
+---
+title: Rect Interaction Visual States
+description: Exercise native rect hover, primary-pressed, and secondary-pressed fill/alpha states through real pointer input, including animated base values continuing under a hover override. Saturated colors are intentional because fill changes are the visual behavior under test.
+specs:
+  - hover should apply and restore rect fill and alpha
+  - primary and secondary pressed states should use their own appearance
+  - releasing a press should reveal the still-active hover appearance
+  - base fill and alpha animations should continue underneath hover
+  - leaving hover should reveal the latest animated base values
+steps:
+  - action: move
+    x: 40
+    "y": 40
+  - action: screenshot
+  - action: move
+    x: 360
+    "y": 240
+  - action: screenshot
+  - action: mouseDown
+  - action: screenshot
+  - action: mouseUp
+  - action: screenshot
+  - action: rightMouseDown
+  - action: screenshot
+  - action: rightMouseUp
+  - action: screenshot
+  - action: keypress
+    key: "n"
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+  - action: move
+    x: 40
+    "y": 40
+  - action: screenshot
+  - action: customEvent
+    name: "snapShotKeyFrame"
+    detail:
+      deltaMS: 500
+  - action: screenshot
+---
+states:
+  - elements:
+      - id: interaction-panel
+        type: rect
+        x: 160
+        "y": 120
+        width: 400
+        height: 240
+        fill: "#374151"
+        alpha: 0.8
+        cornerRadius: 32
+        hover:
+          fill: "#2563EB"
+          alpha: 1
+          cursor: pointer
+        click:
+          fill: "#F59E0B"
+          alpha: 0.75
+        rightClick:
+          fill: "#DB2777"
+          alpha: 0.6
+  - elements:
+      - id: interaction-panel
+        type: rect
+        x: 160
+        "y": 120
+        width: 400
+        height: 240
+        fill: "#8B5CF6"
+        alpha: 0.3
+        cornerRadius: 32
+        hover:
+          fill: "#2563EB"
+          alpha: 1
+          cursor: pointer
+        click:
+          fill: "#F59E0B"
+          alpha: 0.75
+        rightClick:
+          fill: "#DB2777"
+          alpha: 0.6
+    animations:
+      - id: interaction-base-animation
+        targetId: interaction-panel
+        type: update
+        tween:
+          alpha:
+            auto: { duration: 1000, easing: linear }
+          fill:
+            color:
+              auto: { duration: 1000, easing: linear }


### PR DESCRIPTION
## Summary

- add native rect fill and alpha overrides for hover, primary press, and secondary press
- resolve overlapping interaction appearance per field with rightClick, click, hover, then animated base priority
- keep base fill and alpha animations advancing beneath active interaction overrides
- preserve inherited interaction state plus existing payload, sound, cursor, drag, and scroll behavior
- update runtime validation, raw and computed schemas, public types, and rect documentation
- add isolated unit and visual regression coverage

## Verification

- bun run test: 122 files, 1669 tests passed
- bun run build
- Prettier and git diff checks passed
- real browser pointer-path reproduction passed
- VT report: 886 images, 0 mismatches