### PR TITLE
fix: isolate simultaneous transition targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route-graphics",
-  "version": "1.42.1",
+  "version": "1.42.2",
   "description": "A 2D graphics rendering interface that takes JSON input and renders pixels using PixiJS",
   "main": "dist/RouteGraphics.js",
   "type": "module",

--- a/spec/RouteGraphics.publicApi.spec.js
+++ b/spec/RouteGraphics.publicApi.spec.js
@@ -2150,6 +2150,94 @@ describe("RouteGraphics public API", () => {
     expect(app.findElementByLabel("preview-rect")?.x).toBeCloseTo(37.5);
   });
 
+  it("renders simultaneous transitions and accepts the next state", async () => {
+    const { app } = await setupRouteGraphics({
+      pluginsFactory: async () => {
+        const [{ rectPlugin }, { tweenPlugin }] = await Promise.all([
+          import("../src/plugins/elements/rect/index.js"),
+          import("../src/plugins/animations/tween/index.js"),
+        ]);
+
+        return {
+          elements: [rectPlugin],
+          animations: [tweenPlugin],
+          audio: [],
+        };
+      },
+    });
+    const background = {
+      id: "background",
+      type: "rect",
+      x: 0,
+      y: 0,
+      width: 320,
+      height: 240,
+      fill: "#000000",
+    };
+    const character = {
+      id: "character",
+      type: "rect",
+      x: 100,
+      y: 40,
+      width: 80,
+      height: 180,
+      fill: "#FFFFFF",
+    };
+    const createFadeTransition = ({ id, targetId }) => ({
+      id,
+      targetId,
+      type: "transition",
+      prev: {
+        tween: {
+          alpha: {
+            initialValue: 1,
+            keyframes: [{ duration: 300, value: 0, easing: "linear" }],
+          },
+        },
+      },
+      next: {
+        tween: {
+          alpha: {
+            initialValue: 0,
+            keyframes: [{ duration: 300, value: 1, easing: "linear" }],
+          },
+        },
+      },
+    });
+
+    app.render({
+      id: "simultaneous-transition-baseline",
+      elements: [background, character],
+    });
+
+    expect(() =>
+      app.render({
+        id: "simultaneous-transition-active",
+        elements: [
+          { ...background, fill: "#222222" },
+          { ...character, fill: "#DDDDDD" },
+        ],
+        animations: [
+          createFadeTransition({
+            id: "bg-cg-animation-transition",
+            targetId: "background",
+          }),
+          createFadeTransition({
+            id: "character-animation-in",
+            targetId: "character",
+          }),
+        ],
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      app.render({
+        id: "simultaneous-transition-next-state",
+        elements: [{ ...background, fill: "#222222" }],
+      }),
+    ).not.toThrow();
+  });
+
   it("forwards authored timeline events through the public event handler", async () => {
     const eventHandler = vi.fn();
     const { app, pixiMock } = await setupRouteGraphics({

--- a/spec/animations/runReplaceAnimation.spec.js
+++ b/spec/animations/runReplaceAnimation.spec.js
@@ -731,6 +731,110 @@ describe("runReplaceAnimation", () => {
     expect(animationBus.getState().activeCount).toBe(0);
   });
 
+  it("isolates virtual write targets for simultaneous transitions", () => {
+    const previousBackground = createDisplayObject("background");
+    const previousCharacter = createDisplayObject("character");
+    const parent = createParent(previousBackground, previousCharacter);
+    previousBackground.parent = parent;
+    previousCharacter.parent = parent;
+
+    const plugin = {
+      add: vi.fn(({ parent: targetParent, element }) => {
+        targetParent.addChild(createDisplayObject(element.id));
+      }),
+      delete: vi.fn(({ parent: targetParent, element }) => {
+        const displayObject = targetParent.children.find(
+          (child) => child.label === element.id,
+        );
+        if (displayObject) {
+          targetParent.removeChild(displayObject);
+        }
+      }),
+    };
+    const animationBus = createAnimationBus();
+    const dispatch = vi.spyOn(animationBus, "dispatch");
+    const app = {
+      renderer: {
+        width: 1280,
+        height: 720,
+        generateTexture: vi.fn(() => Texture.EMPTY),
+      },
+    };
+    const completionTracker = {
+      getVersion: () => 11,
+      track: vi.fn(),
+      complete: vi.fn(),
+    };
+    const createTransition = ({ id, targetId }) =>
+      runReplaceAnimation({
+        app,
+        parent,
+        prevElement: { id: targetId, type: "container" },
+        nextElement: { id: targetId, type: "container", children: [] },
+        animation: {
+          id,
+          targetId,
+          type: "transition",
+          prev: {
+            tween: {
+              alpha: {
+                initialValue: 1,
+                keyframes: [{ duration: 300, value: 0, easing: "linear" }],
+              },
+            },
+          },
+          next: {
+            tween: {
+              alpha: {
+                initialValue: 0,
+                keyframes: [{ duration: 300, value: 1, easing: "linear" }],
+              },
+            },
+          },
+        },
+        animations: new Map(),
+        animationBus,
+        completionTracker,
+        eventHandler: vi.fn(),
+        elementPlugins: [],
+        plugin,
+        zIndex: 0,
+        signal: new AbortController().signal,
+      });
+
+    createTransition({
+      id: "bg-cg-animation-transition",
+      targetId: "background",
+    });
+    createTransition({
+      id: "character-animation-in",
+      targetId: "character",
+    });
+
+    const identitiesByAnimationId = Object.fromEntries(
+      dispatch.mock.calls.map(([command]) => [
+        command.payload.id,
+        command.payload.instance.tracks.map((track) => track.target.identity),
+      ]),
+    );
+    expect(identitiesByAnimationId).toEqual({
+      "bg-cg-animation-transition": [
+        "transition:bg-cg-animation-transition:prev",
+        "transition:bg-cg-animation-transition:next",
+      ],
+      "character-animation-in": [
+        "transition:character-animation-in:prev",
+        "transition:character-animation-in:next",
+      ],
+    });
+
+    expect(() => animationBus.flush()).not.toThrow();
+    expect(animationBus.getState().activeCount).toBe(2);
+
+    animationBus.cancelAll();
+    expect(animationBus.getState().activeCount).toBe(0);
+  });
+
   it("returns async transition cleanup rejection to the caller", async () => {
     const prevDisplayObject = createDisplayObject("preview-background");
     const nextDisplayObject = createDisplayObject("preview-background");

--- a/src/plugins/animations/replace/runReplaceAnimation.js
+++ b/src/plugins/animations/replace/runReplaceAnimation.js
@@ -183,7 +183,7 @@ const getZeroForValueType = (valueType) => {
   return length === undefined ? 0 : Array(length).fill(0);
 };
 
-const createTransitionSurfaceTarget = (surface, subject) => {
+const createTransitionSurfaceTarget = (identityPrefix, surface, subject) => {
   const wrapper = subject?.wrapper;
   const base = {
     x: wrapper?.x ?? 0,
@@ -195,7 +195,7 @@ const createTransitionSurfaceTarget = (surface, subject) => {
   };
   return {
     handle: { kind: "surface", surface, subject, wrapper, base },
-    identity: `transition:${surface}`,
+    identity: `${identityPrefix}:${surface}`,
     subject: {
       x: base.x,
       y: base.y,
@@ -214,6 +214,7 @@ const createTransitionTimelineController = ({
   compositorEffect,
   validateTerminal = false,
 }) => {
+  const identityPrefix = `transition:${animation.id}`;
   const valueTypes = new Map(
     program.clipTemplates.map((clip) => [clip.channel, clip.valueType]),
   );
@@ -231,15 +232,15 @@ const createTransitionTimelineController = ({
       0,
   };
   const transitionTargets = {
-    prev: createTransitionSurfaceTarget("prev", prevSubject),
-    next: createTransitionSurfaceTarget("next", nextSubject),
+    prev: createTransitionSurfaceTarget(identityPrefix, "prev", prevSubject),
+    next: createTransitionSurfaceTarget(identityPrefix, "next", nextSubject),
     mask: maskHandles.map((handle, index) => ({
       handle,
-      identity: `transition:mask:${index}`,
+      identity: `${identityPrefix}:mask:${index}`,
     })),
     compositor: {
       handle: compositorHandle,
-      identity: "transition:compositor",
+      identity: `${identityPrefix}:compositor`,
     },
   };
 
@@ -357,7 +358,7 @@ const createTransitionTimelineController = ({
       for (const [index] of (animation.mask ?? []).entries()) {
         const value = terminalFrame.values.find(
           (item) =>
-            item.targetIdentity === `transition:mask:${index}` &&
+            item.targetIdentity === `${identityPrefix}:mask:${index}` &&
             item.channel === "transition.mask.progress",
         )?.value;
         if (value !== 1) {


### PR DESCRIPTION
## Summary

- namespace transition surface, mask, and compositor timeline identities by animation instance
- allow independent background and character transitions to animate concurrently without a false write conflict
- prevent the resulting follow-up render from entering the missing-previous-element failure path
- bump `route-graphics` to `1.42.2`

## Regression coverage

- reproduces the exact `bg-cg-animation-transition` and `character-animation-in` alpha collision at the replacement-animation boundary
- verifies their bound timeline write targets are independently namespaced
- exercises simultaneous transitions through the public RouteGraphics API and verifies the following state is accepted

## Validation

- `bun run lint`
- `bunx vitest run spec/animations/runReplaceAnimation.spec.js spec/RouteGraphics.publicApi.spec.js` (89 passed)
- `bun run test` (122 files, 1,675 passed)
- `bun run build`